### PR TITLE
Switch tests to project reference and interface-based storage service

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -8,12 +8,12 @@ namespace ShuffleTask;
 
 public partial class App : Application
 {
-    private readonly StorageService _storage;
+    private readonly IStorageService _storage;
 
     private const string PrefTaskId = "pref.currentTaskId";
     private const string PrefRemainingSecs = "pref.remainingSecs";
 
-    public App(MainPage mainPage, StorageService storage)
+    public App(MainPage mainPage, IStorageService storage)
     {
         InitializeComponent();
         MainPage = mainPage;

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -27,7 +27,7 @@ public static class MauiProgram
         });
 
         // DI registrations
-        builder.Services.AddSingleton<StorageService>();
+        builder.Services.AddSingleton<IStorageService, StorageService>();
         builder.Services.AddSingleton<NotificationService>();
         builder.Services.AddSingleton(sp => new SchedulerService(deterministic: false));
 

--- a/Services/IStorageService.cs
+++ b/Services/IStorageService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ShuffleTask.Models;
+
+namespace ShuffleTask.Services;
+
+public interface IStorageService
+{
+    Task InitializeAsync();
+    Task<List<TaskItem>> GetTasksAsync();
+    Task<TaskItem?> GetTaskAsync(string id);
+    Task AddTaskAsync(TaskItem item);
+    Task UpdateTaskAsync(TaskItem item);
+    Task DeleteTaskAsync(string id);
+    Task<TaskItem?> MarkTaskDoneAsync(string id);
+    Task<TaskItem?> SnoozeTaskAsync(string id, TimeSpan duration);
+    Task<TaskItem?> ResumeTaskAsync(string id);
+    Task<AppSettings> GetSettingsAsync();
+    Task SetSettingsAsync(AppSettings settings);
+}

--- a/Services/StorageService.cs
+++ b/Services/StorageService.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace ShuffleTask.Services;
 
