### PR TITLE
Add profile identity persistence to realtime sync service

### DIFF
--- a/ShuffleTask.Application/Abstractions/IRealtimeSyncService.cs
+++ b/ShuffleTask.Application/Abstractions/IRealtimeSyncService.cs
@@ -7,6 +7,10 @@ public interface IRealtimeSyncService
 {
     string DeviceId { get; }
 
+    string ProfileId { get; }
+
+    string ProfileSecret { get; }
+
     bool IsConnected { get; }
 
     bool ShouldBroadcastLocalChanges { get; }

--- a/ShuffleTask.Application/Abstractions/IStorageService.cs
+++ b/ShuffleTask.Application/Abstractions/IStorageService.cs
@@ -1,4 +1,5 @@
 using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Sync;
 using ShuffleTask.Domain.Entities;
 
 namespace ShuffleTask.Application.Abstractions;
@@ -16,4 +17,5 @@ public interface IStorageService
     Task<TaskItem?> ResumeTaskAsync(string id);
     Task<AppSettings> GetSettingsAsync();
     Task SetSettingsAsync(AppSettings settings);
+    Task<ProfileIdentity> GetProfileIdentityAsync();
 }

--- a/ShuffleTask.Application/Sync/ProfileIdentity.cs
+++ b/ShuffleTask.Application/Sync/ProfileIdentity.cs
@@ -1,0 +1,3 @@
+namespace ShuffleTask.Application.Sync;
+
+public sealed record ProfileIdentity(string ProfileId, string ProfileSecret);

--- a/ShuffleTask.Presentation/PreferenceKeys.cs
+++ b/ShuffleTask.Presentation/PreferenceKeys.cs
@@ -11,6 +11,8 @@ internal static class PreferenceKeys
     public const string ShuffleCount = "pref.shuffleCount";
     public const string CutInLineTaskId = "pref.cutInLineTaskId";
     public const string DeviceId = "pref.sync.deviceId";
+    public const string ProfileId = "pref.sync.profileId";
+    public const string ProfileSecret = "pref.sync.profileSecret";
     public const string TimerMode = "pref.timerMode";
     public const string PomodoroPhase = "pref.pomodoro.phase";
     public const string PomodoroCycle = "pref.pomodoro.cycle";

--- a/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
+++ b/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Sync;
 using ShuffleTask.Domain.Entities;
 
 namespace ShuffleTask.Tests.TestDoubles;
@@ -13,6 +14,7 @@ public class StorageServiceStub : IStorageService
     private readonly TimeProvider _clock;
     private bool _initialized;
     private AppSettings _settings = new();
+    private ProfileIdentity? _profileIdentity;
 
     public int InitializeCallCount { get; private set; }
     public int GetTasksCallCount { get; private set; }
@@ -156,6 +158,13 @@ public class StorageServiceStub : IStorageService
         SetSettingsCallCount++;
         _settings = Clone(settings);
         return Task.CompletedTask;
+    }
+
+    public Task<ProfileIdentity> GetProfileIdentityAsync()
+    {
+        EnsureInitialized();
+        _profileIdentity ??= new ProfileIdentity(Guid.NewGuid().ToString("N"), Guid.NewGuid().ToString("N"));
+        return Task.FromResult(_profileIdentity);
     }
 
     private void AutoResumeDueTasks()


### PR DESCRIPTION
## Summary
- add a ProfileIdentity model and preference keys for sync profile persistence
- persist the profile identity in StorageService and expose it through RealtimeSyncService
- extend RealtimeSyncService tests to cover profile identity generation and reuse

## Testing
- dotnet test ShuffleTask.Presentation.Tests *(fails: unable to reach https://api.nuget.org/v3/index.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68ff44735ea8832690e0f165cde0fe87)