### PR TITLE
Enable AuthFrame emission by passing auth secret to GrpcEventTransport

### DIFF
--- a/ShuffleTask.Presentation/MauiProgram.cs
+++ b/ShuffleTask.Presentation/MauiProgram.cs
@@ -144,9 +144,9 @@ public static partial class MauiProgram
             return new GrpcEventTransport(
                 options.ListeningPort,
                 sp.GetRequiredService<ISessionManager>(),
-                new JsonEventSerializer());/*,
+                new JsonEventSerializer(),
                 TimeSpan.FromSeconds(20),
-                authSecret);*/
+                authSecret);
         });
         builder.Services.AddSingleton<NetworkedEventAggregator>();
         builder.Services.AddSingleton<INetworkSyncService, NetworkSyncService>();


### PR DESCRIPTION
### Motivation
- Ensure the gRPC event transport can emit an `AuthFrame` on connect by supplying the configured authentication secret and an auth timeout.
- Use the resolved network authentication secret so peers can perform authenticated handshakes when connecting.

### Description
- In `ShuffleTask.Presentation/MauiProgram.cs` updated the `GrpcEventTransport` construction to pass `new JsonEventSerializer()`, `TimeSpan.FromSeconds(20)`, and the resolved `authSecret`.
- The `authSecret` is obtained via `options.ResolveAuthenticationSecret()` from the app `NetworkOptions` and is passed into the transport so it has the required authentication information.
- No other behavioral or public API changes were made; the change replaces previously commented-out parameters with the active overload that accepts auth-related options.

### Testing
- No automated tests were executed for this change in the current environment.
- A `dotnet` restore/build was not performed due to the runtime tools not being available in the execution environment, so no build verification was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695538c336808326a052e5c9f19d537f)