### PR TITLE
Refresh sync availability after login

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -194,6 +194,7 @@ public partial class SettingsViewModel : ObservableObject
             Settings.Network.AnonymousSession = false;
             ApplyValidation();
             await _storage.SetSettingsAsync(Settings);
+            OnNetworkChanged(this, new PropertyChangedEventArgs(nameof(Settings.Network.UserId)));
             await _coordinator.RefreshAsync();
 
             if (wasAnonymous && !IsAnonymousSession && !string.IsNullOrWhiteSpace(Settings.Network.UserId))


### PR DESCRIPTION
## Summary
- ensure settings are persisted and anonymous mode is cleared immediately after login
- trigger network change notification so CanSyncAcrossDevices updates as soon as login succeeds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693949f7eab88326ad075ea5234b4499)