### PR TITLE
Add visible edit button for tasks

### DIFF
--- a/Views/TasksPage.xaml
+++ b/Views/TasksPage.xaml
@@ -97,19 +97,32 @@
                                            TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
                                 </Grid>
 
-                                <Label Grid.Column="1"
-                                       Text="{Binding StatusText}"
-                                       FontSize="12"
-                                       VerticalOptions="Start"
-                                       TextColor="{AppThemeBinding Light=#2f855a, Dark=#9ae6b4}">
-                                    <Label.Triggers>
-                                        <DataTrigger TargetType="Label"
-                                                    Binding="{Binding Task.Paused}"
-                                                    Value="True">
-                                            <Setter Property="TextColor" Value="#c53030" />
-                                        </DataTrigger>
-                                    </Label.Triggers>
-                                </Label>
+                                <VerticalStackLayout Grid.Column="1"
+                                                     Spacing="6"
+                                                     HorizontalOptions="End"
+                                                     VerticalOptions="Start">
+                                    <Button Text="Edit"
+                                            FontSize="12"
+                                            Padding="12,4"
+                                            BackgroundColor="Transparent"
+                                            TextColor="#2d9cdb"
+                                            BorderColor="Transparent"
+                                            HorizontalOptions="End"
+                                            Clicked="OnEditButtonClicked"
+                                            CommandParameter="{Binding Task}" />
+                                    <Label Text="{Binding StatusText}"
+                                           FontSize="12"
+                                           HorizontalOptions="End"
+                                           TextColor="{AppThemeBinding Light=#2f855a, Dark=#9ae6b4}">
+                                        <Label.Triggers>
+                                            <DataTrigger TargetType="Label"
+                                                        Binding="{Binding Task.Paused}"
+                                                        Value="True">
+                                                <Setter Property="TextColor" Value="#c53030" />
+                                            </DataTrigger>
+                                        </Label.Triggers>
+                                    </Label>
+                                </VerticalStackLayout>
                             </Grid>
                         </Grid>
                     </Border>

--- a/Views/TasksPage.xaml.cs
+++ b/Views/TasksPage.xaml.cs
@@ -31,6 +31,14 @@ public partial class TasksPage : ContentPage
         await OpenEditorAsync(new TaskItem());
     }
 
+    private async void OnEditButtonClicked(object sender, EventArgs e)
+    {
+        if (sender is Button { CommandParameter: TaskItem task })
+        {
+            await OpenEditorAsync(MainViewModel.Clone(task));
+        }
+    }
+
     private async void OnEditSwipe(object sender, EventArgs e)
     {
         if (sender is SwipeItem { CommandParameter: TaskItem task })


### PR DESCRIPTION
## Summary
- add a visible Edit button to each task card so pointer users can access the editor
- wire the new button to the existing task editor flow alongside the swipe action

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d14c09a4e083268bb94c6bdd1b2151