### PR TITLE
Add task UpdatedAt metadata and simplify sync versioning

### DIFF
--- a/ShuffleTask.Domain/TaskItemData.cs
+++ b/ShuffleTask.Domain/TaskItemData.cs
@@ -34,6 +34,8 @@ public abstract class TaskItemData
 
     public DateTime CreatedAt { get; set; }
 
+    public DateTime UpdatedAt { get; set; }
+
     public TaskLifecycleStatus Status { get; set; } = TaskLifecycleStatus.Active;
 
     public DateTime? SnoozedUntil { get; set; }
@@ -54,11 +56,6 @@ public abstract class TaskItemData
     public int? CustomPomodoroCycles { get; set; }
 
     public CutInLineMode CutInLineMode { get; set; }
-
-    /// <summary>
-    /// Tracks when individual fields were last updated to support conflict resolution during sync.
-    /// </summary>
-    public Dictionary<string, DateTime> FieldUpdatedAt { get; set; } = new();
 
     /// <summary>
     /// Monotonic event version used for idempotency when applying remote updates.
@@ -96,7 +93,7 @@ public abstract class TaskItemData
         CustomPomodoroCycles = source.CustomPomodoroCycles;
         CutInLineMode = source.CutInLineMode;
 
-        FieldUpdatedAt = new Dictionary<string, DateTime>(source.FieldUpdatedAt);
+        UpdatedAt = source.UpdatedAt;
         EventVersion = source.EventVersion;
     }
 }

--- a/ShuffleTask.Persistence/Models/TaskItemRecord.cs
+++ b/ShuffleTask.Persistence/Models/TaskItemRecord.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using SQLite;
 using ShuffleTask.Domain.Entities;
 
@@ -12,22 +11,6 @@ internal sealed class TaskItemRecord : TaskItemData
     {
         get => base.Id;
         set => base.Id = value;
-    }
-
-    [Ignore]
-    public new Dictionary<string, DateTime> FieldUpdatedAt
-    {
-        get => base.FieldUpdatedAt;
-        set => base.FieldUpdatedAt = value;
-    }
-
-    [Column("FieldUpdatedAt")]
-    public string FieldUpdatedAtJson
-    {
-        get => JsonConvert.SerializeObject(base.FieldUpdatedAt);
-        set => base.FieldUpdatedAt = string.IsNullOrWhiteSpace(value)
-            ? new Dictionary<string, DateTime>()
-            : JsonConvert.DeserializeObject<Dictionary<string, DateTime>>(value) ?? new Dictionary<string, DateTime>();
     }
 
     [Indexed]
@@ -55,6 +38,11 @@ internal sealed class TaskItemRecord : TaskItemData
         if (AllowedPeriod == AllowedPeriod.Custom && CustomStartTime is null && CustomEndTime is null)
         {
             AllowedPeriod = AllowedPeriod.OffWork;
+        }
+
+        if (UpdatedAt == default)
+        {
+            UpdatedAt = CreatedAt;
         }
 
         return TaskItem.FromData(this);

--- a/ShuffleTask.Tests/TestDoubles/StorageServiceStubTests.cs
+++ b/ShuffleTask.Tests/TestDoubles/StorageServiceStubTests.cs
@@ -60,6 +60,8 @@ public class StorageServiceStubTests
         Assert.That(retrieved!.Id, Is.EqualTo(task.Id));
         Assert.That(retrieved.Title, Is.EqualTo(task.Title));
         Assert.That(retrieved.Importance, Is.EqualTo(task.Importance));
+        Assert.That(retrieved.EventVersion, Is.GreaterThanOrEqualTo(1));
+        Assert.That(retrieved.UpdatedAt, Is.Not.EqualTo(default(DateTime)));
     }
 
     [Test]
@@ -77,6 +79,10 @@ public class StorageServiceStubTests
 
         await stub.AddTaskAsync(task);
 
+        var original = await stub.GetTaskAsync("update-test");
+        var originalVersion = original!.EventVersion;
+        var originalUpdatedAt = original.UpdatedAt;
+
         task.Title = "Updated";
         task.Importance = 4;
         await stub.UpdateTaskAsync(task);
