### PR TITLE
Remove unsigned Android APK before upload

### DIFF
--- a/.github/workflows/sign-artifacts.yml
+++ b/.github/workflows/sign-artifacts.yml
@@ -402,6 +402,11 @@ jobs:
           & $apksignerPath verify --print-certs $alignedApkPath
           if ($LASTEXITCODE -ne 0) { throw "apksigner verify failed with exit code $LASTEXITCODE" }
 
+          if (Test-Path $apkPath) {
+            Write-Host "Removing unsigned APK at $apkPath"
+            Remove-Item -Path $apkPath -Force
+          }
+
           $signedName = "ShuffleTask-$version.apk"
           Rename-Item -Path $alignedApkPath -NewName $signedName -Force
           $relativeApk = [System.IO.Path]::GetRelativePath((Get-Location).Path, (Join-Path $apkDirectory $signedName))


### PR DESCRIPTION
## Summary
- delete the unsigned APK produced by the build artifacts download before exporting signed packages, ensuring only the signed build is published

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f001cf30748326a4a57837cddd7a17