### PR TITLE
Add visible delete button to tasks list

### DIFF
--- a/Views/TasksPage.xaml
+++ b/Views/TasksPage.xaml
@@ -118,6 +118,17 @@
                                             HorizontalOptions="End"
                                             Clicked="OnEditButtonClicked"
                                             CommandParameter="{Binding Task}" />
+                                    <Button Text="Delete"
+                                            FontSize="12"
+                                            Padding="12,4"
+                                            BackgroundColor="#eb5757"
+                                            TextColor="White"
+                                            BorderColor="#eb5757"
+                                            CornerRadius="8"
+                                            HorizontalOptions="End"
+                                            Clicked="OnDeleteSwipe"
+                                            CommandParameter="{Binding Task}"
+                                            SemanticProperties.Description="{Binding Title, StringFormat='Delete task {0}'}" />
                                     <Label Text="{Binding StatusText}"
                                            FontSize="12"
                                            HorizontalOptions="End"

--- a/Views/TasksPage.xaml.cs
+++ b/Views/TasksPage.xaml.cs
@@ -57,16 +57,25 @@ public partial class TasksPage : ContentPage
 
     private async void OnDeleteSwipe(object sender, EventArgs e)
     {
-        if (sender is SwipeItem { CommandParameter: TaskItem task })
+        var task = sender switch
         {
-            bool confirm = await DisplayAlert("Delete Task", $"Delete '{task.Title}'?", "Delete", "Cancel");
-            if (!confirm)
-            {
-                return;
-            }
+            SwipeItem { CommandParameter: TaskItem swipeTask } => swipeTask,
+            Button { CommandParameter: TaskItem buttonTask } => buttonTask,
+            _ => null
+        };
 
-            await _vm.DeleteAsync(task);
+        if (task is null)
+        {
+            return;
         }
+
+        bool confirm = await DisplayAlert("Delete Task", $"Delete '{task.Title}'?", "Delete", "Cancel");
+        if (!confirm)
+        {
+            return;
+        }
+
+        await _vm.DeleteAsync(task);
     }
 
     private async Task OpenEditorAsync(TaskItem task)


### PR DESCRIPTION
## Summary
- add a visible delete button to each task card with destructive styling and accessibility description
- update the delete handler to work with both swipe and button triggers while reusing the existing view model logic

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d3ad90ec248326a73a7ef59de39db4