### PR TITLE
Add PeriodDefinition model and integrate into scheduling/time-window logic

### DIFF
--- a/ShuffleTask.Application/Services/ManualShuffleService.cs
+++ b/ShuffleTask.Application/Services/ManualShuffleService.cs
@@ -27,6 +27,12 @@ public static class ManualShuffleService
             if (!settings.ManualShuffleRespectsAllowedPeriod)
             {
                 clone.AllowedPeriod = AllowedPeriod.Any;
+                clone.PeriodDefinitionId = PeriodDefinitionCatalog.AnyId;
+                clone.AdHocStartTime = null;
+                clone.AdHocEndTime = null;
+                clone.AdHocWeekdays = null;
+                clone.AdHocIsAllDay = false;
+                clone.AdHocMode = PeriodDefinitionMode.None;
                 clone.CustomStartTime = null;
                 clone.CustomEndTime = null;
                 clone.CustomWeekdays = null;

--- a/ShuffleTask.Application/Services/TimeWindowService.cs
+++ b/ShuffleTask.Application/Services/TimeWindowService.cs
@@ -55,6 +55,35 @@ public static class TimeWindowService
         return AllowedNow(definition, now, s);
     }
 
+    public static bool AllowsWeekend(TaskItem task, AppSettings s)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        PeriodDefinition definition = ResolveDefinition(task);
+        return AllowsWeekend(definition, s);
+    }
+
+    public static bool AllowsWeekend(PeriodDefinition definition, AppSettings s)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        Weekdays weekdays = NormalizeWeekdays(definition.Weekdays);
+        TimeSpan start = definition.StartTime ?? TimeSpan.Zero;
+        TimeSpan end = definition.EndTime ?? TimeSpan.Zero;
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours))
+        {
+            start = s.WorkStart;
+            end = s.WorkEnd;
+        }
+
+        if (weekdays.HasFlag(Weekdays.Sat) || weekdays.HasFlag(Weekdays.Sun))
+        {
+            return true;
+        }
+
+        return start > end && end > TimeSpan.Zero && weekdays.HasFlag(Weekdays.Fri);
+    }
+
     public static bool AllowedNow(PeriodDefinition definition, DateTimeOffset now, AppSettings s)
     {
         ArgumentNullException.ThrowIfNull(definition);

--- a/ShuffleTask.Domain/PeriodDefinition.cs
+++ b/ShuffleTask.Domain/PeriodDefinition.cs
@@ -1,0 +1,82 @@
+namespace ShuffleTask.Domain.Entities;
+
+[Flags]
+public enum PeriodDefinitionMode
+{
+    None = 0,
+    AlignWithWorkHours = 1,
+    OffWorkRelativeToWorkHours = 2
+}
+
+public class PeriodDefinition
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public Weekdays Weekdays { get; set; }
+
+    public TimeSpan? StartTime { get; set; }
+
+    public TimeSpan? EndTime { get; set; }
+
+    public bool IsAllDay { get; set; }
+
+    public PeriodDefinitionMode Mode { get; set; }
+}
+
+public static class PeriodDefinitionCatalog
+{
+    public const string AnyId = "any";
+    public const string WorkId = "work";
+    public const string OffWorkId = "off-work";
+
+    public static readonly Weekdays AllWeekdays =
+        Weekdays.Sun | Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri | Weekdays.Sat;
+
+    public static readonly PeriodDefinition Any = new()
+    {
+        Id = AnyId,
+        Name = "Any time",
+        Weekdays = AllWeekdays,
+        IsAllDay = true,
+        Mode = PeriodDefinitionMode.None
+    };
+
+    public static readonly PeriodDefinition Work = new()
+    {
+        Id = WorkId,
+        Name = "Work hours",
+        Weekdays = Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri,
+        IsAllDay = false,
+        Mode = PeriodDefinitionMode.AlignWithWorkHours
+    };
+
+    public static readonly PeriodDefinition OffWork = new()
+    {
+        Id = OffWorkId,
+        Name = "Off hours",
+        Weekdays = AllWeekdays,
+        IsAllDay = false,
+        Mode = PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours
+    };
+
+    private static readonly IReadOnlyDictionary<string, PeriodDefinition> BuiltIns =
+        new Dictionary<string, PeriodDefinition>(StringComparer.OrdinalIgnoreCase)
+        {
+            [AnyId] = Any,
+            [WorkId] = Work,
+            [OffWorkId] = OffWork
+        };
+
+    public static bool TryGet(string? id, out PeriodDefinition definition)
+    {
+        if (!string.IsNullOrWhiteSpace(id) && BuiltIns.TryGetValue(id, out definition!))
+        {
+            return true;
+        }
+
+        definition = Any;
+        return false;
+    }
+}

--- a/ShuffleTask.Domain/TaskItemData.cs
+++ b/ShuffleTask.Domain/TaskItemData.cs
@@ -28,6 +28,18 @@ public abstract class TaskItemData
 
     public AllowedPeriod AllowedPeriod { get; set; }
 
+    public string? PeriodDefinitionId { get; set; }
+
+    public TimeSpan? AdHocStartTime { get; set; }
+
+    public TimeSpan? AdHocEndTime { get; set; }
+
+    public Weekdays? AdHocWeekdays { get; set; }
+
+    public bool AdHocIsAllDay { get; set; }
+
+    public PeriodDefinitionMode AdHocMode { get; set; }
+
     public bool AutoShuffleAllowed { get; set; } = true;
 
     public TimeSpan? CustomStartTime { get; set; }
