### PR TITLE
Refresh dashboard settings before shuffling

### DIFF
--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -20,6 +20,7 @@ public partial class DashboardViewModel : ObservableObject
     private AppSettings? _settings;
     private PomodoroSession? _pomodoroSession;
     private TimerRequest? _currentTimer;
+    private bool _isInitialized;
 
     private const string DefaultTitle = "Shuffle a task";
     private const string DefaultDescription = "Tap Shuffle to pick what comes next.";
@@ -110,21 +111,31 @@ public partial class DashboardViewModel : ObservableObject
 
     public async Task InitializeAsync()
     {
-        await _storage.InitializeAsync();
-        if (_settings == null)
+        if (!_isInitialized)
         {
-            _settings = await _storage.GetSettingsAsync();
+            await _storage.InitializeAsync();
+            await _notifications.InitializeAsync();
+            _coordinator.RegisterDashboard(this);
+            _isInitialized = true;
         }
-        await _notifications.InitializeAsync();
-        _coordinator.RegisterDashboard(this);
+
+        await LoadSettingsAsync();
     }
 
     private async Task EnsureSettingsAsync()
     {
-        if (_settings == null)
+        if (!_isInitialized)
         {
             await InitializeAsync();
+            return;
         }
+
+        await LoadSettingsAsync();
+    }
+
+    private async Task LoadSettingsAsync()
+    {
+        _settings = await _storage.GetSettingsAsync();
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- reload the dashboard's settings during initialization and before each shuffle so timer changes take effect immediately
- track whether the dashboard has finished one-time initialization before reloading settings

## Testing
- dotnet test *(fails: proxy tunnel request to http://proxy:8080/ returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d66b469e8c83269f8f48e2ee14a364