### PR TITLE
Add PeriodDefinition persistence and task mapping

### DIFF
--- a/ShuffleTask.Application/Abstractions/IStorageService.cs
+++ b/ShuffleTask.Application/Abstractions/IStorageService.cs
@@ -11,6 +11,11 @@ public interface IStorageService
     Task AddTaskAsync(TaskItem item);
     Task UpdateTaskAsync(TaskItem item);
     Task DeleteTaskAsync(string id);
+    Task<List<PeriodDefinition>> GetPeriodDefinitionsAsync();
+    Task<PeriodDefinition?> GetPeriodDefinitionAsync(string id);
+    Task AddPeriodDefinitionAsync(PeriodDefinition definition);
+    Task UpdatePeriodDefinitionAsync(PeriodDefinition definition);
+    Task DeletePeriodDefinitionAsync(string id);
     Task<TaskItem?> MarkTaskDoneAsync(string id);
     Task<TaskItem?> SnoozeTaskAsync(string id, TimeSpan duration);
     Task<TaskItem?> ResumeTaskAsync(string id);

--- a/ShuffleTask.Persistence/Models/PeriodDefinitionRecord.cs
+++ b/ShuffleTask.Persistence/Models/PeriodDefinitionRecord.cs
@@ -1,0 +1,53 @@
+using SQLite;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Persistence.Models;
+
+[Table("PeriodDefinition")]
+internal sealed class PeriodDefinitionRecord
+{
+    [PrimaryKey]
+    public string Id { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public Weekdays Weekdays { get; set; }
+
+    public TimeSpan? StartTime { get; set; }
+
+    public TimeSpan? EndTime { get; set; }
+
+    public bool IsAllDay { get; set; }
+
+    public PeriodDefinitionMode Mode { get; set; }
+
+    public static PeriodDefinitionRecord FromDomain(PeriodDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        return new PeriodDefinitionRecord
+        {
+            Id = definition.Id,
+            Name = definition.Name,
+            Weekdays = definition.Weekdays,
+            StartTime = definition.StartTime,
+            EndTime = definition.EndTime,
+            IsAllDay = definition.IsAllDay,
+            Mode = definition.Mode
+        };
+    }
+
+    public PeriodDefinition ToDomain()
+    {
+        return new PeriodDefinition
+        {
+            Id = Id,
+            Name = Name,
+            Weekdays = Weekdays,
+            StartTime = StartTime,
+            EndTime = EndTime,
+            IsAllDay = IsAllDay,
+            Mode = Mode
+        };
+    }
+}

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -563,6 +563,11 @@ public class StorageService : IStorageService
             return;
         }
 
+        if (IsCustomPeriodDefinitionId(item.PeriodDefinitionId))
+        {
+            return;
+        }
+
         item.AdHocStartTime = null;
         item.AdHocEndTime = null;
         item.AdHocWeekdays = null;


### PR DESCRIPTION
### Motivation
- Introduce persisted named period definitions so tasks can reference shared time windows instead of only inline ad-hoc fields.
- Ensure the storage schema and CRUD layer support both referenced `PeriodDefinition` records and legacy/inline ad-hoc fields without mixing them on save.

### Description
- Add a new persistence model `PeriodDefinitionRecord` in `ShuffleTask.Persistence/Models` and create its table during `StorageService.InitializeAsync` via `CreateTableAsync<PeriodDefinitionRecord>()`.
- Extend `StorageService` with CRUD APIs for period definitions: `GetPeriodDefinitionsAsync`, `GetPeriodDefinitionAsync`, `AddPeriodDefinitionAsync`, `UpdatePeriodDefinitionAsync`, and `DeletePeriodDefinitionAsync`.
- Ensure task reads hydrate referenced definitions by adding `ApplyPeriodDefinitionsAsync` / `ApplyPeriodDefinitionAsync` which populate task ad-hoc fields from a referenced `PeriodDefinitionRecord`, and call this when returning tasks from `GetTasksAsync`, `GetTaskAsync`, and lifecycle operations.
- Normalize task writes by introducing `BuildTaskRecord` / `NormalizePeriodDefinition` to clear ad-hoc fields when `PeriodDefinitionId` is set so saved `TaskItem` records do not mix referenced definitions with inline ad-hoc fields.
- Update the storage contract `IStorageService` to expose the new period-definition methods and update test doubles (`StorageServiceStub` and `InMemoryStorageService`) to implement the same APIs and the task hydration/normalization behavior.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4b875d6883269259bf3eb17ed6f3)