### PR TITLE
Refactor countdown handling for shuffles

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -125,6 +125,6 @@ public partial class App : Application
 
         await _nowVm.InitializeAsync();
         _nowVm.CurrentTask = picked;
-        _nowVm.CountdownText = $"{TimeSpan.FromMinutes(settings.ReminderMinutes):mm\\:ss}";
+        await _nowPage.BeginCountdownAsync(settings.ReminderMinutes);
     }
 }

--- a/Views/NowPage.xaml.cs
+++ b/Views/NowPage.xaml.cs
@@ -56,9 +56,15 @@ namespace ShuffleTask.Views
                 return;
             }
 
+            await BeginCountdownAsync(minutes);
+        }
+
+        public async Task BeginCountdownAsync(int minutes)
+        {
             _remaining = TimeSpan.FromMinutes(minutes);
             _vm.CountdownText = $"{_remaining:mm\\:ss}";
             PersistState();
+            _timer.Stop();
             _timer.Start();
 
             await _vm.NotifyCurrentTaskAsync(minutes);


### PR DESCRIPTION
## Summary
- extract countdown setup into a reusable `BeginCountdownAsync` helper on `NowPage`
- reuse the helper for manual shuffles and scheduler-driven task picks so countdown state persists consistently

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cea69676988326a879c262e227abdc