@@ -84,6 +90,8 @@ public class StorageServiceStubTests
         var retrieved = await stub.GetTaskAsync("update-test");
         Assert.That(retrieved!.Title, Is.EqualTo("Updated"));
         Assert.That(retrieved.Importance, Is.EqualTo(4));
+        Assert.That(retrieved.EventVersion, Is.GreaterThan(originalVersion));
+        Assert.That(retrieved.UpdatedAt, Is.GreaterThan(originalUpdatedAt));
         Assert.That(stub.UpdateTaskCallCount, Is.EqualTo(1));
     }
 
@@ -119,12 +127,15 @@ public class StorageServiceStubTests
         };
 
         await stub.AddTaskAsync(task);
+        var before = await stub.GetTaskAsync("complete-me");
         var completed = await stub.MarkTaskDoneAsync("complete-me");
 
         Assert.That(completed, Is.Not.Null);
         Assert.That(completed!.Status, Is.EqualTo(TaskLifecycleStatus.Completed));
         Assert.That(completed.CompletedAt, Is.Not.Null);
         Assert.That(completed.LastDoneAt, Is.Not.Null);
+        Assert.That(completed.UpdatedAt, Is.EqualTo(completed.CompletedAt));
+        Assert.That(completed.EventVersion, Is.GreaterThan(before!.EventVersion));
         Assert.That(stub.MarkDoneCallCount, Is.EqualTo(1));
     }
 
@@ -143,12 +154,15 @@ public class StorageServiceStubTests
         };
 
         await stub.AddTaskAsync(task);
+        var before = await stub.GetTaskAsync("snooze-me");
         var snoozed = await stub.SnoozeTaskAsync("snooze-me", TimeSpan.FromMinutes(30));
 
         Assert.That(snoozed, Is.Not.Null);
         Assert.That(snoozed!.Status, Is.EqualTo(TaskLifecycleStatus.Snoozed));
         Assert.That(snoozed.SnoozedUntil, Is.Not.Null);
         Assert.That(snoozed.NextEligibleAt, Is.Not.Null);
+        Assert.That(snoozed.UpdatedAt, Is.GreaterThan(before!.UpdatedAt));
+        Assert.That(snoozed.EventVersion, Is.GreaterThan(before.EventVersion));
         Assert.That(stub.SnoozeCallCount, Is.EqualTo(1));
     }
 
@@ -169,12 +183,15 @@ public class StorageServiceStubTests
         };
 
         await stub.AddTaskAsync(task);
+        var before = await stub.GetTaskAsync("resume-me");
         var resumed = await stub.ResumeTaskAsync("resume-me");
 
         Assert.That(resumed, Is.Not.Null);
         Assert.That(resumed!.Status, Is.EqualTo(TaskLifecycleStatus.Active));
         Assert.That(resumed.SnoozedUntil, Is.Null);
         Assert.That(resumed.NextEligibleAt, Is.Null);
+        Assert.That(resumed.UpdatedAt, Is.GreaterThan(before!.UpdatedAt));
+        Assert.That(resumed.EventVersion, Is.GreaterThan(before.EventVersion));
         Assert.That(stub.ResumeCallCount, Is.EqualTo(1));
     }
 
@@ -195,6 +212,7 @@ public class StorageServiceStubTests
         };
 
         await stub.AddTaskAsync(snoozedTask);
+        var before = await stub.GetTaskAsync("auto-resume");
 
         // Advance time past the snooze period
         clock.AdvanceTime(TimeSpan.FromMinutes(10));
@@ -203,6 +221,8 @@ public class StorageServiceStubTests
 
         Assert.That(tasks.Count, Is.EqualTo(1));
         Assert.That(tasks[0].Status, Is.EqualTo(TaskLifecycleStatus.Active));
+        Assert.That(tasks[0].UpdatedAt, Is.GreaterThan(before!.UpdatedAt));
+        Assert.That(tasks[0].EventVersion, Is.GreaterThan(before.EventVersion));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- replace per-field timestamps with a task-level UpdatedAt and keep monotonic EventVersion handling across storage paths
- update persistence schema/mappings and sync handling to use the new metadata shape
- refresh storage service stubs and tests to assert UpdatedAt/EventVersion behavior

## Testing
- dotnet test *(fails: package Yaref92.Events is unavailable in the restore sources)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936dee2abe4832696ef9ac932f3263d)