### PR TITLE
Improve APK signing diagnostics

### DIFF
--- a/.github/workflows/sign-artifacts.yml
+++ b/.github/workflows/sign-artifacts.yml
@@ -330,12 +330,24 @@ jobs:
           }
 
           $apkPath = Join-Path (Get-Location) $apkRelative
+          $apkDirectory = Split-Path $apkPath -Parent
+
+          Write-Host "APK relative path: $apkRelative"
+          Write-Host "APK absolute path: $apkPath"
+
           if (-not (Test-Path $apkPath)) {
-            throw "Missing input APK at $apkRelative"
+            Write-Host "✗ APK not found at expected location."
+            if (Test-Path $apkDirectory) {
+              Write-Host "Directory listing for $apkDirectory:"
+              Get-ChildItem -Path $apkDirectory -Recurse
+            } else {
+              Write-Host "APK directory not found: $apkDirectory"
+            }
+
+            throw "Missing input APK at $apkRelative (absolute path: $apkPath)"
           }
 
           $apkFile = Get-Item $apkPath
-          $apkDirectory = Split-Path $apkPath -Parent
 
           Write-Host "Processing Android APK: $($apkFile.Name)"
 


### PR DESCRIPTION
## Summary
- log the resolved APK paths before validating the download
- dump the APK directory tree when the expected file is missing
- include the absolute APK location in the missing-file error message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee77d4ff508326a2de61d47ea62812