### PR TITLE
Refactor peer connection flow and add SettingsViewModel disposal

### DIFF
--- a/ShuffleTask.Application/Services/NetworkSyncService.cs
+++ b/ShuffleTask.Application/Services/NetworkSyncService.cs
@@ -110,52 +110,12 @@ public class NetworkSyncService : INetworkSyncService, IDisposable
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(host))
+        if (!await ValidatePeerConnectionAsync(host, port).ConfigureAwait(false))
         {
-            await DebugToastAsync(PeerConnect, "Peer host is empty; cannot connect.").ConfigureAwait(false);
             return;
         }
 
-        if (port <= 0)
-        {
-            await DebugToastAsync(PeerConnect, "Peer port is invalid; cannot connect.").ConfigureAwait(false);
-            return;
-        }
-
-        if (IsAnonymous)
-        {
-            const string loginToSync = "Log in to sync.";
-            await DebugToastAsync(PeerConnect, loginToSync).ConfigureAwait(false);
-            throw new InvalidOperationException(loginToSync);
-        }
-
-        await DebugToastAsync(PeerConnect, $"Connecting to {host}:{port}...").ConfigureAwait(false);
-
-        var sessionUserId = SessionUserGuid;
-        await DebugToastAsync(PeerConnect, $"Using UserId '{UserId}' with SessionUserId '{sessionUserId}'.").ConfigureAwait(false);
-        _logger?.LogDebug(
-            "Using UserId {UserId} with SessionUserId {SessionUserId} before connecting to {Host}:{Port}.",
-            UserId,
-            sessionUserId,
-            host,
-            port);
-
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, EnsureConnectionCts().Token);
-        try
-        {
-            await _transport.ConnectToPeerAsync(sessionUserId, host, port, linkedCts.Token).ConfigureAwait(false);
-
-            await PublishManifestAnnouncementAsync(linkedCts.Token).ConfigureAwait(false);
-
-            await DebugToastAsync(PeerConnect, $"Connected to {host}:{port}.").ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(ex, "Error connecting to peer {Host}:{Port}.", host, port);
-            string message = $"Failed to connect to {host}:{port}. {ex.Message}";
-            await DebugToastAsync(PeerConnect, message).ConfigureAwait(false);
-            throw new NetworkConnectionException(message, ex);
-        }
+        await ConnectToPeerInternalAsync(host, port, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DisconnectAsync(CancellationToken cancellationToken = default)
@@ -257,6 +217,66 @@ public class NetworkSyncService : INetworkSyncService, IDisposable
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         await InitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> ValidatePeerConnectionAsync(string host, int port)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            await DebugToastAsync(PeerConnect, "Peer host is empty; cannot connect.").ConfigureAwait(false);
+            return false;
+        }
+
+        if (port <= 0)
+        {
+            await DebugToastAsync(PeerConnect, "Peer port is invalid; cannot connect.").ConfigureAwait(false);
+            return false;
+        }
+
+        if (IsAnonymous)
+        {
+            const string loginToSync = "Log in to sync.";
+            await DebugToastAsync(PeerConnect, loginToSync).ConfigureAwait(false);
+            throw new InvalidOperationException(loginToSync);
+        }
+
+        return true;
+    }
+
+    private async Task ConnectToPeerInternalAsync(string host, int port, CancellationToken cancellationToken)
+    {
+        await DebugToastAsync(PeerConnect, $"Connecting to {host}:{port}...").ConfigureAwait(false);
+
+        var sessionUserId = SessionUserGuid;
+        await LogConnectionAttemptAsync(sessionUserId, host, port).ConfigureAwait(false);
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, EnsureConnectionCts().Token);
+        try
+        {
+            await _transport.ConnectToPeerAsync(sessionUserId, host, port, linkedCts.Token).ConfigureAwait(false);
+
+            await PublishManifestAnnouncementAsync(linkedCts.Token).ConfigureAwait(false);
+
+            await DebugToastAsync(PeerConnect, $"Connected to {host}:{port}.").ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Error connecting to peer {Host}:{Port}.", host, port);
+            string message = $"Failed to connect to {host}:{port}. {ex.Message}";
+            await DebugToastAsync(PeerConnect, message).ConfigureAwait(false);
+            throw new NetworkConnectionException(message, ex);
+        }
+    }
+
+    private async Task LogConnectionAttemptAsync(Guid sessionUserId, string host, int port)
+    {
+        await DebugToastAsync(PeerConnect, $"Using UserId '{UserId}' with SessionUserId '{sessionUserId}'.").ConfigureAwait(false);
+        _logger?.LogDebug(
+            "Using UserId {UserId} with SessionUserId {SessionUserId} before connecting to {Host}:{Port}.",
+            UserId,
+            sessionUserId,
+            host,
+            port);
     }
 
     private void RefreshCachedIdentity()

