### PR TITLE
Add debug identity toast before peer connections

### DIFF
--- a/ShuffleTask.Application/Services/NetworkSyncService.cs
+++ b/ShuffleTask.Application/Services/NetworkSyncService.cs
@@ -135,10 +135,19 @@ public class NetworkSyncService : INetworkSyncService, IDisposable
 
         await DebugToastAsync(PeerConnect, $"Connecting to {host}:{port}...").ConfigureAwait(false);
 
+        var sessionUserId = SessionUserGuid;
+        await DebugToastAsync(PeerConnect, $"Using UserId '{UserId}' with SessionUserId '{sessionUserId}'.").ConfigureAwait(false);
+        _logger?.LogDebug(
+            "Using UserId {UserId} with SessionUserId {SessionUserId} before connecting to {Host}:{Port}.",
+            UserId,
+            sessionUserId,
+            host,
+            port);
+
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, EnsureConnectionCts().Token);
         try
         {
-            await _transport.ConnectToPeerAsync(SessionUserGuid, host, port, linkedCts.Token).ConfigureAwait(false);
+            await _transport.ConnectToPeerAsync(sessionUserId, host, port, linkedCts.Token).ConfigureAwait(false);
 
             await PublishManifestAnnouncementAsync(linkedCts.Token).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- add debug toast/log reporting the resolved UserId and SessionUserId before connecting to peers
- reuse the resolved session user ID for the transport connection call

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69426dbfb62c8326a6bfe7c382eaba22)