### PR TITLE
Add session ownership and anonymous login controls

### DIFF
--- a/ShuffleTask.Application/Abstractions/IStorageService.cs
+++ b/ShuffleTask.Application/Abstractions/IStorageService.cs
@@ -16,4 +16,5 @@ public interface IStorageService
     Task<TaskItem?> ResumeTaskAsync(string id);
     Task<AppSettings> GetSettingsAsync();
     Task SetSettingsAsync(AppSettings settings);
+    Task<int> MigrateDeviceTasksToUserAsync(string deviceId, string userId);
 }

--- a/ShuffleTask.Application/Models/NetworkOptions.cs
+++ b/ShuffleTask.Application/Models/NetworkOptions.cs
@@ -21,7 +21,10 @@ public partial class NetworkOptions : ObservableObject
     private string deviceId = Environment.MachineName;
 
     [ObservableProperty]
-    private string? userId = Environment.UserName;
+    private string? userId;
+
+    [ObservableProperty]
+    private bool anonymousSession = true;
 
     [ObservableProperty]
     private string peerHost = LocalHostString;
@@ -56,7 +59,8 @@ public partial class NetworkOptions : ObservableObject
     {
         ResolveLocalHost();
         DeviceId = string.IsNullOrWhiteSpace(DeviceId) ? Environment.MachineName : DeviceId.Trim();
-        UserId = string.IsNullOrWhiteSpace(UserId) ? null : UserId.Trim();
+        AnonymousSession = AnonymousSession || string.IsNullOrWhiteSpace(UserId);
+        UserId = AnonymousSession ? null : string.IsNullOrWhiteSpace(UserId) ? null : UserId.Trim();
         PeerHost = string.IsNullOrWhiteSpace(PeerHost) ? LocalHostString : PeerHost.Trim();
         ListeningPort = NormalizePort(ListeningPort, DeviceId);
     }

--- a/ShuffleTask.Application/Services/TaskUpsertedAsyncHandler.cs
+++ b/ShuffleTask.Application/Services/TaskUpsertedAsyncHandler.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Events;
 using ShuffleTask.Domain.Entities;
+using System;
 using Yaref92.Events.Abstractions;
 
 namespace ShuffleTask.Application.Services;
@@ -89,6 +90,18 @@ internal class TaskUpsertedAsyncHandler : IAsyncEventHandler<TaskUpsertedEvent>
         if (normalized.EventVersion <= 0)
         {
             normalized.EventVersion = (existing?.EventVersion ?? 0) + 1;
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalized.UserId))
+        {
+            normalized.DeviceId = null;
+        }
+        else
+        {
+            normalized.UserId = existing?.UserId;
+            normalized.DeviceId = string.IsNullOrWhiteSpace(normalized.DeviceId)
+                ? existing?.DeviceId ?? Environment.MachineName
+                : normalized.DeviceId.Trim();
         }
         return normalized;
     }

--- a/ShuffleTask.Domain/TaskItemData.cs
+++ b/ShuffleTask.Domain/TaskItemData.cs
@@ -4,6 +4,10 @@ public abstract class TaskItemData
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("n");
 
+    public string? DeviceId { get; set; }
+
+    public string? UserId { get; set; }
+
     public string Title { get; set; } = string.Empty;
 
     public string Description { get; set; } = string.Empty;
@@ -67,6 +71,8 @@ public abstract class TaskItemData
         ArgumentNullException.ThrowIfNull(source);
 
         Id = source.Id;
+        DeviceId = source.DeviceId;
+        UserId = source.UserId;
         Title = source.Title;
         Description = source.Description;
         Importance = source.Importance;

--- a/ShuffleTask.Persistence/Models/TaskItemRecord.cs
+++ b/ShuffleTask.Persistence/Models/TaskItemRecord.cs
@@ -14,6 +14,20 @@ internal sealed class TaskItemRecord : TaskItemData
     }
 
     [Indexed]
