### PR TITLE
Support custom weekday constraints for Custom allowed periods

### DIFF
--- a/ShuffleTask.Application/Services/ManualShuffleService.cs
+++ b/ShuffleTask.Application/Services/ManualShuffleService.cs
@@ -29,6 +29,7 @@ public static class ManualShuffleService
                 clone.AllowedPeriod = AllowedPeriod.Any;
                 clone.CustomStartTime = null;
                 clone.CustomEndTime = null;
+                clone.CustomWeekdays = null;
             }
 
             clones.Add(clone);

--- a/ShuffleTask.Application/Services/TimeWindowService.cs
+++ b/ShuffleTask.Application/Services/TimeWindowService.cs
@@ -100,7 +100,14 @@ public static class TimeWindowService
 
         if (customWeekdays.HasValue)
         {
-            Weekdays today = GetWeekdayFlag(now);
+            DateTimeOffset local = TimeZoneInfo.ConvertTime(now, TimeZoneInfo.Local);
+            DateTimeOffset weekdaySource = local;
+            if (start.Value > end.Value && local.TimeOfDay < end.Value)
+            {
+                weekdaySource = local.AddDays(-1);
+            }
+
+            Weekdays today = GetWeekdayFlag(weekdaySource);
             if (!customWeekdays.Value.HasFlag(today))
             {
                 return false;

--- a/ShuffleTask.Domain/TaskItemData.cs
+++ b/ShuffleTask.Domain/TaskItemData.cs
@@ -34,6 +34,8 @@ public abstract class TaskItemData
 
     public TimeSpan? CustomEndTime { get; set; }
 
+    public Weekdays? CustomWeekdays { get; set; }
+
     public bool Paused { get; set; }
 
     public DateTime CreatedAt { get; set; }
@@ -86,6 +88,7 @@ public abstract class TaskItemData
         AutoShuffleAllowed = source.AutoShuffleAllowed;
         CustomStartTime = source.CustomStartTime;
         CustomEndTime = source.CustomEndTime;
+        CustomWeekdays = source.CustomWeekdays;
         Paused = source.Paused;
         CreatedAt = source.CreatedAt;
         Status = source.Status;

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -73,6 +73,7 @@ public class StorageService : IStorageService
             await AddCol("AutoShuffleAllowed", IntegerSqlType, "1");
             await AddCol("CustomStartTime", "TEXT", "NULL");
             await AddCol("CustomEndTime", "TEXT", "NULL");
+            await AddCol("CustomWeekdays", IntegerSqlType, "NULL");
             await AddCol("Paused", IntegerSqlType, "0");
             await AddCol("CreatedAt", "TEXT", "CURRENT_TIMESTAMP");
             await AddCol("UpdatedAt", "TEXT", "CURRENT_TIMESTAMP");

--- a/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
@@ -14,6 +14,9 @@ public partial class EditTaskViewModel : ObservableObject
     private TaskItem _workingCopy = new();
 
     private Weekdays _selectedWeekdays;
+    private Weekdays _selectedCustomWeekdays;
+
+    private static readonly Weekdays AllWeekdays = Weekdays.Sun | Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri | Weekdays.Sat;
 
     private const double MinSizePoints = 0.5;
     private const double MaxSizePoints = 13.0;
@@ -33,6 +36,24 @@ public partial class EditTaskViewModel : ObservableObject
                 OnPropertyChanged(nameof(Thursday));
                 OnPropertyChanged(nameof(Friday));
                 OnPropertyChanged(nameof(Saturday));
+            }
+        }
+    }
+
+    public Weekdays SelectedCustomWeekdays
+    {
+        get => _selectedCustomWeekdays;
+        set
+        {
+            if (SetProperty(ref _selectedCustomWeekdays, value))
+            {
+                OnPropertyChanged(nameof(CustomSunday));
+                OnPropertyChanged(nameof(CustomMonday));
+                OnPropertyChanged(nameof(CustomTuesday));
+                OnPropertyChanged(nameof(CustomWednesday));
+                OnPropertyChanged(nameof(CustomThursday));
+                OnPropertyChanged(nameof(CustomFriday));
+                OnPropertyChanged(nameof(CustomSaturday));
             }
         }
     }
