### PR TITLE
Isolate sync harness preferences

### DIFF
--- a/ShuffleTask.Presentation.Tests/PlatformStubs.cs
+++ b/ShuffleTask.Presentation.Tests/PlatformStubs.cs
@@ -41,11 +41,19 @@ namespace Microsoft.Maui.Storage
 
     public static class Preferences
     {
-        private static readonly InMemoryPreferences DefaultInstance = new();
+        private static readonly ConcurrentDictionary<string, InMemoryPreferences> Instances = new();
 
-        public static IPreferences Default => DefaultInstance;
+        private static string CurrentScope => FileSystem.AppDataDirectory;
 
-        public static void Reset() => DefaultInstance.Clear();
+        public static IPreferences Default => Instances.GetOrAdd(CurrentScope, _ => new InMemoryPreferences());
+
+        public static void Reset()
+        {
+            if (Instances.TryGetValue(CurrentScope, out InMemoryPreferences? preferences))
+            {
+                preferences.Clear();
+            }
+        }
     }
 
     public static class FileSystem

--- a/ShuffleTask.Presentation.Tests/RealtimeSyncIntegrationTests.cs
+++ b/ShuffleTask.Presentation.Tests/RealtimeSyncIntegrationTests.cs
@@ -242,15 +242,25 @@ public sealed class RealtimeSyncIntegrationTests
             var optionsLeft = leftOptions ?? new SyncOptions { Enabled = false };
             var optionsRight = rightOptions ?? new SyncOptions { Enabled = false };
 
-            Microsoft.Maui.Storage.Preferences.Default.Set(PreferenceKeys.DeviceId, "device-left");
+            string leftAppData = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"sync-left-{Guid.NewGuid():N}");
+            Microsoft.Maui.Storage.FileSystem.SetAppDataDirectory(leftAppData);
+
+            string leftDeviceId = $"device-left-{Guid.NewGuid():N}";
+            Microsoft.Maui.Storage.Preferences.Default.Set(PreferenceKeys.DeviceId, leftDeviceId);
             var left = new RealtimeSyncService(clockLeft, () => leftStorage, notificationsLeft, optionsLeft);
             await left.InitializeAsync(connectPeers: false);
             TestContext.Progress.WriteLine($"Left listener started: {left.IsListening}");
 
-            Microsoft.Maui.Storage.Preferences.Default.Set(PreferenceKeys.DeviceId, "device-right");
+            string rightAppData = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"sync-right-{Guid.NewGuid():N}");
+            Microsoft.Maui.Storage.FileSystem.SetAppDataDirectory(rightAppData);
+
+            string rightDeviceId = $"device-right-{Guid.NewGuid():N}";
+            Microsoft.Maui.Storage.Preferences.Default.Set(PreferenceKeys.DeviceId, rightDeviceId);
             var right = new RealtimeSyncService(clockRight, () => rightStorage, notificationsRight, optionsRight);
             await right.InitializeAsync(connectPeers: false);
             TestContext.Progress.WriteLine($"Right listener started: {right.IsListening}");
+
+            Assert.That(left.DeviceId, Is.Not.EqualTo(right.DeviceId), "RealtimeSyncService DeviceIds should be unique.");
 
             bool hasTcpPeers = optionsLeft.Enabled && optionsRight.Enabled && (optionsLeft.Peers.Count > 0 || optionsRight.Peers.Count > 0);
             if (hasTcpPeers)


### PR DESCRIPTION
## Summary
- scope the test Preferences stub to create isolated instances per app-data directory
- create RealtimeSyncService instances with unique app-data folders and device identifiers and assert they differ

## Testing
- dotnet test ShuffleTask.Presentation.Tests/ShuffleTask.Presentation.Tests.csproj *(fails: nuget restore blocked by proxy 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693207e0422c8326b4fea3a92ad7cf56)