### PR TITLE
Expose connected peers to UI and tighten session typing

### DIFF
--- a/ShuffleTask.Application/Abstractions/INetworkSyncService.cs
+++ b/ShuffleTask.Application/Abstractions/INetworkSyncService.cs
@@ -1,5 +1,6 @@
 using ShuffleTask.Application.Models;
 using ShuffleTask.Domain.Entities;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace ShuffleTask.Application.Abstractions;
@@ -13,6 +14,8 @@ public interface INetworkSyncService
     bool ShouldBroadcast { get; }
 
     NetworkOptions NetworkOptions { get; }
+
+    IReadOnlyList<PeerInfo> GetConnectedPeers();
 
     Task RequestGracefulFlushAsync(CancellationToken cancellationToken = default);
 

--- a/ShuffleTask.Application/Models/PeerInfo.cs
+++ b/ShuffleTask.Application/Models/PeerInfo.cs
@@ -1,0 +1,8 @@
+namespace ShuffleTask.Application.Models;
+
+public sealed record PeerInfo(
+    string DeviceId,
+    string? UserId,
+    string? SessionId,
+    DateTimeOffset? LastSeen,
+    string? ConnectionState);

--- a/ShuffleTask.Presentation/ViewModels/PeerInfoViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeerInfoViewModel.cs
@@ -1,0 +1,55 @@
+using ShuffleTask.Application.Models;
+using System;
+
+namespace ShuffleTask.ViewModels;
+
+public sealed class PeerInfoViewModel
+{
+    public PeerInfoViewModel(PeerInfo peer, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(peer);
+
+        DeviceId = string.IsNullOrWhiteSpace(peer.DeviceId) ? "Unknown device" : peer.DeviceId;
+        UserIdLabel = string.IsNullOrWhiteSpace(peer.UserId) ? "User: Unknown" : $"User: {peer.UserId}";
+        SessionIdLabel = string.IsNullOrWhiteSpace(peer.SessionId) ? "Session: Unknown" : $"Session: {peer.SessionId}";
+        ConnectionStateLabel = string.IsNullOrWhiteSpace(peer.ConnectionState) ? "State: Unknown" : $"State: {peer.ConnectionState}";
+        LastSeenLabel = FormatLastSeen(peer.LastSeen, now);
+    }
+
+    public string DeviceId { get; }
+
+    public string UserIdLabel { get; }
+
+    public string SessionIdLabel { get; }
+
+    public string ConnectionStateLabel { get; }
+
+    public string LastSeenLabel { get; }
+
+    private static string FormatLastSeen(DateTimeOffset? lastSeen, DateTimeOffset now)
+    {
+        if (!lastSeen.HasValue)
+        {
+            return "Last seen: Unknown";
+        }
+
+        var lastSeenUtc = lastSeen.Value.ToUniversalTime();
+        var delta = now.ToUniversalTime() - lastSeenUtc;
+        if (delta < TimeSpan.FromMinutes(1))
+        {
+            return "Last seen: just now";
+        }
+
+        if (delta < TimeSpan.FromHours(1))
+        {
+            return $"Last seen: {Math.Floor(delta.TotalMinutes)}m ago";
+        }
+
+        if (delta < TimeSpan.FromDays(1))
+        {
+            return $"Last seen: {Math.Floor(delta.TotalHours)}h ago";
+        }
+
+        return $"Last seen: {lastSeen.Value.LocalDateTime:g}";
+    }
+}

--- a/ShuffleTask.Presentation/Views/PeersPage.xaml
+++ b/ShuffleTask.Presentation/Views/PeersPage.xaml
@@ -18,6 +18,8 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <Label Grid.Row="0"
@@ -78,6 +80,56 @@
                     Command="{Binding ConnectPeerCommand}"
                     IsEnabled="{Binding CanSyncAcrossDevices}"
                     HorizontalOptions="Fill" />
+
+            <Label Grid.Row="6"
+                   Grid.ColumnSpan="2"
+                   Text="Connected peers"
+                   FontAttributes="Bold"
+                   FontSize="Medium"
+                   Margin="0,10,0,0" />
+
+            <CollectionView Grid.Row="7"
+                            Grid.ColumnSpan="2"
+                            ItemsSource="{Binding ConnectedPeers}"
+                            SelectionMode="None">
+                <CollectionView.EmptyView>
+                    <Label Text="No peers connected."
+                           FontAttributes="Italic"
+                           TextColor="Gray"
+                           Margin="0,8,0,0" />
+                </CollectionView.EmptyView>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="vm:PeerInfoViewModel">
+                        <Frame BorderColor="#E5E7EB"
+                               CornerRadius="8"
+                               Padding="12"
+                               Margin="0,6">
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="{Binding DeviceId}"
+                                       FontAttributes="Bold"
+                                       FontSize="Medium" />
+                                <Label Text="{Binding UserIdLabel}"
+                                       FontSize="Small"
+                                       TextColor="#4B5563" />
+                                <Label Text="{Binding SessionIdLabel}"
+                                       FontSize="Small"
+                                       TextColor="#4B5563" />
+                                <Grid ColumnDefinitions="Auto,*"
+                                      ColumnSpacing="8">
+                                    <Label Text="{Binding ConnectionStateLabel}"
+                                           FontSize="Small"
+                                           TextColor="#111827" />
+                                    <Label Grid.Column="1"
+                                           Text="{Binding LastSeenLabel}"
+                                           FontSize="Small"
+                                           TextColor="#6B7280"
+                                           HorizontalTextAlignment="End" />
+                                </Grid>
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
         </Grid>
     </ScrollView>
 </ContentPage>


### PR DESCRIPTION
### Motivation
- Surface the list of connected peers in the Settings UI so users can see device/session, last-seen and connection state.  
- Decouple UI from transport internals by exposing a typed `GetConnectedPeers()` API on the network service.  
- Strengthen type-safety in session handling to avoid reflection on untyped objects.  

### Description
- Added `PeerInfo` record and a new `IReadOnlyList<PeerInfo> GetConnectedPeers()` to `INetworkSyncService`.  
- Implemented `GetConnectedPeers()` in `NetworkSyncService` and tightened helpers so `ExtractSessions` accepts `ISessionManager` and yields `IPeerSession`, and `BuildPeerInfo` accepts `IPeerSession`.  
- Introduced `PeerInfoViewModel`, added `ConnectedPeers` (`ObservableCollection<PeerInfoViewModel>`) and a periodic refresh loop in `SettingsViewModel` that maps `PeerInfo` to view models on the main thread.  
- Updated `PeersPage.xaml` to render the `ConnectedPeers` collection with device, user/session labels, last seen and connection state.  

### Testing
- No automated tests were executed in this environment.  
- Existing unit test projects were not modified and can be run with the standard `dotnet test` workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69528a3784fc8326a9dea63c2f8d1c67)