@@ -145,6 +166,13 @@ public partial class EditTaskViewModel : ObservableObject
         SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
     }
 
+    private bool GetCustomWeekday(Weekdays day) => _selectedCustomWeekdays.HasFlag(day);
+
+    private void SetCustomWeekday(Weekdays day, bool isSelected)
+    {
+        SelectedCustomWeekdays = ApplyWeekdaySelection(SelectedCustomWeekdays, day, isSelected);
+    }
+
     public bool Sunday
     {
         get => GetWeekday(Weekdays.Sun);
@@ -186,6 +214,48 @@ public partial class EditTaskViewModel : ObservableObject
         get => GetWeekday(Weekdays.Sat);
         set => SetWeekday(Weekdays.Sat, value);
     }
+
+    public bool CustomSunday
+    {
+        get => GetCustomWeekday(Weekdays.Sun);
+        set => SetCustomWeekday(Weekdays.Sun, value);
+    }
+
+    public bool CustomMonday
+    {
+        get => GetCustomWeekday(Weekdays.Mon);
+        set => SetCustomWeekday(Weekdays.Mon, value);
+    }
+
+    public bool CustomTuesday
+    {
+        get => GetCustomWeekday(Weekdays.Tue);
+        set => SetCustomWeekday(Weekdays.Tue, value);
+    }
+
+    public bool CustomWednesday
+    {
+        get => GetCustomWeekday(Weekdays.Wed);
+        set => SetCustomWeekday(Weekdays.Wed, value);
+    }
+
+    public bool CustomThursday
+    {
+        get => GetCustomWeekday(Weekdays.Thu);
+        set => SetCustomWeekday(Weekdays.Thu, value);
+    }
+
+    public bool CustomFriday
+    {
+        get => GetCustomWeekday(Weekdays.Fri);
+        set => SetCustomWeekday(Weekdays.Fri, value);
+    }
+
+    public bool CustomSaturday
+    {
+        get => GetCustomWeekday(Weekdays.Sat);
+        set => SetCustomWeekday(Weekdays.Sat, value);
+    }
     public AppSettings AppSettings { get; }
 
     public event EventHandler? Saved;
@@ -209,6 +279,7 @@ public partial class EditTaskViewModel : ObservableObject
         IsPaused = _workingCopy.Paused;
         CutInLineMode = _workingCopy.CutInLineMode;
         SelectedWeekdays = _workingCopy.Weekdays;
+        SelectedCustomWeekdays = _workingCopy.CustomWeekdays ?? AllWeekdays;
 
         // Load custom timer _settings
         UseCustomTimer = _workingCopy.CustomTimerMode.HasValue;
@@ -274,6 +345,9 @@ public partial class EditTaskViewModel : ObservableObject
             _workingCopy.AutoShuffleAllowed = AutoShuffleAllowed;
             _workingCopy.CustomStartTime = AllowedPeriod == AllowedPeriod.Custom ? CustomStartTime : null;
             _workingCopy.CustomEndTime = AllowedPeriod == AllowedPeriod.Custom ? CustomEndTime : null;
+            _workingCopy.CustomWeekdays = AllowedPeriod == AllowedPeriod.Custom
+                ? SelectedCustomWeekdays == AllWeekdays ? null : SelectedCustomWeekdays
+                : null;
             _workingCopy.Paused = IsPaused;
             _workingCopy.CutInLineMode = CutInLineMode;
 

--- a/ShuffleTask.Presentation/Views/EditTaskPage.xaml
+++ b/ShuffleTask.Presentation/Views/EditTaskPage.xaml
@@ -165,7 +165,7 @@
                     SelectedItem="{Binding AllowedPeriod}" />
 
             <Label Grid.Row="9"
-                   Text="Work hours apply to weekdays. Custom hours follow your time range."
+                   Text="Work hours apply to weekdays (Mon–Fri). Custom hours use the task's weekday and time range."
                    FontSize="12"
                    TextColor="#6B7280" />
 
