### PR TITLE
Fix edit task page losing save handler when reused

### DIFF
--- a/Views/EditTaskPage.xaml.cs
+++ b/Views/EditTaskPage.xaml.cs
@@ -15,6 +15,24 @@ public partial class EditTaskPage : ContentPage
         BindingContext = vm;
     }
 
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+
+        if (BindingContext is EditTaskViewModel vm)
+        {
+            _viewModel = vm;
+
+            // Ensure the page stays subscribed when it is reused from the service provider.
+            _viewModel.Saved -= OnSaved;
+            _viewModel.Saved += OnSaved;
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+
+            Title = _viewModel.IsNew ? "New Task" : "Edit Task";
+        }
+    }
+
     protected override void OnBindingContextChanged()
     {
         if (_viewModel != null)


### PR DESCRIPTION
## Summary
- re-subscribe to the edit-task view model events when the page reappears so the Save button keeps working after navigation

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d1bb219d1c8326a4a58696b1a23f13