--- a/ShuffleTask.Presentation/MauiProgram.cs
+++ b/ShuffleTask.Presentation/MauiProgram.cs
@@ -144,9 +144,9 @@ public static partial class MauiProgram
             return new GrpcEventTransport(
                 options.ListeningPort,
                 sp.GetRequiredService<ISessionManager>(),
-                new JsonEventSerializer());/*,
+                new JsonEventSerializer(),
                 TimeSpan.FromSeconds(20),
-                authSecret);*/
+                authSecret);
         });
         builder.Services.AddSingleton<NetworkedEventAggregator>();
         builder.Services.AddSingleton<INetworkSyncService, NetworkSyncService>();

--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -6,12 +6,13 @@ using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
 using ShuffleTask.Application.Exceptions;
 using ShuffleTask.Presentation.Services;
+using System;
 using System.ComponentModel;
 using Yaref92.Events.Connections;
 
 namespace ShuffleTask.ViewModels;
 
-public partial class SettingsViewModel : ObservableObject
+public partial class SettingsViewModel : ObservableObject, IDisposable
 {
     private readonly IStorageService _storage;
     private readonly ISchedulerService _scheduler;
@@ -24,6 +25,7 @@ public partial class SettingsViewModel : ObservableObject
     private NetworkOptions? _networkOptions;
     private string? _lastUserId;
     private bool _lastAnonymousMode;
+    private bool _disposed;
 
     [ObservableProperty]
     private AppSettings _settings;
@@ -427,6 +429,18 @@ public partial class SettingsViewModel : ObservableObject
         {
             System.Diagnostics.Debug.WriteLine($"Error showing connection error toast: {ex.Message}");
         }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        UpdateNetworkSubscription(_networkOptions, null);
+        _disposed = true;
+        GC.SuppressFinalize(this);
     }
 
 }


### PR DESCRIPTION
### Motivation
- Reduce complexity and improve clarity of the peer connection flow in the network sync service by extracting smaller responsibilities.  
- Ensure connection-related UI notifications and logging are executed predictably and awaited.  
- Prevent event subscription leaks by providing a disposal path on the settings view model.  
- Ensure the gRPC transport is provided with the resolved authentication secret so an `AuthFrame` can be emitted on connect.

### Description
- Extracted validation and connection responsibilities from `ConnectToPeerAsync` into `ValidatePeerConnectionAsync`, `ConnectToPeerInternalAsync`, and `LogConnectionAttemptAsync` in `ShuffleTask.Application/Services/NetworkSyncService.cs` so the flow is clearer and cyclomatic complexity is reduced.  
- Made the connection log/toast fully asynchronous by awaiting `LogConnectionAttemptAsync` and kept original behavior and error handling (including publishing the manifest announcement after connect).  
- Added `IDisposable` to `ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs`, introduced a `_disposed` flag, and unsubscribe logic via `UpdateNetworkSubscription(_networkOptions, null)` in `Dispose` to detach property change handlers and avoid leaks.  
- Enabled gRPC auth options in `ShuffleTask.Presentation/MauiProgram.cs` by passing the resolved auth secret and an auth timeout into the `GrpcEventTransport` constructor so peers can perform authenticated handshakes.

### Testing
- No automated tests were executed for these changes in this environment.  
- No `dotnet` build/restore or runtime verification was performed here, so build and integration verification remain to be run in CI or locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695538c336808326a052e5c9f19d537f)