### PR TITLE
Add login command to settings view model

### DIFF
--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -340,12 +340,15 @@
 
             <Label Grid.Row="27"
                    Text="User id"
-                   VerticalOptions="Center"
-                   IsEnabled="{Binding CanSyncAcrossDevices}" />
-            <Entry Grid.Row="27"
-                   Grid.Column="1"
-                   Text="{Binding Settings.Network.UserId}"
-                   IsEnabled="{Binding CanSyncAcrossDevices}" />
+                   VerticalOptions="Center" />
+            <Grid Grid.Row="27" Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <Entry Grid.Column="0"
+                       Text="{Binding Settings.Network.UserId}"
+                       IsReadOnly="True" />
+                <Button Grid.Column="1"
+                        Text="Login"
+                        Command="{Binding LoginCommand}" />
+            </Grid>
 
             <Label Grid.Row="28"
                    Text="Peer host"


### PR DESCRIPTION
## Summary
- add a login command that trims usernames, caps length, stores the user, and refreshes settings with migration prompt
- prompt for username when none is provided and switch from anonymous to logged-in sessions on success
- update the settings page to show the user id read-only with a Login button

## Testing
- dotnet test ShuffleTask.sln -c Release *(fails: missing Yaref92.Events package in available feeds)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693932f5e12083268da72bc9bdb1c9bd)