### PR TITLE
Add login flow UI updates for network user

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -252,6 +252,10 @@ public partial class SettingsViewModel : ObservableObject
 
     public bool IsLoggedIn => !IsAnonymousSession;
 
+    public string UserDisplayLabel => string.IsNullOrWhiteSpace(Settings?.Network?.UserId)
+        ? "Not logged in"
+        : Settings.Network.UserId;
+
     private void ApplyValidation()
     {
         Settings.ReminderMinutes = Math.Clamp(Settings.ReminderMinutes, 1, 480);
@@ -286,6 +290,7 @@ public partial class SettingsViewModel : ObservableObject
         OnPropertyChanged(nameof(IsAnonymousSession));
         OnPropertyChanged(nameof(CanSyncAcrossDevices));
         OnPropertyChanged(nameof(IsLoggedIn));
+        OnPropertyChanged(nameof(UserDisplayLabel));
     }
 
     private void UpdateNetworkSubscription(NetworkOptions? oldNetwork, NetworkOptions? newNetwork)

--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -342,9 +342,8 @@
                    Text="User id"
                    VerticalOptions="Center" />
             <Grid Grid.Row="27" Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <Entry Grid.Column="0"
-                       Text="{Binding Settings.Network.UserId}"
-                       IsReadOnly="True" />
+                <Label Grid.Column="0"
+                       Text="{Binding UserDisplayLabel}" />
                 <Button Grid.Column="1"
                         Text="Login"
                         Command="{Binding LoginCommand}" />


### PR DESCRIPTION
## Summary
- add a display-only user label alongside the login action in settings
- expose a user display label from the view model and notify on network changes
- keep anonymous session indicator read-only while keeping login flow to set authenticated state

## Testing
- dotnet test ShuffleTask.sln *(fails: missing package Yaref92.Events in feed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69395be57ba483269872da31bdf07048)