### PR TITLE
Add debug session option to sign artifacts workflow

### DIFF
--- a/.github/workflows/sign-artifacts.yml
+++ b/.github/workflows/sign-artifacts.yml
@@ -7,6 +7,10 @@ on:
         description: 'Semantic version to sign (e.g., 1.0.0)'
         type: string
         required: true
+      debug_session:
+        description: 'Enable an interactive debug session before signing'
+        type: boolean
+        default: false
 
 jobs:
   sign:
@@ -166,6 +170,13 @@ jobs:
           Write-Host "✓ Downloaded artifacts:"
           Write-Host "  Windows: $($winExe.Name)"
           Write-Host "  Android: $($androidApk.Name)"
+
+      - name: Debug signing session
+        if: steps.check-signed.outputs.exists == 'false' && github.event.inputs.debug_session == 'true'
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          sudo: false
 
       - name: Validate signing prerequisites
         if: steps.check-signed.outputs.exists == 'false'
@@ -460,3 +471,5 @@ jobs:
           else
             echo "✗ Signing failed or status unknown." >> $GITHUB_STEP_SUMMARY
           fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Enable the \`debug_session\` input to hold the runner for interactive troubleshooting before signing steps begin." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- add a debug_session workflow input to control interactive tmate access
- pause the signing job with an optional debug session guarded for security
- document the debug session behavior in the workflow summary output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee6291d3748326937657a4364bed71