### PR TITLE
Show additional task metadata on tasks page

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -91,13 +91,19 @@ public class TaskListItem
 
     public string ScheduleText { get; }
 
+    public string ImportanceText { get; }
+
+    public string AllowedPeriodText { get; }
+
     public string StatusText => Task.Paused ? "Paused" : "Active";
 
-    private TaskListItem(TaskItem task, string repeatText, string scheduleText)
+    private TaskListItem(TaskItem task, string repeatText, string scheduleText, string importanceText, string allowedPeriodText)
     {
         Task = task;
         RepeatText = repeatText;
         ScheduleText = scheduleText;
+        ImportanceText = importanceText;
+        AllowedPeriodText = allowedPeriodText;
     }
 
     public static TaskListItem From(TaskItem task)
@@ -115,7 +121,20 @@ public class TaskListItem
             ? $"Due {task.Deadline:MMM d, yyyy HH:mm}"
             : "No deadline";
 
-        return new TaskListItem(task, repeat, schedule);
+        int importance = Math.Clamp(task.Importance, 1, 5);
+        string importanceStars = new string('★', importance).PadRight(5, '☆');
+        string importanceText = $"Importance: {importanceStars} ({importance}/5)";
+
+        string allowedPeriodText = task.AllowedPeriod switch
+        {
+            AllowedPeriod.Any => "Auto shuffle: Any time",
+            AllowedPeriod.Work => "Auto shuffle: Work hours",
+            AllowedPeriod.OffWork => "Auto shuffle: Off hours",
+            AllowedPeriod.Off => "Auto shuffle: Off days",
+            _ => "Auto shuffle: Any time"
+        };
+
+        return new TaskListItem(task, repeat, schedule, importanceText, allowedPeriodText);
     }
 
     private static string FormatWeekdays(Weekdays weekdays)

--- a/Views/TasksPage.xaml
+++ b/Views/TasksPage.xaml
@@ -85,7 +85,7 @@
                                   ColumnDefinitions="*,Auto"
                                   ColumnSpacing="12">
                                 <Grid Grid.Column="0"
-                                      RowDefinitions="Auto,Auto"
+                                      RowDefinitions="Auto,Auto,Auto,Auto"
                                       RowSpacing="2">
                                     <Label Grid.Row="0"
                                            Text="{Binding RepeatText}"
@@ -93,6 +93,14 @@
                                            TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
                                     <Label Grid.Row="1"
                                            Text="{Binding ScheduleText}"
+                                           FontSize="12"
+                                           TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
+                                    <Label Grid.Row="2"
+                                           Text="{Binding ImportanceText}"
+                                           FontSize="12"
+                                           TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
+                                    <Label Grid.Row="3"
+                                           Text="{Binding AllowedPeriodText}"
                                            FontSize="12"
                                            TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
                                 </Grid>


### PR DESCRIPTION
## Summary
- expose new TaskListItem fields so each card surfaces the task's importance and allowed auto shuffle period
- render the extra details on the Tasks page so the list shows every editable field alongside the existing schedule/status text

## Testing
- dotnet build ShuffleTask.csproj -f net8.0-android

------
https://chatgpt.com/codex/tasks/task_e_68d1c0a376548326b48b05ccb63afaab