@@ -190,7 +190,7 @@
             </Grid>
 
             <Grid Grid.Row="12"
-                  RowDefinitions="Auto,Auto"
+                  RowDefinitions="Auto,Auto,Auto,Auto"
                   RowSpacing="8"
                   IsVisible="False">
                 <Grid.Triggers>
@@ -209,6 +209,27 @@
                                 Time="{Binding CustomStartTime}" />
                     <TimePicker Grid.Column="1"
                                 Time="{Binding CustomEndTime}" />
+                </Grid>
+                <Label Grid.Row="2"
+                       Text="Custom weekdays" />
+                <Grid Grid.Row="3"
+                      RowDefinitions="Auto,Auto"
+                      ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                      ColumnSpacing="8">
+                    <CheckBox Grid.Row="0" Grid.Column="0" IsChecked="{Binding CustomSunday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" IsChecked="{Binding CustomMonday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="2" IsChecked="{Binding CustomTuesday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="3" IsChecked="{Binding CustomWednesday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="4" IsChecked="{Binding CustomThursday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="5" IsChecked="{Binding CustomFriday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="6" IsChecked="{Binding CustomSaturday}" />
+                    <Label Grid.Row="1" Grid.Column="0" Text="Sun" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="1" Text="Mon" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="2" Text="Tue" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="3" Text="Wed" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="4" Text="Thu" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="5" Text="Fri" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="6" Text="Sat" HorizontalOptions="Center" />
                 </Grid>
             </Grid>
 

--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -72,7 +72,7 @@
 
             <Label Grid.Row="3"
                    Grid.ColumnSpan="2"
-                   Text="Work hours apply to weekdays (Mon–Fri). Custom hours follow your time range."
+                   Text="Work hours apply to weekdays (Mon–Fri). Custom hours use the task's weekdays and time range."
                    FontSize="12"
                    TextColor="#6B7280" />
 

--- a/ShuffleTask.Tests/Domain/TaskItemTests.cs
+++ b/ShuffleTask.Tests/Domain/TaskItemTests.cs
@@ -97,6 +97,7 @@ public class TaskItemTests
             IntervalDays = 2,
             LastDoneAt = new DateTime(2025, 9, 10, 12, 0, 0, DateTimeKind.Utc),
             AllowedPeriod = AllowedPeriod.Work,
+            CustomWeekdays = Weekdays.Mon | Weekdays.Wed,
             Paused = true,
             CreatedAt = new DateTime(2025, 9, 1, 9, 0, 0, DateTimeKind.Utc),
             Status = TaskLifecycleStatus.Completed,
@@ -127,6 +128,7 @@ public class TaskItemTests
             Assert.That(actual.IntervalDays, Is.EqualTo(expected.IntervalDays));
             Assert.That(actual.LastDoneAt, Is.EqualTo(expected.LastDoneAt));
             Assert.That(actual.AllowedPeriod, Is.EqualTo(expected.AllowedPeriod));
+            Assert.That(actual.CustomWeekdays, Is.EqualTo(expected.CustomWeekdays));
             Assert.That(actual.Paused, Is.EqualTo(expected.Paused));
             Assert.That(actual.CreatedAt, Is.EqualTo(expected.CreatedAt));
             Assert.That(actual.Status, Is.EqualTo(expected.Status));

--- a/ShuffleTask.Tests/ManualShuffleServiceTests.cs
+++ b/ShuffleTask.Tests/ManualShuffleServiceTests.cs
@@ -43,7 +43,8 @@ public class ManualShuffleServiceTests
             AllowedPeriod = AllowedPeriod.Custom,
             AutoShuffleAllowed = false,
             CustomStartTime = TimeSpan.FromHours(8),
-            CustomEndTime = TimeSpan.FromHours(12)
+            CustomEndTime = TimeSpan.FromHours(12),
+            CustomWeekdays = Weekdays.Mon | Weekdays.Tue
         };
 
         var settings = new AppSettings
@@ -58,6 +59,7 @@ public class ManualShuffleServiceTests
         Assert.That(candidate.AllowedPeriod, Is.EqualTo(AllowedPeriod.Any), "Allowed period should be cleared when ignoring time windows.");
         Assert.IsNull(candidate.CustomStartTime, "Custom start time should be cleared when ignoring the window.");
         Assert.IsNull(candidate.CustomEndTime, "Custom end time should be cleared when ignoring the window.");
+        Assert.IsNull(candidate.CustomWeekdays, "Custom weekdays should be cleared when ignoring the window.");
         Assert.That(candidate.AutoShuffleAllowed, Is.True, "Manual shuffle should bypass AutoShuffleAllowed flag.");
 
         Assert.That(original.AllowedPeriod, Is.EqualTo(AllowedPeriod.Custom), "Original task should not be mutated.");

--- a/ShuffleTask.Tests/TimeWindowServiceTests.cs
+++ b/ShuffleTask.Tests/TimeWindowServiceTests.cs
@@ -166,6 +166,35 @@ public class TimeWindowServiceTests
     }
 
     [Test]
