### PR TITLE
Fix dashboard button background resources

### DIFF
--- a/Views/DashboardPage.xaml
+++ b/Views/DashboardPage.xaml
@@ -26,8 +26,8 @@
         <!-- Buttons row - Done highlighted, others neutral -->
         <HorizontalStackLayout Grid.Row="2" Spacing="12" HorizontalOptions="Center" Padding="6">
             <Button Text="Done" Command="{Binding DoneCommand}" BackgroundColor="#E6D078" TextColor="Black" WidthRequest="110" />
-            <Button Text="Snooze" Command="{Binding SnoozeCommand}" BackgroundColor="{StaticResource Gray200Brush}" TextColor="Black" WidthRequest="110" />
-            <Button Text="Shuffle" x:Name="ShuffleButton" Command="{Binding ShuffleCommand}"  BackgroundColor="{StaticResource Gray200Brush}" TextColor="Black" WidthRequest="110" />
+            <Button Text="Snooze" Command="{Binding SnoozeCommand}" BackgroundColor="{StaticResource Gray200}" TextColor="Black" WidthRequest="110" />
+            <Button Text="Shuffle" x:Name="ShuffleButton" Command="{Binding ShuffleCommand}"  BackgroundColor="{StaticResource Gray200}" TextColor="Black" WidthRequest="110" />
         </HorizontalStackLayout>
     </Grid>
 </ContentPage>


### PR DESCRIPTION
## Summary
- update the dashboard Snooze and Shuffle buttons to use the Color resource instead of the SolidColorBrush when setting BackgroundColor

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68cfc0e8b08083269a8ac7f4a55f80ba