### PR TITLE
Refresh task scope after session changes

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -369,18 +369,29 @@ public partial class SettingsViewModel : ObservableObject
             }
         }
 
+        var (userScope, deviceScope) = ResolveTaskScopes();
+
         await _coordinator.RefreshAsync();
-        await RefreshBoundCollectionsAsync();
+        await RefreshBoundCollectionsAsync(userScope, deviceScope);
     }
 
-    private Task RefreshBoundCollectionsAsync()
+    private (string? UserId, string DeviceId) ResolveTaskScopes()
+    {
+        bool anonymous = IsAnonymousSession;
+        string? userScope = anonymous ? null : Settings.Network?.UserId;
+        string deviceScope = anonymous ? Settings.Network?.DeviceId ?? string.Empty : string.Empty;
+
+        return (userScope, deviceScope);
+    }
+
+    private Task RefreshBoundCollectionsAsync(string? userScope, string? deviceScope)
     {
         if (_tasksViewModel is null)
         {
             return Task.CompletedTask;
         }
 
-        return MainThread.InvokeOnMainThreadAsync(_tasksViewModel.LoadAsync);
+        return MainThread.InvokeOnMainThreadAsync(() => _tasksViewModel.LoadAsync(userScope, deviceScope));
     }
 
 }

--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -29,7 +29,7 @@ public partial class TasksViewModel : ObservableObject
     [ObservableProperty]
     private bool isBusy;
 
-    public async Task LoadAsync()
+    public async Task LoadAsync(string? userId = null, string? deviceId = null)
     {
         if (IsBusy)
         {
@@ -41,8 +41,8 @@ public partial class TasksViewModel : ObservableObject
         {
             await _storage.InitializeAsync();
             List<TaskItem> items = await _storage.GetTasksAsync(
-                _settings.Network?.UserId,
-                _settings.Network?.DeviceId ?? string.Empty);
+                userId ?? _settings.Network?.UserId,
+                deviceId ?? _settings.Network?.DeviceId ?? string.Empty);
             AppSettings settings = _settings;
             DateTimeOffset now = _clock.GetUtcNow();
 


### PR DESCRIPTION
## Summary
- add explicit task scope resolution to refresh UI after login/logout
- allow task list loading with optional user/device overrides so migrations reload with correct ownership

## Testing
- dotnet test *(fails: Yaref92.Events package not available in restore feeds)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693974fa97448326bebf027c74aa5573)