+    public void AutoShuffleAllowedNow_CustomWeekdays_RestrictsWeekend()
+    {
+        var settings = new AppSettings
+        {
+            WorkStart = new TimeSpan(9, 0, 0),
+            WorkEnd = new TimeSpan(17, 0, 0)
+        };
+        var weekday = LocalDate(2024, 1, 2, 11, 0);
+        var weekend = LocalDate(2024, 1, 6, 11, 0);
+
+        var task = new TaskItem
+        {
+            AllowedPeriod = AllowedPeriod.Custom,
+            AutoShuffleAllowed = true,
+            CustomStartTime = new TimeSpan(10, 0, 0),
+            CustomEndTime = new TimeSpan(14, 0, 0),
+            CustomWeekdays = Weekdays.Mon | Weekdays.Tue
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(TimeWindowService.AutoShuffleAllowedNow(task, weekday, settings), Is.True,
+                "Task should be allowed on configured weekdays within the time range");
+            Assert.That(TimeWindowService.AutoShuffleAllowedNow(task, weekend, settings), Is.False,
+                "Task should not be allowed on weekends when custom weekdays exclude them");
+        });
+    }
+
+    [Test]
     public void AutoShuffleAllowedNow_WeekendOverridesWorkAndCustom()
     {
         var settings = new AppSettings


### PR DESCRIPTION
### Motivation
- Add explicit weekday constraints for tasks using the `Custom` allowed period because existing model only stored a time range and `TimeWindowService` only checked time-of-day. 
- Surface weekday selection in the Edit Task UI so users can limit custom windows to specific days (separate from repeat weekdays). 

### Description
- Add a nullable `Weekdays? CustomWeekdays` to `TaskItemData` and copy it in `CopyFrom`, and add schema migration in `StorageService` via `CustomWeekdays` column. 
- Honor custom weekday constraints in scheduling by updating `TimeWindowService.IsWithinCustomHours` (new signature includes `Weekdays? customWeekdays`) and add `GetWeekdayFlag` to evaluate the local weekday. 
- Ensure manual shuffle candidate creation clears `CustomWeekdays` when `ManualShuffleRespectsAllowedPeriod` is disabled in `ManualShuffleService`. 
- Expose custom-weekday selection in the edit UI by adding `SelectedCustomWeekdays` and per-day checkbox properties in `EditTaskViewModel`, persist/load the `CustomWeekdays` field, and add the weekday grid and updated label text in `EditTaskPage.xaml` and `SettingsPage.xaml`. 
- Update unit tests to cover the new behavior (updated `TaskItemTests`, `ManualShuffleServiceTests` and added `TimeWindowServiceTests.AutoShuffleAllowedNow_CustomWeekdays_RestrictsWeekend`). 

### Testing
- Unit tests updated/added: `ShuffleTask.Tests/TimeWindowServiceTests.cs` (new weekday restriction test), `ShuffleTask.Tests/ManualShuffleServiceTests.cs` (assert `CustomWeekdays` cleared), and `ShuffleTask.Tests/Domain/TaskItemTests.cs` (copy/clone assertions include `CustomWeekdays`).
- Automated test suite was not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4abbda9483268ca5b733d5b3436c)