### PR TITLE
Handle already-received events in realtime sync tests

### DIFF
--- a/ShuffleTask.Presentation.Tests/RealtimeSyncIntegrationTests.cs
+++ b/ShuffleTask.Presentation.Tests/RealtimeSyncIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
@@ -314,7 +315,13 @@ public sealed class RealtimeSyncIntegrationTests
 
     private static async Task AwaitInboundEventAsync(TransportTraceLog traceLog, TimeSpan timeout, string? expectedEventType)
     {
-        TransportEventTrace? inbound = await traceLog.WaitForReceiveAsync(timeout).ConfigureAwait(false);
+        TransportEventTrace? inbound = FindMatchingInbound(traceLog, expectedEventType);
+
+        if (inbound == null)
+        {
+            inbound = await traceLog.WaitForReceiveAsync(timeout).ConfigureAwait(false);
+        }
+
         if (inbound == null)
         {
             Assert.Fail($"No inbound events observed within {timeout.TotalSeconds:0} seconds.");
@@ -323,6 +330,13 @@ public sealed class RealtimeSyncIntegrationTests
         if (!string.IsNullOrWhiteSpace(expectedEventType))
         {
             Assert.That(inbound!.EventType, Is.EqualTo(expectedEventType), "Unexpected inbound event type.");
+        }
+
+        static TransportEventTrace? FindMatchingInbound(TransportTraceLog log, string? expectedType)
+        {
+            return string.IsNullOrWhiteSpace(expectedType)
+                ? log.ReceivedEvents.LastOrDefault()
+                : log.ReceivedEvents.LastOrDefault(e => string.Equals(e.EventType, expectedType, StringComparison.Ordinal));
         }
     }
 


### PR DESCRIPTION
## Summary
- Update realtime sync integration test helper to return immediately when the expected inbound event is already logged
- Keep existing wait path for new events to reduce flakiness without changing test flow

## Testing
- `dotnet test ShuffleTask.sln --filter PendingEvents_FlushAfterReconnect` *(fails: unable to reach https://api.nuget.org/v3/index.json in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932bbd81b2c8326bbf59996016b1cb4)