### PR TITLE
Align domain event constructors with base properties

### DIFF
--- a/ShuffleTask.Domain/Events/ShuffleStateChanged.cs
+++ b/ShuffleTask.Domain/Events/ShuffleStateChanged.cs
@@ -10,9 +10,9 @@ public sealed class ShuffleStateChanged : DomainEventBase
     public ShuffleStateChanged(
         ShuffleDeviceContext context,
         ShuffleTimerSnapshot timer,
-        DateTime? occuredAt = null,
+        DateTime? dateTimeOccurredUtc = null,
         Guid? eventId = null)
-        : base(occuredAt ?? default, eventId ?? Guid.Empty)
+        : base(dateTimeOccurredUtc ?? default, eventId ?? Guid.Empty)
     {
         if (string.IsNullOrWhiteSpace(context.DeviceId))
         {

--- a/ShuffleTask.Domain/Events/TaskDeleted.cs
+++ b/ShuffleTask.Domain/Events/TaskDeleted.cs
@@ -6,8 +6,8 @@ namespace ShuffleTask.Domain.Events;
 public sealed class TaskDeleted : DomainEventBase
 {
     [JsonConstructor]
-    public TaskDeleted(string taskId, string deviceId, DateTime deletedAt, DateTime? occuredAt = null, Guid? eventId = null)
-        : base(occuredAt ?? default, eventId ?? Guid.Empty)
+    public TaskDeleted(string taskId, string deviceId, DateTime deletedAt, DateTime? dateTimeOccurredUtc = null, Guid? eventId = null)
+        : base(dateTimeOccurredUtc ?? default, eventId ?? Guid.Empty)
     {
         if (string.IsNullOrWhiteSpace(taskId))
         {

--- a/ShuffleTask.Domain/Events/TaskShuffled.cs
+++ b/ShuffleTask.Domain/Events/TaskShuffled.cs
@@ -5,7 +5,8 @@ public class TaskShuffled : DomainEventBase
 {
     public Guid TaskId { get; }
 
-    public TaskShuffled(Guid taskId, DateTime occuredAt = default, Guid eventId = default) : base(occuredAt, eventId)
+    public TaskShuffled(Guid taskId, DateTime dateTimeOccurredUtc = default, Guid eventId = default)
+        : base(dateTimeOccurredUtc, eventId)
     {
         TaskId = taskId;
     }

--- a/ShuffleTask.Domain/Events/TaskUpserted.cs
+++ b/ShuffleTask.Domain/Events/TaskUpserted.cs
@@ -7,8 +7,8 @@ namespace ShuffleTask.Domain.Events;
 public sealed class TaskUpserted : DomainEventBase
 {
     [JsonConstructor]
-    public TaskUpserted(TaskItem task, string deviceId, DateTime updatedAt, DateTime? occuredAt = null, Guid? eventId = null)
-        : base(occuredAt ?? default, eventId ?? Guid.Empty)
+    public TaskUpserted(TaskItem task, string deviceId, DateTime updatedAt, DateTime? dateTimeOccurredUtc = null, Guid? eventId = null)
+        : base(dateTimeOccurredUtc ?? default, eventId ?? Guid.Empty)
     {
         Task = task ?? throw new ArgumentNullException(nameof(task));
         DeviceId = deviceId ?? throw new ArgumentNullException(nameof(deviceId));


### PR DESCRIPTION
## Summary
- rename domain event constructor parameters to match base property names for proper JSON deserialization across domain events

## Testing
- dotnet test ShuffleTask.sln *(fails: NuGet restore blocked by proxy 403 when reaching api.nuget.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295894c83483268eb6856712468dea)