### PR TITLE
Normalize priority weights and favour large task bias

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -1,38 +1,128 @@
+using System;
+using System.Runtime.Serialization;
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace ShuffleTask.Models;
 
-public class AppSettings
+public partial class AppSettings : ObservableObject
 {
-    public TimeSpan WorkStart { get; set; } = new TimeSpan(9, 0, 0); // default 09:00
-    public TimeSpan WorkEnd { get; set; } = new TimeSpan(17, 0, 0); // default 17:00
+    private const double ImportanceUrgencyTotal = 100.0;
+    private const double DefaultImportanceWeight = 60.0;
+    private const double DefaultUrgencyWeight = 40.0;
 
-    public int MinGapMinutes { get; set; } = 45; // default 45
-    public int MaxGapMinutes { get; set; } = 150; // default 150
+    public AppSettings()
+    {
+        NormalizeWeights();
+    }
 
-    public int ReminderMinutes { get; set; } = 60; // default 60 (one-hour timer)
+    [ObservableProperty]
+    private TimeSpan workStart = new(9, 0, 0); // default 09:00
 
-    public bool EnableNotifications { get; set; } = true; // default true
-    public bool SoundOn { get; set; } = true; // default true
+    [ObservableProperty]
+    private TimeSpan workEnd = new(17, 0, 0); // default 17:00
 
-    public bool Active { get; set; } = true; // master switch
+    [ObservableProperty]
+    private int minGapMinutes = 45; // default 45
+
+    [ObservableProperty]
+    private int maxGapMinutes = 150; // default 150
+
+    [ObservableProperty]
+    private int reminderMinutes = 60; // default 60 (one-hour timer)
+
+    [ObservableProperty]
+    private bool enableNotifications = true; // default true
+
+    [ObservableProperty]
+    private bool soundOn = true; // default true
+
+    [ObservableProperty]
+    private bool active = true; // master switch
 
     // New settings
     // 0..1, scales preference for tasks not done in a while
-    public double StreakBias { get; set; } = 0.3;
+    [ObservableProperty]
+    private double streakBias = 0.3;
 
     // When true (default), randomness is stable per day; when false, more chaotic
-    public bool StableRandomnessPerDay { get; set; } = true;
+    [ObservableProperty]
+    private bool stableRandomnessPerDay = true;
 
-    // Weighting controls
-    // Importance vs urgency weighting expressed in points (default 60/40 split)
-    public double ImportanceWeight { get; set; } = 60.0;
-    public double UrgencyWeight { get; set; } = 40.0;
+    private double importanceWeight = DefaultImportanceWeight;
+    private double urgencyWeight = DefaultUrgencyWeight;
 
     // Percent of the urgency share that should go to deadlines (0-100)
-    public double UrgencyDeadlineShare { get; set; } = 75.0;
+    [ObservableProperty]
+    private double urgencyDeadlineShare = 75.0;
 
     // Dampens how strongly repeating work counts toward urgency (0-1 by default)
-    public double RepeatUrgencyPenalty { get; set; } = 0.6;
+    [ObservableProperty]
+    private double repeatUrgencyPenalty = 0.6;
 
-    // Strength of the size-based multiplier; 0 disables, higher values boost small work
-    public double SizeBiasStrength { get; set; } = 0.2;
+    // Strength of the size-based multiplier; 0 disables, higher values boost large work
+    [ObservableProperty]
+    private double sizeBiasStrength = 0.2;
+
+    public double ImportanceWeight
+    {
+        get => importanceWeight;
+        set => UpdateImportanceAndUrgency(value, null);
+    }
+
+    public double UrgencyWeight
+    {
+        get => urgencyWeight;
+        set => UpdateImportanceAndUrgency(null, value);
+    }
+
+    public void NormalizeWeights()
+    {
+        double sum = importanceWeight + urgencyWeight;
+
+        if (sum <= 0)
+        {
+            UpdateImportanceAndUrgency(DefaultImportanceWeight, null);
+            return;
+        }
+
+        if (Math.Abs(sum - ImportanceUrgencyTotal) > 0.0001)
+        {
+            double scale = ImportanceUrgencyTotal / sum;
+            UpdateImportanceAndUrgency(importanceWeight * scale, null);
+        }
+        else
+        {
+            UpdateImportanceAndUrgency(importanceWeight, null);
+        }
+    }
+
+    private void UpdateImportanceAndUrgency(double? newImportance, double? newUrgency)
+    {
+        double importanceShare;
+
+        if (newImportance.HasValue)
+        {
+            importanceShare = Math.Clamp(newImportance.Value, 0.0, ImportanceUrgencyTotal);
+        }
+        else if (newUrgency.HasValue)
+        {
+            double urgencyShare = Math.Clamp(newUrgency.Value, 0.0, ImportanceUrgencyTotal);
+            importanceShare = ImportanceUrgencyTotal - urgencyShare;
+        }
+        else
+        {
+            importanceShare = Math.Clamp(importanceWeight, 0.0, ImportanceUrgencyTotal);
+        }
+
+        double urgencyShare = ImportanceUrgencyTotal - importanceShare;
+
+        SetProperty(ref importanceWeight, importanceShare, nameof(ImportanceWeight));
+        SetProperty(ref urgencyWeight, urgencyShare, nameof(UrgencyWeight));
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        NormalizeWeights();
+    }
 }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ ShuffleTask ranks tasks by combining weighted importance, urgency, and a size-aw
   - `windowHours = clamp(72 * (storyPoints / 3), 24, 168)`
   - Upcoming deadlines receive `deadlineUrgency = 1 - clamp(hoursUntilDeadline / windowHours, 0, 1)` while overdue work keeps the existing boost.
   - Repeat urgency is unchanged, still weighted at 25% of the urgency share with a streak penalty.
