### PR TITLE
Add editable preset period definitions and settings controls

### DIFF
--- a/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
+++ b/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
@@ -22,6 +22,10 @@ internal sealed class InMemoryStorageService : IStorageService
     public Task InitializeAsync()
     {
         _initialized = true;
+        foreach (var preset in PeriodDefinitionCatalog.CreatePresetDefinitions())
+        {
+            _periodDefinitions[preset.Id] = Clone(preset);
+        }
         return Task.CompletedTask;
     }
 

--- a/ShuffleTask.Domain/PeriodDefinition.cs
+++ b/ShuffleTask.Domain/PeriodDefinition.cs
@@ -30,6 +30,11 @@ public static class PeriodDefinitionCatalog
     public const string AnyId = "any";
     public const string WorkId = "work";
     public const string OffWorkId = "off-work";
+    public const string WeekdaysId = "weekdays";
+    public const string WeekendsId = "weekends";
+    public const string MorningsId = "mornings";
+    public const string EveningsId = "evenings";
+    public const string LunchBreakId = "lunch-break";
 
     public static readonly Weekdays AllWeekdays =
         Weekdays.Sun | Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri | Weekdays.Sat;
@@ -61,6 +66,57 @@ public static class PeriodDefinitionCatalog
         Mode = PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours
     };
 
+    public static readonly PeriodDefinition Weekdays = new()
+    {
+        Id = WeekdaysId,
+        Name = "Weekdays",
+        Weekdays = Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri,
+        IsAllDay = true,
+        Mode = PeriodDefinitionMode.None
+    };
+
+    public static readonly PeriodDefinition Weekends = new()
+    {
+        Id = WeekendsId,
+        Name = "Weekends",
+        Weekdays = Weekdays.Sun | Weekdays.Sat,
+        IsAllDay = true,
+        Mode = PeriodDefinitionMode.None
+    };
+
+    public static readonly PeriodDefinition Mornings = new()
+    {
+        Id = MorningsId,
+        Name = "Mornings",
+        Weekdays = AllWeekdays,
+        StartTime = new TimeSpan(7, 0, 0),
+        EndTime = new TimeSpan(10, 0, 0),
+        IsAllDay = false,
+        Mode = PeriodDefinitionMode.None
+    };
+
+    public static readonly PeriodDefinition Evenings = new()
+    {
+        Id = EveningsId,
+        Name = "Evenings",
+        Weekdays = AllWeekdays,
+        StartTime = new TimeSpan(18, 0, 0),
+        EndTime = new TimeSpan(21, 0, 0),
+        IsAllDay = false,
+        Mode = PeriodDefinitionMode.None
+    };
+
+    public static readonly PeriodDefinition LunchBreak = new()
+    {
+        Id = LunchBreakId,
+        Name = "Lunch break",
+        Weekdays = AllWeekdays,
+        StartTime = new TimeSpan(12, 0, 0),
+        EndTime = new TimeSpan(13, 0, 0),
+        IsAllDay = false,
+        Mode = PeriodDefinitionMode.None
+    };
+
     private static readonly IReadOnlyDictionary<string, PeriodDefinition> BuiltIns =
         new Dictionary<string, PeriodDefinition>(StringComparer.OrdinalIgnoreCase)
         {
@@ -68,6 +124,18 @@ public static class PeriodDefinitionCatalog
             [WorkId] = Work,
             [OffWorkId] = OffWork
         };
+
+    public static IReadOnlyList<PeriodDefinition> CreatePresetDefinitions()
+    {
+        return new List<PeriodDefinition>
+        {
+            CreatePreset(Weekdays),
+            CreatePreset(Weekends),
+            CreatePreset(Mornings),
+            CreatePreset(Evenings),
+            CreatePreset(LunchBreak)
+        };
+    }
 
     public static bool TryGet(string? id, out PeriodDefinition definition)
     {
@@ -78,5 +146,19 @@ public static class PeriodDefinitionCatalog
 
         definition = Any;
         return false;
+    }
+
+    private static PeriodDefinition CreatePreset(PeriodDefinition template)
+    {
+        return new PeriodDefinition
+        {
+            Id = template.Id,
+            Name = template.Name,
+            Weekdays = template.Weekdays,
+            StartTime = template.StartTime,
+            EndTime = template.EndTime,
+            IsAllDay = template.IsAllDay,
+            Mode = template.Mode
+        };
     }
 }