@@ -85,6 +97,12 @@ public abstract class TaskItemData
         IntervalDays = source.IntervalDays;
         LastDoneAt = source.LastDoneAt;
         AllowedPeriod = source.AllowedPeriod;
+        PeriodDefinitionId = source.PeriodDefinitionId;
+        AdHocStartTime = source.AdHocStartTime;
+        AdHocEndTime = source.AdHocEndTime;
+        AdHocWeekdays = source.AdHocWeekdays;
+        AdHocIsAllDay = source.AdHocIsAllDay;
+        AdHocMode = source.AdHocMode;
         AutoShuffleAllowed = source.AutoShuffleAllowed;
         CustomStartTime = source.CustomStartTime;
         CustomEndTime = source.CustomEndTime;

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -70,6 +70,12 @@ public class StorageService : IStorageService
             await AddCol("IntervalDays", IntegerSqlType, "0");
             await AddCol("LastDoneAt", "TEXT", "NULL");
             await AddCol("AllowedPeriod", IntegerSqlType, "0");
+            await AddCol("PeriodDefinitionId", "TEXT", "NULL");
+            await AddCol("AdHocStartTime", "TEXT", "NULL");
+            await AddCol("AdHocEndTime", "TEXT", "NULL");
+            await AddCol("AdHocWeekdays", IntegerSqlType, "NULL");
+            await AddCol("AdHocIsAllDay", IntegerSqlType, "0");
+            await AddCol("AdHocMode", IntegerSqlType, "0");
             await AddCol("AutoShuffleAllowed", IntegerSqlType, "1");
             await AddCol("CustomStartTime", "TEXT", "NULL");
             await AddCol("CustomEndTime", "TEXT", "NULL");

--- a/ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs
+++ b/ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs
@@ -821,7 +821,7 @@ public class ShuffleCoordinatorService : IDisposable
         return TimeWindowService.AllowedNow(task, when, settings);
     }
 
-    private static bool ShouldDelayForWeekend(IReadOnlyList<TaskItem> tasks, DateTimeOffset target)
+    private bool ShouldDelayForWeekend(IReadOnlyList<TaskItem> tasks, DateTimeOffset target)
     {
         if (!TimeWindowService.IsWeekend(target))
         {
@@ -846,7 +846,7 @@ public class ShuffleCoordinatorService : IDisposable
                 continue;
             }
 
-            if (TimeWindowService.AllowedNow(task, target, settings))
+            if (TimeWindowService.AllowsWeekend(task, _settings))
             {
                 return false;
             }

--- a/ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs
+++ b/ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs
@@ -818,7 +818,7 @@ public class ShuffleCoordinatorService : IDisposable
             return false;
         }
 
-        return TimeWindowService.AllowedNow(task.AllowedPeriod, when, settings);
+        return TimeWindowService.AllowedNow(task, when, settings);
     }
 
     private static bool ShouldDelayForWeekend(IReadOnlyList<TaskItem> tasks, DateTimeOffset target)
@@ -846,20 +846,12 @@ public class ShuffleCoordinatorService : IDisposable
                 continue;
             }
 
-            if (task.AllowedPeriod is AllowedPeriod.Any or AllowedPeriod.OffWork)
+            if (TimeWindowService.AllowedNow(task, target, settings))
             {
                 return false;
             }
 
-            if (task.AllowedPeriod is AllowedPeriod.Custom)
-            {
-                return false;
-            }
-
-            if (task.AllowedPeriod is AllowedPeriod.Work)
-            {
-                hasWeekendBlocked = true;
-            }
+            hasWeekendBlocked = true;
         }
 
         return hasWeekendBlocked;


### PR DESCRIPTION
### Motivation
- Introduce a first-class model for named and ad-hoc scheduling periods so tasks can reference reusable period definitions or carry task-local ad-hoc windows.
- Support richer semantics such as “align with work hours” and “off-work relative to work hours” via flags on the period model.
- Preserve compatibility with the existing `AllowedPeriod` enum during migration by mapping legacy enum values to built-in `PeriodDefinition`s.

### Description
- Added `PeriodDefinition`, `PeriodDefinitionMode`, and a small built-in catalog in `ShuffleTask.Domain/PeriodDefinition.cs` with IDs for `any`, `work`, and `off-work` and flags for alignment/relative semantics. 
- Extended `TaskItemData` with `PeriodDefinitionId` and ad-hoc payload fields (`AdHocStartTime`, `AdHocEndTime`, `AdHocWeekdays`, `AdHocIsAllDay`, `AdHocMode`) so tasks can reference named periods or store inline custom definitions. 
- Reworked `TimeWindowService` so it exposes `AllowedNow` overloads that accept a `PeriodDefinition` or a `TaskItem`, implements `ResolveDefinition` (lookup built-ins, build ad-hoc, or map legacy `AllowedPeriod`), and evaluates weekday/time/flag semantics accordingly. 
- Updated `ManualShuffleService` to set a neutral `PeriodDefinitionId`/ad-hoc payload when manual shuffle ignores allowed periods, updated `ShuffleCoordinatorService` weekend scheduling checks to call `TimeWindowService.AllowedNow(task, ...)`, and added persistence schema migration columns in `StorageService` for the new task fields.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f3fff296c8326a62e3c67bfde5491)