### PR TITLE
Fix new task detection in editor

### DIFF
--- a/Views/TasksPage.xaml.cs
+++ b/Views/TasksPage.xaml.cs
@@ -28,7 +28,7 @@ public partial class TasksPage : ContentPage
 
     private async void OnAddClicked(object? sender, EventArgs e)
     {
-        await OpenEditorAsync(new TaskItem());
+        await OpenEditorAsync(null);
     }
 
     private async void OnEditButtonClicked(object sender, EventArgs e)
@@ -69,7 +69,7 @@ public partial class TasksPage : ContentPage
         }
     }
 
-    private async Task OpenEditorAsync(TaskItem task)
+    private async Task OpenEditorAsync(TaskItem? task)
     {
         var page = _services.GetRequiredService<EditTaskPage>();
         var editorVm = _services.GetRequiredService<EditTaskViewModel>();


### PR DESCRIPTION
## Summary
- treat the add-task flow as a brand new entry by not pre-seeding an id
- allow the task editor loader to receive a null task so SaveAsync inserts a record

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d3c850bc4c83269c25d4576a7ed5c4