-public class StorageService
+public class StorageService : IStorageService
 {
     private const string DatabaseFileName = "shuffletask.db3";
     private const string SettingsKey = "app_settings";

--- a/ShuffleTask.Tests/ShuffleTask.Tests.csproj
+++ b/ShuffleTask.Tests/ShuffleTask.Tests.csproj
@@ -8,20 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="../Models/Enums.cs" Link="Models/Enums.cs" />
-    <Compile Include="../Models/AppSettings.cs" Link="Models/AppSettings.cs" />
-    <Compile Include="../Models/TaskItem.cs" Link="Models/TaskItem.cs" />
-    <Compile Include="../Services/ImportanceUrgencyCalculator.cs" Link="Services/ImportanceUrgencyCalculator.cs" />
-    <Compile Include="../Services/SchedulerService.cs" Link="Services/SchedulerService.cs" />
-    <Compile Include="../Services/TimeWindowService.cs" Link="Services/TimeWindowService.cs" />
-    <Compile Include="../ViewModels/TasksViewModel.cs" Link="Viewodels/TasksViewModel.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ShuffleTask.csproj" />
   </ItemGroup>
 </Project>

--- a/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
+++ b/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
@@ -1,16 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using ShuffleTask.Models;
+using ShuffleTask.Services;
 
-namespace ShuffleTask.Services;
+namespace ShuffleTask.Tests.TestDoubles;
 
-public class StorageService
+public class StorageServiceStub : IStorageService
 {
     private readonly Dictionary<string, TaskItem> _tasks = new();
     private bool _initialized;
+    private AppSettings _settings = new();
 
     public int InitializeCallCount { get; private set; }
     public int GetTasksCallCount { get; private set; }
     public int UpdateTaskCallCount { get; private set; }
     public int DeleteTaskCallCount { get; private set; }
+    public int MarkDoneCallCount { get; private set; }
+    public int SnoozeCallCount { get; private set; }
+    public int ResumeCallCount { get; private set; }
+    public int GetSettingsCallCount { get; private set; }
+    public int SetSettingsCallCount { get; private set; }
 
     public Task InitializeAsync()
     {
@@ -22,6 +33,7 @@ public class StorageService
     public Task<List<TaskItem>> GetTasksAsync()
     {
         EnsureInitialized();
+        AutoResumeDueTasks();
         GetTasksCallCount++;
         var snapshot = _tasks.Values
             .OrderByDescending(t => t.CreatedAt)
@@ -33,6 +45,7 @@ public class StorageService
     public Task<TaskItem?> GetTaskAsync(string id)
     {
         EnsureInitialized();
+        AutoResumeDueTasks();
         return Task.FromResult(_tasks.TryGetValue(id, out var item) ? Clone(item) : null);
     }
 
@@ -59,6 +72,167 @@ public class StorageService
         return Task.CompletedTask;
     }
 
+    public Task<TaskItem?> MarkTaskDoneAsync(string id)
+    {
+        EnsureInitialized();
+        MarkDoneCallCount++;
+
+        if (!_tasks.TryGetValue(id, out var existing))
+        {
+            return Task.FromResult<TaskItem?>(null);
+        }
+
+        DateTime nowUtc = DateTime.UtcNow;
+        DateTime doneAt = EnsureUtc(nowUtc);
+
+        existing.LastDoneAt = doneAt;
+        existing.CompletedAt = doneAt;
+        existing.Status = TaskLifecycleStatus.Completed;
+        existing.SnoozedUntil = null;
+        existing.NextEligibleAt = ComputeNextEligibleUtc(existing, nowUtc);
+
+        _tasks[id] = Clone(existing);
+        return Task.FromResult<TaskItem?>(Clone(existing));
+    }
+
+    public Task<TaskItem?> SnoozeTaskAsync(string id, TimeSpan duration)
+    {
+        EnsureInitialized();
+        SnoozeCallCount++;
+
+        if (duration <= TimeSpan.Zero)
+        {
+            duration = TimeSpan.FromMinutes(15);
+        }
+
+        if (!_tasks.TryGetValue(id, out var existing))
+        {
+            return Task.FromResult<TaskItem?>(null);
+        }
+
+        DateTime nowUtc = DateTime.UtcNow;
+        DateTime until = EnsureUtc(nowUtc.Add(duration));
+
+        existing.Status = TaskLifecycleStatus.Snoozed;
+        existing.SnoozedUntil = until;
+        existing.NextEligibleAt = until;
+        existing.CompletedAt = null;
+
+        _tasks[id] = Clone(existing);
+        return Task.FromResult<TaskItem?>(Clone(existing));
+    }
+
+    public Task<TaskItem?> ResumeTaskAsync(string id)
+    {
+        EnsureInitialized();
+        ResumeCallCount++;
+
+        if (!_tasks.TryGetValue(id, out var existing))
+        {
+            return Task.FromResult<TaskItem?>(null);
+        }
+
+        ApplyResume(existing);
+        _tasks[id] = Clone(existing);
+        return Task.FromResult<TaskItem?>(Clone(existing));
+    }
+
+    public Task<AppSettings> GetSettingsAsync()
+    {
+        EnsureInitialized();
+        GetSettingsCallCount++;
+        return Task.FromResult(Clone(_settings));
+    }
+
+    public Task SetSettingsAsync(AppSettings settings)
+    {
+        EnsureInitialized();
+        SetSettingsCallCount++;
+        _settings = Clone(settings);
+        return Task.CompletedTask;
+    }
+
+    private void AutoResumeDueTasks()
+    {
+        DateTime nowUtc = DateTime.UtcNow;
+
+        foreach (var task in _tasks.Values)
+        {
+            if (task.Status == TaskLifecycleStatus.Active)
+            {
+                continue;
+            }
+
+            if (task.NextEligibleAt == null)
+            {
+                continue;
+            }
+
+            DateTime nextUtc = EnsureUtc(task.NextEligibleAt.Value);
+            if (nextUtc <= nowUtc)
+            {
+                ApplyResume(task);
+            }
+        }
+    }
+
+    private static void ApplyResume(TaskItem task)
+    {
+        task.Status = TaskLifecycleStatus.Active;
+        task.SnoozedUntil = null;
+        task.NextEligibleAt = null;
+        task.CompletedAt = null;
+    }
+
+    private static DateTime? ComputeNextEligibleUtc(TaskItem task, DateTime nowUtc)
+    {
+        return task.Repeat switch
+        {
+            RepeatType.None => null,
+            RepeatType.Daily => EnsureUtc(nowUtc.ToLocalTime().AddDays(1)),
+            RepeatType.Weekly => ComputeWeeklyNext(task.Weekdays, nowUtc),
+            RepeatType.Interval => EnsureUtc(nowUtc.ToLocalTime().AddDays(Math.Max(1, task.IntervalDays))),
+            _ => null
+        };
+    }
+
+    private static DateTime? ComputeWeeklyNext(Weekdays weekdays, DateTime nowUtc)
+    {
+        DateTime local = nowUtc.ToLocalTime();
+        if (weekdays == Weekdays.None)
+        {
+            weekdays = DayToWeekdayFlag(local.DayOfWeek);
+        }
+
+        for (int offset = 1; offset <= 7; offset++)
+        {
+            DateTime candidate = DateTime.SpecifyKind(local.Date.AddDays(offset).Add(local.TimeOfDay), DateTimeKind.Local);
+            Weekdays flag = DayToWeekdayFlag(candidate.DayOfWeek);
+            if ((weekdays & flag) != 0)
+            {
+                return EnsureUtc(candidate);
+            }
+        }
+
+        DateTime fallback = DateTime.SpecifyKind(local.Date.AddDays(7).Add(local.TimeOfDay), DateTimeKind.Local);
+        return EnsureUtc(fallback);
+    }
+
+    private static Weekdays DayToWeekdayFlag(DayOfWeek dow)
+    {
+        return dow switch
+        {
+            DayOfWeek.Sunday => Weekdays.Sun,
+            DayOfWeek.Monday => Weekdays.Mon,
+            DayOfWeek.Tuesday => Weekdays.Tue,
+            DayOfWeek.Wednesday => Weekdays.Wed,
+            DayOfWeek.Thursday => Weekdays.Thu,
+            DayOfWeek.Friday => Weekdays.Fri,
+            DayOfWeek.Saturday => Weekdays.Sat,
+            _ => Weekdays.None
+        };
+    }
+
     private void EnsureInitialized()
     {
         if (!_initialized)
@@ -82,7 +256,44 @@ public class StorageService
             LastDoneAt = task.LastDoneAt,
             AllowedPeriod = task.AllowedPeriod,
             Paused = task.Paused,
-            CreatedAt = task.CreatedAt
+            CreatedAt = task.CreatedAt,
+            SizePoints = task.SizePoints,
+            Status = task.Status,
+            SnoozedUntil = task.SnoozedUntil,
+            CompletedAt = task.CompletedAt,
+            NextEligibleAt = task.NextEligibleAt
+        };
+    }
+
+    private static AppSettings Clone(AppSettings settings)
+    {
+        return new AppSettings
+        {
+            WorkStart = settings.WorkStart,
+            WorkEnd = settings.WorkEnd,
+            MinGapMinutes = settings.MinGapMinutes,
+            MaxGapMinutes = settings.MaxGapMinutes,
+            ReminderMinutes = settings.ReminderMinutes,
+            EnableNotifications = settings.EnableNotifications,
+            SoundOn = settings.SoundOn,
+            Active = settings.Active,
+            StreakBias = settings.StreakBias,
+            StableRandomnessPerDay = settings.StableRandomnessPerDay,
+            ImportanceWeight = settings.ImportanceWeight,
+            UrgencyWeight = settings.UrgencyWeight,
+            UrgencyDeadlineShare = settings.UrgencyDeadlineShare,
+            RepeatUrgencyPenalty = settings.RepeatUrgencyPenalty,
+            SizeBiasStrength = settings.SizeBiasStrength
+        };
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
         };
     }
 }