--- a/ShuffleTask.Domain/PeriodDefinition.cs
+++ b/ShuffleTask.Domain/PeriodDefinition.cs
@@ -122,7 +122,12 @@ public static class PeriodDefinitionCatalog
         {
             [AnyId] = Any,
             [WorkId] = Work,
-            [OffWorkId] = OffWork
+            [OffWorkId] = OffWork,
+            [WeekdaysId] = Weekdays,
+            [WeekendsId] = Weekends,
+            [MorningsId] = Mornings,
+            [EveningsId] = Evenings,
+            [LunchBreakId] = LunchBreak
         };
 
     public static IReadOnlyList<PeriodDefinition> CreatePresetDefinitions()

--- a/ShuffleTask.Domain/PeriodDefinition.cs
+++ b/ShuffleTask.Domain/PeriodDefinition.cs
@@ -37,7 +37,7 @@ public static class PeriodDefinitionCatalog
     public const string LunchBreakId = "lunch-break";
 
     public static readonly Weekdays AllWeekdays =
-        Weekdays.Sun | Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri | Weekdays.Sat;
+        Entities.Weekdays.Sun| Entities.Weekdays.Mon | Entities.Weekdays.Tue | Entities.Weekdays.Wed | Entities.Weekdays.Thu | Entities.Weekdays.Fri | Entities.Weekdays.Sat;
 
     public static readonly PeriodDefinition Any = new()
     {
@@ -52,7 +52,7 @@ public static class PeriodDefinitionCatalog
     {
         Id = WorkId,
         Name = "Work hours",
-        Weekdays = Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri,
+        Weekdays = Entities.Weekdays.Mon | Entities.Weekdays.Tue | Entities.Weekdays.Wed | Entities.Weekdays.Thu | Entities.Weekdays.Fri,
         IsAllDay = false,
         Mode = PeriodDefinitionMode.AlignWithWorkHours
     };
@@ -70,7 +70,7 @@ public static class PeriodDefinitionCatalog
     {
         Id = WeekdaysId,
         Name = "Weekdays",
-        Weekdays = Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri,
+        Weekdays = Entities.Weekdays.Mon | Entities.Weekdays.Tue | Entities.Weekdays.Wed | Entities.Weekdays.Thu | Entities.Weekdays.Fri,
         IsAllDay = true,
         Mode = PeriodDefinitionMode.None
     };
@@ -79,7 +79,7 @@ public static class PeriodDefinitionCatalog
     {
         Id = WeekendsId,
         Name = "Weekends",
-        Weekdays = Weekdays.Sun | Weekdays.Sat,
+        Weekdays = Entities.Weekdays.Sun | Entities.Weekdays.Sat,
         IsAllDay = true,
         Mode = PeriodDefinitionMode.None
     };

--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -47,6 +47,12 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <Label Grid.Row="0"
@@ -343,7 +349,49 @@
                         IsVisible="{Binding IsLoggedIn}" />
             </Grid>
 
-            <Grid Grid.Row="27"
+            <Label Grid.Row="27"
+                   Text="Morning start"
+                   VerticalOptions="Center" />
+            <TimePicker Grid.Row="27"
+                        Grid.Column="1"
+                        Time="{Binding MorningStart}" />
+
+            <Label Grid.Row="28"
+                   Text="Morning end"
+                   VerticalOptions="Center" />
+            <TimePicker Grid.Row="28"
+                        Grid.Column="1"
+                        Time="{Binding MorningEnd}" />
+
+            <Label Grid.Row="29"
+                   Text="Evening start"
+                   VerticalOptions="Center" />
+            <TimePicker Grid.Row="29"
+                        Grid.Column="1"
+                        Time="{Binding EveningStart}" />
+
+            <Label Grid.Row="30"
+                   Text="Evening end"
+                   VerticalOptions="Center" />
+            <TimePicker Grid.Row="30"
+                        Grid.Column="1"
+                        Time="{Binding EveningEnd}" />
+
+            <Label Grid.Row="31"
+                   Text="Lunch start"
+                   VerticalOptions="Center" />
+            <TimePicker Grid.Row="31"
+                        Grid.Column="1"
+                        Time="{Binding LunchStart}" />
+
+            <Label Grid.Row="32"
+                   Text="Lunch end"
+                   VerticalOptions="Center" />
+            <TimePicker Grid.Row="32"
+                        Grid.Column="1"
+                        Time="{Binding LunchEnd}" />
+
+            <Grid Grid.Row="33"
                   Grid.ColumnSpan="2"
                   ColumnDefinitions="*,*"
                   ColumnSpacing="16">
@@ -355,7 +403,7 @@
                         Command="{Binding ShufflePreviewCommand}" />
             </Grid>
 
-            <ActivityIndicator Grid.Row="28"
+            <ActivityIndicator Grid.Row="34"
                                Grid.ColumnSpan="2"
                                HorizontalOptions="Center"
                                IsVisible="{Binding IsBusy}"

--- a/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
+++ b/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
@@ -36,6 +36,10 @@ public class StorageServiceStub : IStorageService
     {
         InitializeCallCount++;
         _initialized = true;
+        foreach (var preset in PeriodDefinitionCatalog.CreatePresetDefinitions())
+        {
+            _periodDefinitions[preset.Id] = Clone(preset);
+        }
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
### Motivation
- Provide built-in, editable period presets for common time windows (weekdays, weekends, mornings, evenings, lunch) so they can be reused and adjusted by users. 
- Persist user-editable presets while keeping `Work`/`OffWork` behavior aligned to `AppSettings` work hours.
- Expose simple Settings UI so default time ranges for mornings/evenings/lunch can be changed without opening a separate editor.

### Description
- Added new preset IDs and definitions to `PeriodDefinitionCatalog` for `Weekdays`, `Weekends`, `Mornings` (07:00–10:00), `Evenings` (18:00–21:00) and `LunchBreak` (12:00–13:00) and a helper `CreatePresetDefinitions()` that returns them as editable templates. (`ShuffleTask.Domain/PeriodDefinition.cs`).
- Seeded these presets into persistent storage on initialization via `EnsurePresetPeriodDefinitionsAsync()` so presets exist as editable `PeriodDefinitionRecord`s in the DB. (`ShuffleTask.Persistence/StorageService.cs`).
- Seeded the same presets into test doubles to keep tests and in-memory scenarios consistent by adding them in `InitializeAsync()` of `InMemoryStorageService` and `StorageServiceStub`. (`ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs`, `ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs`).
- Exposed editing controls for the default time windows by adding `TimeSpan` properties `MorningStart`, `MorningEnd`, `EveningStart`, `EveningEnd`, `LunchStart`, `LunchEnd` and lifecycle helpers `LoadPresetDefinitionsAsync()`, `PersistPresetDefinitionsAsync()` and `UpsertPresetDefinitionAsync()` in the settings VM to load/save the persisted presets. (`ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs`).
- Added corresponding `TimePicker` entries to the settings page bound to the new VM properties so users can edit morning/evening/lunch ranges in the app UI. (`ShuffleTask.Presentation/Views/SettingsPage.xaml`).
- Kept `Work` / `OffWork` presets unchanged and still represented using alignment modes (no fixed times are stored for those presets).

### Testing
- No automated tests were executed as part of this change; test runners were not invoked during the rollout. 
- Test doubles were updated to include preset seeding so existing unit tests that rely on period definitions should not regress when run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b7ab356c83268259389a804ece41)