### PR TITLE
Update the signing workflow to download build artifacts with Invoke-WebRequest

### DIFF
--- a/.github/workflows/sign-artifacts.yml
+++ b/.github/workflows/sign-artifacts.yml
@@ -125,8 +125,14 @@ jobs:
           $winZip = Join-Path $downloadRoot 'windows-artifact.zip'
           $androidZip = Join-Path $downloadRoot 'android-artifact.zip'
 
-          gh api --method GET --header "Accept: application/octet-stream" $windowsArtifact.archive_download_url --output $winZip
-          gh api --method GET --header "Accept: application/octet-stream" $androidArtifact.archive_download_url --output $androidZip
+          $headers = @{
+            Authorization = "token $env:GH_TOKEN"
+            Accept = "application/octet-stream"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+
+          Invoke-WebRequest -Uri $windowsArtifact.archive_download_url -Headers $headers -OutFile $winZip
+          Invoke-WebRequest -Uri $androidArtifact.archive_download_url -Headers $headers -OutFile $androidZip
 
           Expand-Archive -Path $winZip -DestinationPath $winExtract -Force
           Expand-Archive -Path $androidZip -DestinationPath $androidExtract -Force


### PR DESCRIPTION
## Summary
- Updated the signing workflow to download build artifacts with Invoke-WebRequest

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed6885d160832685d453dc2961fde0