+    public new string? DeviceId
+    {
+        get => base.DeviceId;
+        set => base.DeviceId = value;
+    }
+
+    [Indexed]
+    public new string? UserId
+    {
+        get => base.UserId;
+        set => base.UserId = value;
+    }
+
+    [Indexed]
     public new string Title
     {
         get => base.Title;

--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -331,49 +331,69 @@
                    Text="{Binding Settings.Network.DeviceId}" />
 
             <Label Grid.Row="26"
-                   Text="User id"
+                   Text="Anonymous session"
                    VerticalOptions="Center" />
-            <Entry Grid.Row="26"
-                   Grid.Column="1"
-                   Text="{Binding Settings.Network.UserId}" />
+            <Switch Grid.Row="26"
+                    Grid.Column="1"
+                    IsToggled="{Binding IsAnonymousSession}" />
 
             <Label Grid.Row="27"
-                   Text="Peer host"
-                   VerticalOptions="Center" />
+                   Text="User id"
+                   VerticalOptions="Center"
+                   IsEnabled="{Binding CanSyncAcrossDevices}" />
             <Entry Grid.Row="27"
                    Grid.Column="1"
-                   Text="{Binding Settings.Network.PeerHost}" />
+                   Text="{Binding Settings.Network.UserId}"
+                   IsEnabled="{Binding CanSyncAcrossDevices}" />
 
             <Label Grid.Row="28"
-                   Text="Peer port"
-                   VerticalOptions="Center" />
+                   Text="Peer host"
+                   VerticalOptions="Center"
+                   IsEnabled="{Binding CanSyncAcrossDevices}" />
             <Entry Grid.Row="28"
                    Grid.Column="1"
-                   Keyboard="Numeric"
-                   Text="{Binding Settings.Network.PeerPort}" />
+                   Text="{Binding Settings.Network.PeerHost}"
+                   IsEnabled="{Binding CanSyncAcrossDevices}" />
 
             <Label Grid.Row="29"
-                   Text="Auth token"
-                   VerticalOptions="Center" />
-            <Label Grid.Row="29"
+                   Text="Peer port"
+                   VerticalOptions="Center"
+                   IsEnabled="{Binding CanSyncAcrossDevices}" />
+            <Entry Grid.Row="29"
                    Grid.Column="1"
-                   LineBreakMode="CharacterWrap"
-                   Text="{Binding AuthTokenPreview}" />
+                   Keyboard="Numeric"
+                   Text="{Binding Settings.Network.PeerPort}"
+                   IsEnabled="{Binding CanSyncAcrossDevices}" />
 
-            <Grid Grid.Row="30"
-                  Grid.ColumnSpan="2"
-                  ColumnDefinitions="*,*"
-                  ColumnSpacing="16">
+            <Button Grid.Row="30"
+                    Grid.ColumnSpan="2"
+                    Text="Logout"
+                    Command="{Binding LogoutCommand}"
+                    IsEnabled="{Binding IsLoggedIn}" />
+
+            <Label Grid.Row="31"
+                    Text="Auth token"
+                    VerticalOptions="Center" />
+            <Label Grid.Row="31"
+                    Grid.Column="1"
+                    LineBreakMode="CharacterWrap"
+                    Text="{Binding AuthTokenPreview}" />
+
+            <Grid Grid.Row="32"
+                   Grid.ColumnSpan="2"
+                   ColumnDefinitions="*,*"
+                   ColumnSpacing="16">
                 <Button Grid.Column="0"
                         Text="Connect to peer"
-                        Command="{Binding ConnectPeerCommand}" />
+                        Command="{Binding ConnectPeerCommand}"
+                        IsEnabled="{Binding CanSyncAcrossDevices}" />
                 <Label Grid.Column="1"
                        Text="{Binding LocalConnectionSummary}"
                        HorizontalTextAlignment="End"
                        VerticalOptions="Center" />
             </Grid>
 
-            <Grid Grid.Row="31"
+            <Grid Grid.Row="33"
                   Grid.ColumnSpan="2"
                   ColumnDefinitions="*,*"
                   ColumnSpacing="16">
@@ -385,7 +405,7 @@
                         Command="{Binding ShufflePreviewCommand}" />
             </Grid>
 
-            <ActivityIndicator Grid.Row="32"
+            <ActivityIndicator Grid.Row="34"
                                Grid.ColumnSpan="2"
                                HorizontalOptions="Center"
                                IsVisible="{Binding IsBusy}"


### PR DESCRIPTION
## Summary
- attach tasks to user or device metadata and add a migration path from device-owned to user-owned tasks
- add anonymous session controls, logout button, and prompt to sync device tasks when signing in
- gate network sync traffic when anonymous and update ownership handling in task sync

## Testing
- dotnet test *(fails: Unable to find package Yaref92.Events during restore)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693822307c34832681622e8179ee0f74)