### PR TITLE
Allow tuning shuffle weighting

### DIFF
--- a/Converters/ComplementPercentageConverter.cs
+++ b/Converters/ComplementPercentageConverter.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace ShuffleTask.Converters;
+
+public class ComplementPercentageConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        double numeric = ToDouble(value, culture);
+        if (double.IsNaN(numeric))
+        {
+            return 0.0;
+        }
+
+        double complement = 100.0 - Math.Clamp(numeric, 0.0, 100.0);
+        return complement;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+
+    private static double ToDouble(object? value, CultureInfo culture)
+    {
+        switch (value)
+        {
+            case null:
+                return double.NaN;
+            case double d when !double.IsNaN(d) && !double.IsInfinity(d):
+                return d;
+            case float f when !float.IsNaN(f) && !float.IsInfinity(f):
+                return f;
+            case IConvertible convertible:
+                try
+                {
+                    return convertible.ToDouble(culture);
+                }
+                catch
+                {
+                    return double.NaN;
+                }
+            default:
+                return double.NaN;
+        }
+    }
+}

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -21,4 +21,18 @@ public class AppSettings
 
     // When true (default), randomness is stable per day; when false, more chaotic
     public bool StableRandomnessPerDay { get; set; } = true;
+
+    // Weighting controls
+    // Importance vs urgency weighting expressed in points (default 60/40 split)
+    public double ImportanceWeight { get; set; } = 60.0;
+    public double UrgencyWeight { get; set; } = 40.0;
+
+    // Percent of the urgency share that should go to deadlines (0-100)
+    public double UrgencyDeadlineShare { get; set; } = 75.0;
+
+    // Dampens how strongly repeating work counts toward urgency (0-1 by default)
+    public double RepeatUrgencyPenalty { get; set; } = 0.6;
+
+    // Strength of the size-based multiplier; 0 disables, higher values boost small work
+    public double SizeBiasStrength { get; set; } = 0.2;
 }

--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ ShuffleTask ranks tasks by combining weighted importance, urgency, and a size-aw
   - The final score is `(importancePoints + deadlinePoints + repeatPoints) * sizeMultiplier`.
 
 Story point estimates default to 3 and can be adjusted between 0.5 and 13 in the task editor. Smaller estimates start boosting urgency closer to the deadline, while larger estimates surface earlier in the shuffle.
+
+### Tune the balance
+
+Open **Settings → Weighting** to tailor how the shuffle behaves:
+
+- Adjust the **importance** and **urgency** point pools (defaults remain the 60/40 split described above).
+- Split the urgency pool between **deadlines** and **repeating work** with a single slider.
+- Control the **repeat penalty** to soften or remove the dampening on routine tasks.
+- Dial the **size bias strength** down to zero to make scores size-agnostic or up to favor quick wins.
+
+Changes are saved to your profile and take effect immediately in the next shuffle preview.

--- a/Views/SettingsPage.xaml
+++ b/Views/SettingsPage.xaml
@@ -4,14 +4,25 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:ShuffleTask.ViewModels"
              xmlns:controls="clr-namespace:ShuffleTask.Controls"
+             xmlns:converters="clr-namespace:ShuffleTask.Converters"
              x:Class="ShuffleTask.Views.SettingsPage"
              x:DataType="vm:SettingsViewModel"
              Title="Settings">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:ComplementPercentageConverter x:Key="ComplementPercentageConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <ScrollView>
         <Grid Padding="20"
               ColumnDefinitions="Auto,*"
               RowSpacing="18">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -116,7 +127,86 @@
                     Grid.Column="1"
                     IsToggled="{Binding Settings.StableRandomnessPerDay}" />
 
