### PR TITLE
Add interfaces for scheduler and notification services

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -28,8 +28,8 @@ public static class MauiProgram
 
         // DI registrations
         builder.Services.AddSingleton<IStorageService, StorageService>();
-        builder.Services.AddSingleton<NotificationService>();
-        builder.Services.AddSingleton(sp => new SchedulerService(deterministic: false));
+        builder.Services.AddSingleton<INotificationService, NotificationService>();
+        builder.Services.AddSingleton<ISchedulerService>(_ => new SchedulerService(deterministic: false));
 
         // ViewModels
         builder.Services.AddSingleton<DashboardViewModel>();

--- a/Services/INotificationService.cs
+++ b/Services/INotificationService.cs
@@ -1,0 +1,14 @@
+using ShuffleTask.Models;
+
+namespace ShuffleTask.Services;
+
+public interface INotificationService
+{
+    Task InitializeAsync();
+
+    Task NotifyTaskAsync(TaskItem task, int minutes, AppSettings settings);
+
+    Task NotifyTaskAsync(TaskItem task, int minutes, AppSettings settings, TimeSpan delay);
+
+    Task ShowToastAsync(string title, string message, AppSettings settings);
+}

--- a/Services/ISchedulerService.cs
+++ b/Services/ISchedulerService.cs
@@ -1,0 +1,10 @@
+using ShuffleTask.Models;
+
+namespace ShuffleTask.Services;
+
+public interface ISchedulerService
+{
+    TimeSpan NextGap(AppSettings settings, DateTime nowLocal);
+
+    TaskItem? PickNextTask(IEnumerable<TaskItem> tasks, AppSettings settings, DateTime nowLocal);
+}

--- a/Services/NotificationService.cs
+++ b/Services/NotificationService.cs
@@ -7,7 +7,7 @@ namespace ShuffleTask.Services;
 /// <summary>
 /// Provides cross-platform notifications using platform primitives with a XAML alert fallback.
 /// </summary>
-public partial class NotificationService
+public partial class NotificationService : INotificationService
 {
     private readonly INotificationPlatform _platform;
 

--- a/Services/SchedulerService.cs
+++ b/Services/SchedulerService.cs
@@ -2,7 +2,7 @@ using ShuffleTask.Models;
 
 namespace ShuffleTask.Services;
 
-public class SchedulerService
+public class SchedulerService : ISchedulerService
 {
     private readonly bool _deterministic;
 
@@ -15,10 +15,10 @@ public class SchedulerService
         _deterministic = deterministic;
     }
 
-    public TimeSpan NextGap(AppSettings s, DateTime nowLocal)
+    public TimeSpan NextGap(AppSettings settings, DateTime nowLocal)
     {
-        int min = Math.Max(0, s.MinGapMinutes);
-        int max = Math.Max(min, s.MaxGapMinutes);
+        int min = Math.Max(0, settings.MinGapMinutes);
+        int max = Math.Max(min, settings.MaxGapMinutes);
 
         if (_deterministic)
         {
@@ -29,7 +29,7 @@ public class SchedulerService
 
         // Pick RNG based on settings
         Random rng;
-        if (s.StableRandomnessPerDay)
+        if (settings.StableRandomnessPerDay)
         {
             int seed = nowLocal.Year * 10000 + nowLocal.Month * 100 + nowLocal.Day;
             rng = new Random(seed ^ 0x5f3759df);
@@ -44,8 +44,8 @@ public class SchedulerService
         return TimeSpan.FromMinutes(minutes);
     }
 
-    public TaskItem? PickNextTask(IEnumerable<TaskItem> tasks, AppSettings s, DateTime nowLocal)
-        => PickNextTask(tasks, s, nowLocal, _deterministic);
+    public TaskItem? PickNextTask(IEnumerable<TaskItem> tasks, AppSettings settings, DateTime nowLocal)
+        => PickNextTask(tasks, settings, nowLocal, _deterministic);
 
     public static TaskItem? PickNextTask(IEnumerable<TaskItem> tasks, AppSettings s, DateTime nowLocal, bool deterministic)
     {

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -12,8 +12,8 @@ namespace ShuffleTask.ViewModels;
 public partial class DashboardViewModel : ObservableObject
 {
     private readonly IStorageService _storage;
-    private readonly SchedulerService _scheduler;
-    private readonly NotificationService _notifications;
+    private readonly ISchedulerService _scheduler;
+    private readonly INotificationService _notifications;
 
     private TaskItem? _activeTask;
     private AppSettings? _settings;
@@ -22,7 +22,7 @@ public partial class DashboardViewModel : ObservableObject
     private const string DefaultDescription = "Tap Shuffle to pick what comes next.";
     private const string DefaultSchedule = "No schedule yet.";
 
-    public DashboardViewModel(IStorageService storage, SchedulerService scheduler, NotificationService notifications)
+    public DashboardViewModel(IStorageService storage, ISchedulerService scheduler, INotificationService notifications)
     {
         _storage = storage;
         _scheduler = scheduler;

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -9,8 +9,8 @@ namespace ShuffleTask.ViewModels;
 public partial class SettingsViewModel : ObservableObject
 {
     private readonly IStorageService _storage;
-    private readonly SchedulerService _scheduler;
-    private readonly NotificationService _notifications;
+    private readonly ISchedulerService _scheduler;
+    private readonly INotificationService _notifications;
 
     [ObservableProperty]
     private AppSettings settings = new();
@@ -18,7 +18,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool isBusy;
 
-    public SettingsViewModel(IStorageService storage, SchedulerService scheduler, NotificationService notifications)
+    public SettingsViewModel(IStorageService storage, ISchedulerService scheduler, INotificationService notifications)
     {
         _storage = storage;
         _scheduler = scheduler;


### PR DESCRIPTION
## Summary
- add ISchedulerService and INotificationService interfaces for the existing services
- update service registrations and view models to rely on the new abstractions

## Testing
- `dotnet test` *(fails: Unable to reach https://api.nuget.org/v3/index.json in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d478a776e8832697d50f674b274aa0