### PR TITLE
Avoid modifying loop indices in NumericStepper

### DIFF
--- a/ShuffleTask.Presentation/Controls/NumericStepper.xaml.cs
+++ b/ShuffleTask.Presentation/Controls/NumericStepper.xaml.cs
@@ -240,16 +240,19 @@ public partial class NumericStepper : ContentView
     private static bool ContainsFormatPlaceholder(string format)
     {
         var span = format.AsSpan();
-        for (var index = 0; index < span.Length; index++)
+        var index = 0;
+
+        while (index < span.Length)
         {
             if (span[index] != '{')
             {
+                index++;
                 continue;
             }
 
             if (IsEscapedBrace(span, index))
             {
-                index++;
+                index += 2;
                 continue;
             }
 
@@ -265,6 +268,8 @@ public partial class NumericStepper : ContentView
                     break;
                 }
             }
+
+            index++;
         }
 
         return false;
@@ -274,18 +279,21 @@ public partial class NumericStepper : ContentView
     {
         var span = format.AsSpan();
 
-        for (var index = 0; index < span.Length; index++)
+        var index = 0;
+
+        while (index < span.Length)
         {
             var current = span[index];
 
             if (current != '{' && current != '}')
             {
+                index++;
                 continue;
             }
 
             if (IsEscapedBrace(span, index))
             {
-                index++;
+                index += 2;
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- replace for-loops with while-loops when scanning format strings to avoid modifying loop counters inside the body
- ensure escaped brace sequences advance the index without violating analyzer rules

## Testing
- dotnet test ShuffleTask.Presentation.Tests

------
https://chatgpt.com/codex/tasks/task_e_68e61dd4924c83269e1f3c776b518990