### PR TITLE
Make anonymous session switch read-only derived state

### DIFF
--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -335,7 +335,8 @@
                    VerticalOptions="Center" />
             <Switch Grid.Row="26"
                     Grid.Column="1"
-                    IsToggled="{Binding IsAnonymousSession}" />
+                    IsToggled="{Binding IsAnonymousSession}"
+                    IsEnabled="False" />
 
             <Label Grid.Row="27"
                    Text="User id"


### PR DESCRIPTION
## Summary
- derive the anonymous session indicator from network options and user ID state
- subscribe to network option changes so derived login and sync properties stay updated
- disable the anonymous session switch in settings so it reflects state without allowing edits

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69383351e40483268a35645ec053bb86)