--- a/ShuffleTask.Tests/Tests/TasksViewModelTests.cs
+++ b/ShuffleTask.Tests/Tests/TasksViewModelTests.cs
@@ -4,19 +4,20 @@ using ShuffleTask.Services;
 using ShuffleTask.ViewModels;
 using System.Threading.Tasks;
 using System.Linq;
+using ShuffleTask.Tests.TestDoubles;
 
 namespace ShuffleTask.Tests;
 
 [TestFixture]
 public class TasksViewModelTests
 {
-    private StorageService _storage = null!;
+    private StorageServiceStub _storage = null!;
     private TasksViewModel _viewModel = null!;
 
     [SetUp]
     public async Task SetUp()
     {
-        _storage = new StorageService();
+        _storage = new StorageServiceStub();
         await _storage.InitializeAsync();
         _viewModel = new TasksViewModel(_storage);
     }

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -11,7 +11,7 @@ namespace ShuffleTask.ViewModels;
 
 public partial class DashboardViewModel : ObservableObject
 {
-    private readonly StorageService _storage;
+    private readonly IStorageService _storage;
     private readonly SchedulerService _scheduler;
     private readonly NotificationService _notifications;
 
@@ -22,7 +22,7 @@ public partial class DashboardViewModel : ObservableObject
     private const string DefaultDescription = "Tap Shuffle to pick what comes next.";
     private const string DefaultSchedule = "No schedule yet.";
 
-    public DashboardViewModel(StorageService storage, SchedulerService scheduler, NotificationService notifications)
+    public DashboardViewModel(IStorageService storage, SchedulerService scheduler, NotificationService notifications)
     {
         _storage = storage;
         _scheduler = scheduler;

--- a/ViewModels/EditTaskViewModel.cs
+++ b/ViewModels/EditTaskViewModel.cs
@@ -8,7 +8,7 @@ namespace ShuffleTask.ViewModels;
 
 public partial class EditTaskViewModel : ObservableObject
 {
-    private readonly StorageService _storage;
+    private readonly IStorageService _storage;
 
     private TaskItem _workingCopy = new();
 
@@ -79,7 +79,7 @@ public partial class EditTaskViewModel : ObservableObject
         private set => SetProperty(ref _isNew, value);
     }
 
-    public EditTaskViewModel(StorageService storage)
+    public EditTaskViewModel(IStorageService storage)
     {
         _storage = storage;
     }

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -8,7 +8,7 @@ namespace ShuffleTask.ViewModels;
 
 public partial class SettingsViewModel : ObservableObject
 {
-    private readonly StorageService _storage;
+    private readonly IStorageService _storage;
     private readonly SchedulerService _scheduler;
     private readonly NotificationService _notifications;
 
@@ -18,7 +18,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool isBusy;
 
-    public SettingsViewModel(StorageService storage, SchedulerService scheduler, NotificationService notifications)
+    public SettingsViewModel(IStorageService storage, SchedulerService scheduler, NotificationService notifications)
     {
         _storage = storage;
         _scheduler = scheduler;

--- a/ViewModels/TasksViewModel.cs
+++ b/ViewModels/TasksViewModel.cs
@@ -10,9 +10,9 @@ namespace ShuffleTask.ViewModels;
 
 public partial class TasksViewModel : ObservableObject
 {
-    private readonly StorageService _storage;
+    private readonly IStorageService _storage;
 
-    public TasksViewModel(StorageService storage)
+    public TasksViewModel(IStorageService storage)
     {
         _storage = storage;
     }


### PR DESCRIPTION
## Summary
- add an `IStorageService` interface implemented by the production storage service and consumed throughout the app
- register the interface with dependency injection and update view models and App to depend on the abstraction
- update the test project to reference the main project and convert the in-memory storage stub to implement the interface without conflicting class names

## Testing
- `dotnet test` *(fails: unable to reach https://api.nuget.org/v3/index.json in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d45dc70a188326bb1f99af1f774330