### PR TITLE
Add application sync coordinator tests

### DIFF
--- a/ShuffleTask.Application.Tests/NetworkSyncIntegrationTests.cs
+++ b/ShuffleTask.Application.Tests/NetworkSyncIntegrationTests.cs
@@ -1,0 +1,137 @@
+using NUnit.Framework;
+using ShuffleTask.Application.Events;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Services;
+using ShuffleTask.Application.Tests.TestDoubles;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Application.Tests;
+
+public class NetworkSyncIntegrationTests
+{
+    private const string UserId = "user-a";
+    private const string DeviceA = "device-a";
+    private const string DeviceB = "device-b";
+
+    [Test]
+    public async Task PeersRequestMissingTasksAndIgnoreStaleUpserts()
+    {
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var peerAStorage = new InMemoryStorageService();
+        await peerAStorage.InitializeAsync();
+        await peerAStorage.AddTaskAsync(new TaskItem
+        {
+            Id = "shared",
+            Title = "Shared Latest",
+            UserId = UserId,
+            DeviceId = DeviceA,
+            EventVersion = 5,
+            CreatedAt = baseTime.AddHours(-2),
+            UpdatedAt = baseTime.AddMinutes(10)
+        });
+        await peerAStorage.AddTaskAsync(new TaskItem
+        {
+            Id = "only-a",
+            Title = "Local Only",
+            UserId = UserId,
+            DeviceId = DeviceA,
+            EventVersion = 2,
+            CreatedAt = baseTime,
+            UpdatedAt = baseTime.AddMinutes(1)
+        });
+
+        var peerBStorage = new InMemoryStorageService();
+        await peerBStorage.InitializeAsync();
+        await peerBStorage.AddTaskAsync(new TaskItem
+        {
+            Id = "shared",
+            Title = "Shared Old",
+            UserId = UserId,
+            DeviceId = DeviceB,
+            EventVersion = 3,
+            CreatedAt = baseTime.AddHours(-3),
+            UpdatedAt = baseTime.AddMinutes(5)
+        });
+        await peerBStorage.AddTaskAsync(new TaskItem
+        {
+            Id = "only-b",
+            Title = "Remote Only",
+            UserId = UserId,
+            DeviceId = DeviceB,
+            EventVersion = 1,
+            CreatedAt = baseTime,
+            UpdatedAt = baseTime.AddMinutes(2)
+        });
+
+        var peerACoordinator = new PeerSyncCoordinator(peerAStorage);
+        var peerBCoordinator = new PeerSyncCoordinator(peerBStorage);
+        var peerAHandler = new TaskUpsertedAsyncHandler(logger: null, peerAStorage);
+        var peerBHandler = new TaskUpsertedAsyncHandler(logger: null, peerBStorage);
+
+        var manifestFromB = await BuildManifestAsync(peerBStorage);
+        var manifestFromA = await BuildManifestAsync(peerAStorage);
+
+        var comparisonAtA = await peerACoordinator.CompareManifestAsync(manifestFromB, UserId, DeviceA);
+        var comparisonAtB = await peerBCoordinator.CompareManifestAsync(manifestFromA, UserId, DeviceB);
+
+        // Peer A requests what it is missing/newer on peer B
+        var tasksRequestedByA = comparisonAtA.GetTasksToRequest();
+        await SendTasksAsync(peerBStorage, peerAHandler, tasksRequestedByA);
+
+        // Peer B requests what it is missing/newer on peer A
+        var tasksRequestedByB = comparisonAtB.GetTasksToRequest();
+        await SendTasksAsync(peerAStorage, peerBHandler, tasksRequestedByB);
+
+        // Peer B accidentally re-sends a stale shared task; it should be ignored by peer A
+        var staleShared = new TaskUpsertedEvent(new TaskItem
+        {
+            Id = "shared",
+            Title = "Shared Old",
+            UserId = UserId,
+            DeviceId = DeviceB,
+            EventVersion = 2,
+            CreatedAt = baseTime.AddHours(-3),
+            UpdatedAt = baseTime.AddMinutes(4)
+        }, deviceId: DeviceB, userId: UserId);
+        await peerAHandler.OnNextAsync(staleShared);
+
+        var finalSharedA = await peerAStorage.GetTaskAsync("shared");
+        var finalSharedB = await peerBStorage.GetTaskAsync("shared");
+        var finalOnlyAOnB = await peerBStorage.GetTaskAsync("only-a");
+        var finalOnlyBOnA = await peerAStorage.GetTaskAsync("only-b");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(finalSharedA!.EventVersion, Is.EqualTo(5), "Stale shared task should not overwrite local newer version");
+            Assert.That(finalSharedB!.EventVersion, Is.EqualTo(5), "Peer B should receive the latest shared task version");
+            Assert.That(finalOnlyAOnB, Is.Not.Null, "Peer B should receive peer A's exclusive task");
+            Assert.That(finalOnlyBOnA, Is.Not.Null, "Peer A should receive peer B's exclusive task");
+        });
+    }
+
+    private static async Task SendTasksAsync(IStorageService senderStorage, TaskUpsertedAsyncHandler receiverHandler, IEnumerable<string> taskIds)
+    {
+        foreach (var taskId in taskIds)
+        {
+            var task = await senderStorage.GetTaskAsync(taskId).ConfigureAwait(false);
+            if (task is null)
+            {
+                continue;
+            }
+
+            var evt = new TaskUpsertedEvent(task, task.DeviceId ?? string.Empty, task.UserId);
+            await receiverHandler.OnNextAsync(evt).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<IReadOnlyCollection<TaskManifestEntry>> BuildManifestAsync(IStorageService storage)
+    {
+        var tasks = await storage.GetTasksAsync(UserId, string.Empty).ConfigureAwait(false);
+        return tasks.Select(t => new TaskManifestEntry(t.Id, t.EventVersion, t.UpdatedAt)
+        {
+            DeviceId = t.DeviceId,
+            UserId = t.UserId
+        }).ToArray();
+    }
+}

--- a/ShuffleTask.Application.Tests/PeerSyncCoordinatorDiffTests.cs
+++ b/ShuffleTask.Application.Tests/PeerSyncCoordinatorDiffTests.cs
@@ -1,0 +1,129 @@
+using NUnit.Framework;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Services;
+using ShuffleTask.Application.Tests.TestDoubles;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Application.Tests;
+
+public class PeerSyncCoordinatorDiffTests
+{
+    private static readonly DateTime BaseTimeUtc = new(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task CompareManifestAsync_FavorsHigherVersion()
+    {
+        var storage = await CreateStorageAsync(new TaskItem
+        {
+            Id = "shared",
+            Title = "Local",
+            EventVersion = 1,
+            UpdatedAt = BaseTimeUtc,
+            CreatedAt = BaseTimeUtc.AddMinutes(-1)
+        });
+
+        var coordinator = new PeerSyncCoordinator(storage);
+        var manifest = new[] { new TaskManifestEntry("shared", 2, BaseTimeUtc.AddMinutes(-2)) };
+
+        var result = await coordinator.CompareManifestAsync(manifest);
+
+        Assert.That(result.RemoteNewer.Single().TaskId, Is.EqualTo("shared"));
+        Assert.That(result.LocalNewer, Is.Empty);
+    }
+
+    [Test]
+    public async Task CompareManifestAsync_BreaksVersionTiesByUpdatedAt()
+    {
+        var storage = await CreateStorageAsync(new TaskItem
+        {
+            Id = "shared",
+            Title = "Local",
+            EventVersion = 3,
+            UpdatedAt = BaseTimeUtc,
+            CreatedAt = BaseTimeUtc.AddMinutes(-1)
+        });
+
+        var coordinator = new PeerSyncCoordinator(storage);
+        var manifest = new[] { new TaskManifestEntry("shared", 3, BaseTimeUtc.AddMinutes(5)) };
+
+        var result = await coordinator.CompareManifestAsync(manifest);
+
+        Assert.That(result.RemoteNewer.Select(e => e.TaskId), Is.EquivalentTo(new[] { "shared" }));
+    }
+
+    [Test]
+    public async Task CompareManifestAsync_FiltersTasksByUserOwnership()
+    {
+        var storage = new InMemoryStorageService();
+        await storage.InitializeAsync();
+        await storage.AddTaskAsync(new TaskItem
+        {
+            Id = "owned-by-me",
+            Title = "Mine",
+            UserId = "user-a",
+            CreatedAt = BaseTimeUtc,
+            UpdatedAt = BaseTimeUtc,
+            EventVersion = 1
+        });
+        await storage.AddTaskAsync(new TaskItem
+        {
+            Id = "someone-else",
+            Title = "Theirs",
+            UserId = "user-b",
+            CreatedAt = BaseTimeUtc,
+            UpdatedAt = BaseTimeUtc,
+            EventVersion = 5
+        });
+
+        var coordinator = new PeerSyncCoordinator(storage);
+        var remoteManifest = new[] { new TaskManifestEntry("someone-else", 10, BaseTimeUtc.AddMinutes(1)) };
+
+        var result = await coordinator.CompareManifestAsync(remoteManifest, userId: "user-a", deviceId: "");
+
+        Assert.That(result.Missing.Select(e => e.TaskId), Is.Empty, "Unowned tasks should be ignored when userId is provided");
+        Assert.That(result.RemoteNewer, Is.Empty);
+        Assert.That(result.LocalNewer.Select(e => e.TaskId), Is.EquivalentTo(new[] { "owned-by-me" }));
+    }
+
+    [Test]
+    public async Task CompareManifestAsync_FiltersDeviceScopedTasksWhenAnonymous()
+    {
+        var storage = new InMemoryStorageService();
+        await storage.InitializeAsync();
+        await storage.AddTaskAsync(new TaskItem
+        {
+            Id = "device-task",
+            Title = "Device",
+            DeviceId = "device-123",
+            CreatedAt = BaseTimeUtc,
+            UpdatedAt = BaseTimeUtc,
+            EventVersion = 2
+        });
+        await storage.AddTaskAsync(new TaskItem
+        {
+            Id = "other-device",
+            Title = "Other",
+            DeviceId = "device-999",
+            CreatedAt = BaseTimeUtc,
+            UpdatedAt = BaseTimeUtc,
+            EventVersion = 7
+        });
+
+        var coordinator = new PeerSyncCoordinator(storage);
+        var remoteManifest = new[] { new TaskManifestEntry("other-device", 10, BaseTimeUtc.AddMinutes(2)) };
+
+        var result = await coordinator.CompareManifestAsync(remoteManifest, userId: "", deviceId: "device-123");
+
+        Assert.That(result.LocalNewer.Select(e => e.TaskId), Is.EquivalentTo(new[] { "device-task" }));
+        Assert.That(result.RemoteNewer, Is.Empty);
+        Assert.That(result.Missing, Is.Empty, "Tasks for other devices should not be considered");
+    }
+
+    private static async Task<InMemoryStorageService> CreateStorageAsync(TaskItem task)
+    {
+        var storage = new InMemoryStorageService();
+        await storage.InitializeAsync();
+        await storage.AddTaskAsync(task);
+        return storage;
+    }
+}

--- a/ShuffleTask.Application.Tests/ShuffleTask.Application.Tests.csproj
+++ b/ShuffleTask.Application.Tests/ShuffleTask.Application.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ShuffleTask.Application\ShuffleTask.Application.csproj" />
+    <ProjectReference Include="..\ShuffleTask.Domain\ShuffleTask.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
+++ b/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
@@ -1,0 +1,117 @@
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Domain.Entities;
+using System.Collections.Concurrent;
+
+namespace ShuffleTask.Application.Tests.TestDoubles;
+
+internal sealed class InMemoryStorageService : IStorageService
+{
+    private readonly ConcurrentDictionary<string, TaskItem> _tasks = new(StringComparer.Ordinal);
+    private readonly TimeProvider _clock;
+    private bool _initialized;
+    private readonly AppSettings _settings;
+
+    public InMemoryStorageService(TimeProvider? clock = null, AppSettings? settings = null)
+    {
+        _clock = clock ?? TimeProvider.System;
+        _settings = settings ?? new AppSettings();
+    }
+
+    public Task InitializeAsync()
+    {
+        _initialized = true;
+        return Task.CompletedTask;
+    }
+
+    public Task<List<TaskItem>> GetTasksAsync(string? userId = "", string deviceId = "")
+    {
+        EnsureInitialized();
+        var query = _tasks.Values.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            query = query.Where(t => t.UserId == userId);
+        }
+        else if (!string.IsNullOrWhiteSpace(deviceId))
+        {
+            query = query.Where(t => string.IsNullOrWhiteSpace(t.UserId) && string.Equals(t.DeviceId, deviceId, StringComparison.Ordinal));
+        }
+
+        return Task.FromResult(query.Select(Clone).ToList());
+    }
+
+    public Task<TaskItem?> GetTaskAsync(string id)
+    {
+        EnsureInitialized();
+        return Task.FromResult(_tasks.TryGetValue(id, out var value) ? Clone(value) : null);
+    }
+
+    public Task AddTaskAsync(TaskItem item)
+    {
+        EnsureInitialized();
+        NormalizeMetadata(item, null, bumpVersion: true);
+        _tasks[item.Id] = Clone(item);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateTaskAsync(TaskItem item)
+    {
+        EnsureInitialized();
+        NormalizeMetadata(item, _tasks.TryGetValue(item.Id, out var existing) ? existing : null, bumpVersion: true);
+        _tasks[item.Id] = Clone(item);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteTaskAsync(string id)
+    {
+        _tasks.TryRemove(id, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task<TaskItem?> MarkTaskDoneAsync(string id) => Task.FromResult<TaskItem?>(null);
+    public Task<TaskItem?> SnoozeTaskAsync(string id, TimeSpan duration) => Task.FromResult<TaskItem?>(null);
+    public Task<TaskItem?> ResumeTaskAsync(string id) => Task.FromResult<TaskItem?>(null);
+
+    public Task<AppSettings> GetSettingsAsync()
+    {
+        EnsureInitialized();
+        return Task.FromResult(_settings);
+    }
+
+    public Task SetSettingsAsync(AppSettings settings)
+    {
+        EnsureInitialized();
+        _settings.CopyFrom(settings);
+        return Task.CompletedTask;
+    }
+
+    public Task<int> MigrateDeviceTasksToUserAsync(string deviceId, string userId) => Task.FromResult(0);
+
+    private void EnsureInitialized()
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException("Storage not initialized");
+        }
+    }
+
+    private void NormalizeMetadata(TaskItem target, TaskItem? existing, bool bumpVersion)
+    {
+        var now = _clock.GetUtcNow().UtcDateTime;
+        target.Id = string.IsNullOrWhiteSpace(target.Id) ? Guid.NewGuid().ToString("n") : target.Id;
+        target.CreatedAt = target.CreatedAt == default ? now : EnsureUtc(target.CreatedAt);
+        target.UpdatedAt = target.UpdatedAt == default ? now : EnsureUtc(target.UpdatedAt);
+
+        var existingVersion = existing?.EventVersion ?? 0;
+        target.EventVersion = bumpVersion ? Math.Max(existingVersion + 1, target.EventVersion) : Math.Max(existingVersion, target.EventVersion);
+        target.UserId = string.IsNullOrWhiteSpace(target.UserId) ? existing?.UserId : target.UserId;
+        target.DeviceId = string.IsNullOrWhiteSpace(target.UserId)
+            ? (string.IsNullOrWhiteSpace(target.DeviceId) ? existing?.DeviceId ?? Environment.MachineName : target.DeviceId)
+            : null;
+    }
+
+    private static TaskItem Clone(TaskItem task) => TaskItem.Clone(task);
+
+    private static DateTime EnsureUtc(DateTime value) => value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();
+}

--- a/ShuffleTask.Application/ShuffleTask.Application.csproj
+++ b/ShuffleTask.Application/ShuffleTask.Application.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ShuffleTask.Tests" />
+    <InternalsVisibleTo Include="ShuffleTask.Application.Tests" />
   </ItemGroup>
 
 </Project>

--- a/ShuffleTask.sln
+++ b/ShuffleTask.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShuffleTask.Persistence", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShuffleTask.Presentation.Tests", "ShuffleTask.Presentation.Tests\ShuffleTask.Presentation.Tests.csproj", "{B6CB2066-5C4B-4129-9A5C-405F75337A41}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShuffleTask.Application.Tests", "ShuffleTask.Application.Tests\ShuffleTask.Application.Tests.csproj", "{136F9500-E18E-476E-8AE0-638FBD77EE06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -99,6 +101,18 @@ Global
 		{B6CB2066-5C4B-4129-9A5C-405F75337A41}.Release|x64.Build.0 = Release|Any CPU
 		{B6CB2066-5C4B-4129-9A5C-405F75337A41}.Release|x86.ActiveCfg = Release|Any CPU
 		{B6CB2066-5C4B-4129-9A5C-405F75337A41}.Release|x86.Build.0 = Release|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Debug|x64.Build.0 = Debug|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Debug|x86.Build.0 = Debug|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Release|x64.ActiveCfg = Release|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Release|x64.Build.0 = Release|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Release|x86.ActiveCfg = Release|Any CPU
+		{136F9500-E18E-476E-8AE0-638FBD77EE06}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a ShuffleTask.Application.Tests project covering peer sync behaviors
- add unit tests for PeerSyncCoordinator diffing across versions, timestamps, and ownership filters
- add integration-style test simulating peers exchanging manifests and ignoring stale upserts

## Testing
- dotnet test ShuffleTask.sln *(fails: missing Yaref92.Events package in restore source)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ad2f840008326ba2767e36cef192e)