-- **Size multiplier** nudges smaller wins upward while keeping larger efforts visible:
-  - `sizeMultiplier = clamp(1 + 0.2 * (1 - storyPoints / 3), 0.8, 1.2)`
+- **Size multiplier** lifts larger efforts while keeping quick wins visible:
+  - `sizeMultiplier = clamp(1 + 0.2 * (storyPoints / 3 - 1), 0.8, 1.2)`
   - The final score is `(importancePoints + deadlinePoints + repeatPoints) * sizeMultiplier`.
 
 Story point estimates default to 3 and can be adjusted between 0.5 and 13 in the task editor. Smaller estimates start boosting urgency closer to the deadline, while larger estimates surface earlier in the shuffle.
@@ -19,9 +19,9 @@ Story point estimates default to 3 and can be adjusted between 0.5 and 13 in the
 
 Open **Settings → Weighting** to tailor how the shuffle behaves:
 
-- Adjust the **importance** and **urgency** point pools (defaults remain the 60/40 split described above).
+- Adjust the split between **importance** and **urgency** (defaults remain the 60/40 split described above) with a single slider.
 - Split the urgency pool between **deadlines** and **repeating work** with a single slider.
 - Control the **repeat penalty** to soften or remove the dampening on routine tasks.
-- Dial the **size bias strength** down to zero to make scores size-agnostic or up to favor quick wins.
+- Dial the **size bias strength** down to zero to make scores size-agnostic or up to highlight big pushes.
 
 Changes are saved to your profile and take effect immediately in the next shuffle preview.

