### PR TITLE
Guard System.Drawing.Common package for Windows builds

### DIFF
--- a/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
+++ b/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
@@ -35,6 +35,9 @@
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
         <PackageReference Include="System.Drawing.Common" Version="9.0.9" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- guard the System.Drawing.Common package reference behind a Windows-only ItemGroup so Android publishes avoid desktop assemblies

## Testing
- not run (Windows targeting requires additional setup in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ed5e6c36448326bcd0bf9b0bb93b46