### PR TITLE
Add task manifest messaging scaffolding

### DIFF
--- a/ShuffleTask.Application/Events/TaskBatchResponse.cs
+++ b/ShuffleTask.Application/Events/TaskBatchResponse.cs
@@ -1,0 +1,13 @@
+using ShuffleTask.Domain.Entities;
+using Yaref92.Events;
+
+namespace ShuffleTask.Application.Events;
+
+public class TaskBatchResponse(IEnumerable<TaskItem> tasks, string deviceId, string? userId) : DomainEventBase()
+{
+    public IEnumerable<TaskItem> Tasks { get; set; } = tasks;
+
+    public string DeviceId { get; set; } = deviceId;
+
+    public string? UserId { get; set; } = userId;
+}

--- a/ShuffleTask.Application/Events/TaskManifestAnnounced.cs
+++ b/ShuffleTask.Application/Events/TaskManifestAnnounced.cs
@@ -1,0 +1,13 @@
+using ShuffleTask.Application.Models;
+using Yaref92.Events;
+
+namespace ShuffleTask.Application.Events;
+
+public class TaskManifestAnnounced(IEnumerable<TaskManifestEntry> manifest, string deviceId, string? userId) : DomainEventBase()
+{
+    public IEnumerable<TaskManifestEntry> Manifest { get; set; } = manifest;
+
+    public string DeviceId { get; set; } = deviceId;
+
+    public string? UserId { get; set; } = userId;
+}

--- a/ShuffleTask.Application/Events/TaskManifestRequest.cs
+++ b/ShuffleTask.Application/Events/TaskManifestRequest.cs
@@ -1,0 +1,13 @@
+using ShuffleTask.Application.Models;
+using Yaref92.Events;
+
+namespace ShuffleTask.Application.Events;
+
+public class TaskManifestRequest(IEnumerable<TaskManifestEntry> manifest, string deviceId, string? userId) : DomainEventBase()
+{
+    public IEnumerable<TaskManifestEntry> Manifest { get; set; } = manifest;
+
+    public string DeviceId { get; set; } = deviceId;
+
+    public string? UserId { get; set; } = userId;
+}

--- a/ShuffleTask.Application/Models/TaskManifestEntry.cs
+++ b/ShuffleTask.Application/Models/TaskManifestEntry.cs
@@ -1,0 +1,25 @@
+namespace ShuffleTask.Application.Models;
+
+public class TaskManifestEntry
+{
+    public TaskManifestEntry()
+    {
+    }
+
+    public TaskManifestEntry(string taskId, int eventVersion, DateTime updatedAt)
+    {
+        TaskId = taskId;
+        EventVersion = eventVersion;
+        UpdatedAt = updatedAt;
+    }
+
+    public string TaskId { get; set; } = string.Empty;
+
+    public int EventVersion { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public string? DeviceId { get; set; }
+
+    public string? UserId { get; set; }
+}

--- a/ShuffleTask.Application/Services/ManifestMessagesAsyncHandler.cs
+++ b/ShuffleTask.Application/Services/ManifestMessagesAsyncHandler.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Logging;
+using ShuffleTask.Application.Events;
+using Yaref92.Events.Abstractions;
+
+namespace ShuffleTask.Application.Services;
+
+internal class TaskManifestAnnouncedAsyncHandler(ILogger<NetworkSyncService>? logger) : IAsyncEventHandler<TaskManifestAnnounced>
+{
+    private readonly ILogger<NetworkSyncService>? _logger = logger;
+
+    public Task OnNextAsync(TaskManifestAnnounced domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+        _logger?.LogDebug("Received task manifest announcement from {DeviceId}", domainEvent.DeviceId);
+        return Task.CompletedTask;
+    }
+}
+
+internal class TaskManifestRequestAsyncHandler(ILogger<NetworkSyncService>? logger) : IAsyncEventHandler<TaskManifestRequest>
+{
+    private readonly ILogger<NetworkSyncService>? _logger = logger;
+
+    public Task OnNextAsync(TaskManifestRequest domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+        _logger?.LogDebug("Received task manifest request from {DeviceId}", domainEvent.DeviceId);
+        return Task.CompletedTask;
+    }
+}
+
+internal class TaskBatchResponseAsyncHandler(ILogger<NetworkSyncService>? logger) : IAsyncEventHandler<TaskBatchResponse>
+{
+    private readonly ILogger<NetworkSyncService>? _logger = logger;
+
+    public Task OnNextAsync(TaskBatchResponse domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+        _logger?.LogDebug("Received task batch response from {DeviceId}", domainEvent.DeviceId);
+        return Task.CompletedTask;
+    }
+}

--- a/ShuffleTask.Application/Services/NetworkSyncService.cs
+++ b/ShuffleTask.Application/Services/NetworkSyncService.cs
@@ -223,6 +223,9 @@ public class NetworkSyncService : INetworkSyncService, IDisposable
 
         _aggregator.SubscribeToEventType(new TaskUpsertedAsyncHandler(_logger, _storage));
         _aggregator.SubscribeToEventType(new TaskDeletedAsyncHandler(_logger, _storage));
+        _aggregator.SubscribeToEventType(new TaskManifestAnnouncedAsyncHandler(_logger));
+        _aggregator.SubscribeToEventType(new TaskManifestRequestAsyncHandler(_logger));
+        _aggregator.SubscribeToEventType(new TaskBatchResponseAsyncHandler(_logger));
     }
 
     private void RegisterTrackedEventTypes()
@@ -236,6 +239,9 @@ public class NetworkSyncService : INetworkSyncService, IDisposable
         _aggregator.RegisterEventType<TaskDeletedEvent>();
         _aggregator.RegisterEventType<TaskStarted>();
         _aggregator.RegisterEventType<TimeUpNotificationEvent>();
+        _aggregator.RegisterEventType<TaskManifestAnnounced>();
+        _aggregator.RegisterEventType<TaskManifestRequest>();
+        _aggregator.RegisterEventType<TaskBatchResponse>();
     }
 
     private CancellationTokenSource EnsureConnectionCts()


### PR DESCRIPTION
## Summary
- add compact task manifest DTO and manifest-related event contracts
- register manifest events with the network aggregator and provide logging handlers

## Testing
- dotnet test ShuffleTask.sln *(fails: missing Yaref92.Events package source in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab901b0d48326a71cf823dbbb16cd)