### PR TITLE
Add session-aware task loading

### DIFF
--- a/ShuffleTask.Application/Abstractions/IStorageService.cs
+++ b/ShuffleTask.Application/Abstractions/IStorageService.cs
@@ -6,7 +6,7 @@ namespace ShuffleTask.Application.Abstractions;
 public interface IStorageService
 {
     Task InitializeAsync();
-    Task<List<TaskItem>> GetTasksAsync();
+    Task<List<TaskItem>> GetTasksAsync(string? userId = "", string deviceId = "");
     Task<TaskItem?> GetTaskAsync(string id);
     Task AddTaskAsync(TaskItem item);
     Task UpdateTaskAsync(TaskItem item);

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -136,13 +136,24 @@ public class StorageService : IStorageService
     }
 
     // Tasks CRUD
-    public async Task<List<TaskItem>> GetTasksAsync()
+    public async Task<List<TaskItem>> GetTasksAsync(string? userId = "", string deviceId = "")
     {
         await AutoResumeDueTasksAsync();
 
-        var records = await Db.Table<TaskItemRecord>()
-                              .OrderByDescending(t => t.CreatedAt)
-                              .ToListAsync();
+        var query = Db.Table<TaskItemRecord>().AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            query = query.Where(t => t.UserId == userId);
+        }
+        else if (!string.IsNullOrWhiteSpace(deviceId))
+        {
+            query = query.Where(t => (t.UserId == null || t.UserId == "") && t.DeviceId == deviceId);
+        }
+
+        var records = await query
+            .OrderByDescending(t => t.CreatedAt)
+            .ToListAsync();
         return records.Select(r => r.ToDomain()).ToList();
     }
 

--- a/ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs
+++ b/ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs
@@ -252,7 +252,8 @@ public class ShuffleCoordinatorService : IDisposable
 
     private async Task ScheduleFromAvailableTasksAsync(AppSettings settings, DateTimeOffset now)
     {
-        var tasks = await _storage.GetTasksAsync().ConfigureAwait(false);
+        var network = settings.Network;
+        var tasks = await _storage.GetTasksAsync(network?.UserId, network?.DeviceId ?? string.Empty).ConfigureAwait(false);
         if (tasks.Count == 0)
         {
             ClearPendingShuffle();
@@ -551,7 +552,8 @@ public class ShuffleCoordinatorService : IDisposable
             return task;
         }
 
-        var tasks = await _storage.GetTasksAsync().ConfigureAwait(false);
+        var network = settings.Network;
+        var tasks = await _storage.GetTasksAsync(network?.UserId, network?.DeviceId ?? string.Empty).ConfigureAwait(false);
         TaskItem? candidate = _scheduler.PickNextTask(tasks, settings, now);
         if (candidate != null)
         {

--- a/ShuffleTask.Presentation/ViewModels/DashboardViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/DashboardViewModel.cs
@@ -151,7 +151,8 @@ public partial class DashboardViewModel : ObservableObject
                 return;
             }
 
-            var tasks = await _storage.GetTasksAsync();
+            var network = _settings.Network;
+            var tasks = await _storage.GetTasksAsync(network?.UserId, network?.DeviceId ?? string.Empty);
             DateTimeOffset now = _clock.GetUtcNow();
             string? previousId = _activeTask?.Id;
 

--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -127,7 +127,8 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             await _storage.InitializeAsync();
-            var items = await _storage.GetTasksAsync();
+            var network = Settings.Network;
+            var items = await _storage.GetTasksAsync(network?.UserId, network?.DeviceId ?? string.Empty);
             DateTimeOffset now = _clock.GetUtcNow();
             var next = _scheduler.PickNextTask(items, Settings, now);
             if (next != null && Settings.EnableNotifications)

--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -40,7 +40,9 @@ public partial class TasksViewModel : ObservableObject
         try
         {
             await _storage.InitializeAsync();
-            List<TaskItem> items = await _storage.GetTasksAsync();
+            List<TaskItem> items = await _storage.GetTasksAsync(
+                _settings.Network?.UserId,
+                _settings.Network?.DeviceId ?? string.Empty);
             AppSettings settings = _settings;
             DateTimeOffset now = _clock.GetUtcNow();
 

--- a/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
+++ b/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
@@ -37,12 +37,23 @@ public class StorageServiceStub : IStorageService
         return Task.CompletedTask;
     }
 
-    public Task<List<TaskItem>> GetTasksAsync()
+    public Task<List<TaskItem>> GetTasksAsync(string? userId = "", string deviceId = "")
     {
         EnsureInitialized();
         AutoResumeDueTasks();
         GetTasksCallCount++;
-        var snapshot = _tasks.Values
+        var query = _tasks.Values.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            query = query.Where(t => t.UserId == userId);
+        }
+        else if (!string.IsNullOrWhiteSpace(deviceId))
+        {
+            query = query.Where(t => (t.UserId == null || t.UserId == "") && t.DeviceId == deviceId);
+        }
+
+        var snapshot = query
             .OrderByDescending(t => t.CreatedAt)
             .Select(Clone)
             .ToList();


### PR DESCRIPTION
## Summary
- make task retrieval filterable by user or device context
- pass current network context when loading tasks across UI and coordinator flows

## Testing
- dotnet test *(fails: missing Yaref92.Events package in restore)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69395195abb0832696b0cea0acd027a0)