### PR TITLE
Ensure GUI workflow waits on gitVersion

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -202,7 +202,7 @@ jobs:
 
   buildAndTestGUI:
     name: Build and Test GUI
-    needs: [checkWhetherGUIBuildNeeded]
+    needs: [checkWhetherGUIBuildNeeded, gitVersion]
     if: |
       (needs.checkWhetherGUIBuildNeeded.outputs.diff != '' &&
       needs.checkWhetherGUIBuildNeeded.outputs.override != 'false') ||


### PR DESCRIPTION
## Summary
- add gitVersion as a dependency of the buildAndTestGUI job so version outputs are available

## Testing
- ❌ `gh workflow run ci-pipeline.yaml --dry-run` *(command not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da373fd86c83268cc92a766776fefd