-            <Grid Grid.Row="10"
+            <Label Grid.Row="10"
+                   Text="Importance weight"
+                   VerticalOptions="Center" />
+            <controls:NumericStepper Grid.Row="10"
+                                     Grid.Column="1"
+                                     Minimum="0"
+                                     Maximum="120"
+                                     Increment="5"
+                                     ValueStringFormat="{0:0}"
+                                     Value="{Binding Settings.ImportanceWeight}"
+                                     HorizontalOptions="Start" />
+
+            <Label Grid.Row="11"
+                   Text="Urgency weight"
+                   VerticalOptions="Center" />
+            <controls:NumericStepper Grid.Row="11"
+                                     Grid.Column="1"
+                                     Minimum="0"
+                                     Maximum="120"
+                                     Increment="5"
+                                     ValueStringFormat="{0:0}"
+                                     Value="{Binding Settings.UrgencyWeight}"
+                                     HorizontalOptions="Start" />
+
+            <Label Grid.Row="12"
+                   Text="Deadline share"
+                   VerticalOptions="Center" />
+            <Grid Grid.Row="12"
+                  Grid.Column="1"
+                  RowDefinitions="Auto,Auto"
+                  ColumnDefinitions="*,Auto"
+                  RowSpacing="4"
+                  ColumnSpacing="8">
+                <Slider Grid.Row="0"
+                        Grid.ColumnSpan="2"
+                        Minimum="0"
+                        Maximum="100"
+                        Value="{Binding Settings.UrgencyDeadlineShare}" />
+                <Label Grid.Row="1"
+                       Grid.Column="0"
+                       Text="{Binding Settings.UrgencyDeadlineShare, StringFormat='Deadlines: {0:0}%'}"
+                       VerticalOptions="Center" />
+                <Label Grid.Row="1"
+                       Grid.Column="1"
+                       Text="{Binding Settings.UrgencyDeadlineShare, Converter={StaticResource ComplementPercentageConverter}, StringFormat='Repeats: {0:0}%'}"
+                       HorizontalTextAlignment="End"
+                       VerticalOptions="Center" />
+            </Grid>
+
+            <Label Grid.Row="13"
+                   Text="Repeat penalty"
+                   VerticalOptions="Center" />
+            <Grid Grid.Row="13"
+                  Grid.Column="1"
+                  ColumnDefinitions="*,Auto"
+                  ColumnSpacing="8">
+                <Slider Minimum="0"
+                        Maximum="1"
+                        Value="{Binding Settings.RepeatUrgencyPenalty}" />
+                <Label Grid.Column="1"
+                       Text="{Binding Settings.RepeatUrgencyPenalty, StringFormat='{0:F2}'}"
+                       VerticalOptions="Center" />
+            </Grid>
+
+            <Label Grid.Row="14"
+                   Text="Size bias strength"
+                   VerticalOptions="Center" />
+            <Grid Grid.Row="14"
+                  Grid.Column="1"
+                  ColumnDefinitions="*,Auto"
+                  ColumnSpacing="8">
+                <Slider Minimum="0"
+                        Maximum="1"
+                        Value="{Binding Settings.SizeBiasStrength}" />
+                <Label Grid.Column="1"
+                       Text="{Binding Settings.SizeBiasStrength, StringFormat='{0:F2}'}"
+                       VerticalOptions="Center" />
+            </Grid>
+
+            <Grid Grid.Row="15"
                   Grid.ColumnSpan="2"
                   ColumnDefinitions="*,*"
                   ColumnSpacing="16">
@@ -128,7 +218,7 @@
                         Command="{Binding ShufflePreviewCommand}" />
             </Grid>
 
-            <ActivityIndicator Grid.Row="11"
+            <ActivityIndicator Grid.Row="16"
                                Grid.ColumnSpan="2"
                                HorizontalOptions="Center"
                                IsVisible="{Binding IsBusy}"


### PR DESCRIPTION
## Summary
- add persisted settings for importance, urgency, deadline share, repeat dampening, and size bias strength
- teach the importance/urgency calculator to read the new knobs and added a converter plus UI controls so weights are adjustable in the settings page
- expand documentation and unit coverage to verify the weighting knobs behave as expected

## Testing
- dotnet test *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d60a3c288326b6e03dceff656fa8