--- a/Services/ImportanceUrgencyCalculator.cs
+++ b/Services/ImportanceUrgencyCalculator.cs
@@ -227,7 +227,7 @@ public static class ImportanceUrgencyCalculator
     private static double ComputeSizeMultiplier(double storyPoints, double sizeBiasStrength)
     {
         double normalized = storyPoints / DefaultStoryPoints;
-        double bias = 1.0 + (sizeBiasStrength * (1.0 - normalized));
+        double bias = 1.0 + (sizeBiasStrength * (normalized - 1.0));
 
         if (bias < SizeBiasMinMultiplier)
         {

--- a/ShuffleTask.Tests/ImportanceUrgencyCalculatorTests.cs
+++ b/ShuffleTask.Tests/ImportanceUrgencyCalculatorTests.cs
@@ -75,7 +75,7 @@ public class ImportanceUrgencyCalculatorTests
     }
 
     [Test]
-    public void Calculate_SmallerTasksEarnSizeMultiplierBoost()
+    public void Calculate_LargerTasksEarnSizeMultiplierBoost()
     {
         var settings = new AppSettings();
 
@@ -100,10 +100,10 @@ public class ImportanceUrgencyCalculatorTests
         var smallScore = ImportanceUrgencyCalculator.Calculate(smallTask, DefaultNow, settings);
         var largeScore = ImportanceUrgencyCalculator.Calculate(largeTask, DefaultNow, settings);
 
-        Assert.That(smallScore.SizeMultiplier, Is.GreaterThan(largeScore.SizeMultiplier),
-            "Smaller tasks should receive the larger size multiplier.");
-        Assert.That(smallScore.CombinedScore, Is.GreaterThan(largeScore.CombinedScore),
-            "With the same inputs otherwise, the smaller task should edge the larger one.");
+        Assert.That(largeScore.SizeMultiplier, Is.GreaterThan(smallScore.SizeMultiplier),
+            "Larger tasks should receive the larger size multiplier.");
+        Assert.That(largeScore.CombinedScore, Is.GreaterThan(smallScore.CombinedScore),
+            "With the same inputs otherwise, the larger task should edge the smaller one.");
     }
 
     [Test]

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -38,6 +38,7 @@ public partial class SettingsViewModel : ObservableObject
         {
             await _storage.InitializeAsync();
             Settings = await _storage.GetSettingsAsync();
+            Settings.NormalizeWeights();
             await _notifications.InitializeAsync();
         }
         finally

--- a/Views/SettingsPage.xaml
+++ b/Views/SettingsPage.xaml
@@ -128,33 +128,34 @@
                     IsToggled="{Binding Settings.StableRandomnessPerDay}" />
 
             <Label Grid.Row="10"
-                   Text="Importance weight"
+                   Text="Importance vs urgency"
                    VerticalOptions="Center" />
-            <controls:NumericStepper Grid.Row="10"
-                                     Grid.Column="1"
-                                     Minimum="0"
-                                     Maximum="120"
-                                     Increment="5"
-                                     ValueStringFormat="{0:0}"
-                                     Value="{Binding Settings.ImportanceWeight}"
-                                     HorizontalOptions="Start" />
+            <Grid Grid.Row="10"
+                  Grid.Column="1"
+                  RowDefinitions="Auto,Auto"
+                  ColumnDefinitions="*,Auto"
+                  RowSpacing="4"
+                  ColumnSpacing="8">
+                <Slider Grid.Row="0"
+                        Grid.ColumnSpan="2"
+                        Minimum="0"
+                        Maximum="100"
+                        Value="{Binding Settings.ImportanceWeight}" />
+                <Label Grid.Row="1"
+                       Grid.Column="0"
+                       Text="{Binding Settings.ImportanceWeight, StringFormat='Importance: {0:0}%'}"
+                       VerticalOptions="Center" />
+                <Label Grid.Row="1"
+                       Grid.Column="1"
+                       Text="{Binding Settings.ImportanceWeight, Converter={StaticResource ComplementPercentageConverter}, StringFormat='Urgency: {0:0}%'}"
+                       HorizontalTextAlignment="End"
+                       VerticalOptions="Center" />
+            </Grid>
 
             <Label Grid.Row="11"
-                   Text="Urgency weight"
-                   VerticalOptions="Center" />
-            <controls:NumericStepper Grid.Row="11"
-                                     Grid.Column="1"
-                                     Minimum="0"
-                                     Maximum="120"
-                                     Increment="5"
-                                     ValueStringFormat="{0:0}"
-                                     Value="{Binding Settings.UrgencyWeight}"
-                                     HorizontalOptions="Start" />
-
-            <Label Grid.Row="12"
                    Text="Deadline share"
                    VerticalOptions="Center" />
-            <Grid Grid.Row="12"
+            <Grid Grid.Row="11"
                   Grid.Column="1"
                   RowDefinitions="Auto,Auto"
                   ColumnDefinitions="*,Auto"
@@ -176,10 +177,10 @@
                        VerticalOptions="Center" />
             </Grid>
 
-            <Label Grid.Row="13"
+            <Label Grid.Row="12"
                    Text="Repeat penalty"
                    VerticalOptions="Center" />
-            <Grid Grid.Row="13"
+            <Grid Grid.Row="12"
                   Grid.Column="1"
                   ColumnDefinitions="*,Auto"
                   ColumnSpacing="8">
@@ -191,10 +192,10 @@
                        VerticalOptions="Center" />
             </Grid>
 
-            <Label Grid.Row="14"
+            <Label Grid.Row="13"
                    Text="Size bias strength"
                    VerticalOptions="Center" />
-            <Grid Grid.Row="14"
+            <Grid Grid.Row="13"
                   Grid.Column="1"
                   ColumnDefinitions="*,Auto"
                   ColumnSpacing="8">
@@ -206,7 +207,7 @@
                        VerticalOptions="Center" />
             </Grid>
 
-            <Grid Grid.Row="15"
+            <Grid Grid.Row="14"
                   Grid.ColumnSpan="2"
                   ColumnDefinitions="*,*"
                   ColumnSpacing="16">
@@ -218,7 +219,7 @@
                         Command="{Binding ShufflePreviewCommand}" />
             </Grid>
 
-            <ActivityIndicator Grid.Row="16"
+            <ActivityIndicator Grid.Row="15"
                                Grid.ColumnSpan="2"
                                HorizontalOptions="Center"
                                IsVisible="{Binding IsBusy}"


### PR DESCRIPTION
## Summary
- convert `AppSettings` into an observable settings container that keeps importance and urgency weights complementary and normalizes stored data
- replace the importance/urgency steppers with a paired slider display and propagate normalization after loading settings
- invert the size-bias multiplier to reward larger work, updating the documentation and regression tests accordingly

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e32e48b48326a53daefd45565f62