### PR TITLE
Add period definition selector and modal editor

### DIFF
--- a/ShuffleTask.Application/Services/TimeWindowService.cs
+++ b/ShuffleTask.Application/Services/TimeWindowService.cs
@@ -111,7 +111,7 @@ public static class TimeWindowService
             return definition;
         }
 
-        if (TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
+        if (TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
         {
             return adHocDefinition;
         }
@@ -121,33 +121,6 @@ public static class TimeWindowService
             AllowedPeriod.Custom => BuildLegacyCustomDefinition(task),
             _ => GetDefinitionForAllowedPeriod(task.AllowedPeriod)
         };
-    }
-
-    private static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)
-    {
-        bool hasAdHocDefinition = task.AdHocStartTime.HasValue
-            || task.AdHocEndTime.HasValue
-            || task.AdHocWeekdays.HasValue
-            || task.AdHocIsAllDay
-            || task.AdHocMode != PeriodDefinitionMode.None;
-
-        if (!hasAdHocDefinition)
-        {
-            definition = PeriodDefinitionCatalog.Any;
-            return false;
-        }
-
-        definition = new PeriodDefinition
-        {
-            Id = string.Empty,
-            Name = "Ad-hoc",
-            StartTime = task.AdHocStartTime,
-            EndTime = task.AdHocEndTime,
-            Weekdays = task.AdHocWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
-            IsAllDay = task.AdHocIsAllDay,
-            Mode = task.AdHocMode
-        };
-        return true;
     }
 
     private static PeriodDefinition BuildLegacyCustomDefinition(TaskItem task)

--- a/ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs
+++ b/ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs
@@ -1,0 +1,38 @@
+namespace ShuffleTask.Domain.Entities;
+
+public static class TaskItemPeriodDefinitionHelper
+{
+    public static bool HasAdHocDefinition(TaskItem task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        return task.AdHocStartTime.HasValue
+            || task.AdHocEndTime.HasValue
+            || task.AdHocWeekdays.HasValue
+            || task.AdHocIsAllDay
+            || task.AdHocMode != PeriodDefinitionMode.None;
+    }
+
+    public static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        if (!HasAdHocDefinition(task))
+        {
+            definition = PeriodDefinitionCatalog.Any;
+            return false;
+        }
+
+        definition = new PeriodDefinition
+        {
+            Id = string.Empty,
+            Name = "Ad-hoc",
+            StartTime = task.AdHocStartTime,
+            EndTime = task.AdHocEndTime,
+            Weekdays = task.AdHocWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
+            IsAllDay = task.AdHocIsAllDay,
+            Mode = task.AdHocMode
+        };
+        return true;
+    }
+}

--- a/ShuffleTask.Presentation/MauiProgram.cs
+++ b/ShuffleTask.Presentation/MauiProgram.cs
@@ -85,6 +85,7 @@ public static partial class MauiProgram
         });
         builder.Services.AddSingleton<TasksViewModel>();
         builder.Services.AddSingleton<EditTaskViewModel>();
+        builder.Services.AddSingleton<PeriodDefinitionEditorViewModel>();
         builder.Services.AddSingleton<SettingsViewModel>();
 
         // Views
@@ -94,6 +95,7 @@ public static partial class MauiProgram
         builder.Services.AddSingleton<MainPage>();
         builder.Services.AddSingleton<TasksPage>();
         builder.Services.AddSingleton<EditTaskPage>();
+        builder.Services.AddSingleton<PeriodDefinitionEditorPage>();
 
 #if DEBUG
         var loggingBuilder = builder.Logging;

--- a/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
+++ b/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
@@ -65,6 +65,9 @@
       <MauiXaml Update="Views\EditTaskPage.xaml">
         <Generator>MSBuild:Compile</Generator>
       </MauiXaml>
+      <MauiXaml Update="Views\PeriodDefinitionEditorPage.xaml">
+        <Generator>MSBuild:Compile</Generator>
+      </MauiXaml>
       <MauiXaml Update="Views\DashboardPage.xaml">
         <Generator>MSBuild:Compile</Generator>
       </MauiXaml>

--- a/ShuffleTask.Presentation/Utilities/AlignmentModeCatalog.cs
+++ b/ShuffleTask.Presentation/Utilities/AlignmentModeCatalog.cs
@@ -1,0 +1,24 @@
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.ViewModels;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+public static class AlignmentModeCatalog
+{
+    public static IReadOnlyList<AlignmentModeOption> Defaults { get; } =
+        new[]
+        {
+            new AlignmentModeOption(
+                "Fixed time window",
+                "Use the start and end times below.",
+                PeriodDefinitionMode.None),
+            new AlignmentModeOption(
+                "Align with work hours",
+                "Uses Settings → Work hours for the time range.",
+                PeriodDefinitionMode.AlignWithWorkHours),
+            new AlignmentModeOption(
+                "Align with off-work hours",
+                "Schedules outside Settings → Work hours (includes weekends).",
+                PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours)
+        };
+}

--- a/ShuffleTask.Presentation/Utilities/PeriodDefinitionFormatter.cs
+++ b/ShuffleTask.Presentation/Utilities/PeriodDefinitionFormatter.cs
@@ -1,0 +1,191 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+internal static class PeriodDefinitionFormatter
+{
+    public static string FormatAllowedPeriodLabel(TaskItem task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        if (PeriodDefinitionCatalog.TryGet(task.PeriodDefinitionId, out PeriodDefinition definition))
+        {
+            return FormatDefinitionLabel(definition);
+        }
+
+        if (!string.IsNullOrWhiteSpace(task.PeriodDefinitionId)
+            && TryBuildAdHocDefinition(task, out PeriodDefinition presetDefinition))
+        {
+            return $"Preset ({DescribeDefinition(presetDefinition)})";
+        }
+
+        if (TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
+        {
+            return $"Ad-hoc ({DescribeDefinition(adHocDefinition)})";
+        }
+
+        return task.AllowedPeriod switch
+        {
+            AllowedPeriod.Work => "Work hours (Mon–Fri)",
+            AllowedPeriod.OffWork => "Off hours (includes weekends)",
+            AllowedPeriod.Custom => FormatLegacyCustom(task),
+            _ => "Any time"
+        };
+    }
+
+    public static string DescribeDefinition(PeriodDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        string weekdays = FormatWeekdays(definition.Weekdays);
+        string timeWindow = FormatTimeWindow(definition);
+        string alignment = FormatAlignment(definition.Mode);
+
+        if (!string.IsNullOrWhiteSpace(alignment))
+        {
+            return $"{weekdays}, {timeWindow}. {alignment}";
+        }
+
+        return $"{weekdays}, {timeWindow}.";
+    }
+
+    private static string FormatDefinitionLabel(PeriodDefinition definition)
+    {
+        if (string.Equals(definition.Id, PeriodDefinitionCatalog.AnyId, StringComparison.OrdinalIgnoreCase))
+        {
+            return "Any time";
+        }
+
+        if (string.Equals(definition.Id, PeriodDefinitionCatalog.WorkId, StringComparison.OrdinalIgnoreCase))
+        {
+            return "Work hours";
+        }
+
+        if (string.Equals(definition.Id, PeriodDefinitionCatalog.OffWorkId, StringComparison.OrdinalIgnoreCase))
+        {
+            return "Off hours";
+        }
+
+        return definition.Name;
+    }
+
+    private static string FormatWeekdays(Weekdays weekdays)
+    {
+        if (weekdays == Weekdays.None)
+        {
+            return "Any day";
+        }
+
+        if (weekdays == PeriodDefinitionCatalog.AllWeekdays)
+        {
+            return "Every day";
+        }
+
+        if (weekdays == (Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri))
+        {
+            return "Weekdays";
+        }
+
+        if (weekdays == (Weekdays.Sat | Weekdays.Sun))
+        {
+            return "Weekends";
+        }
+
+        var labels = new List<string>();
+
+        void Add(Weekdays day, string label)
+        {
+            if (weekdays.HasFlag(day))
+            {
+                labels.Add(label);
+            }
+        }
+
+        Add(Weekdays.Mon, "Mon");
+        Add(Weekdays.Tue, "Tue");
+        Add(Weekdays.Wed, "Wed");
+        Add(Weekdays.Thu, "Thu");
+        Add(Weekdays.Fri, "Fri");
+        Add(Weekdays.Sat, "Sat");
+        Add(Weekdays.Sun, "Sun");
+
+        return string.Join(", ", labels);
+    }
+
+    private static string FormatTimeWindow(PeriodDefinition definition)
+    {
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours))
+        {
+            return "Off-work hours";
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours))
+        {
+            return "Work hours";
+        }
+
+        if (definition.IsAllDay)
+        {
+            return "All day";
+        }
+
+        if (definition.StartTime.HasValue && definition.EndTime.HasValue)
+        {
+            return $"{definition.StartTime:hh\\:mm}–{definition.EndTime:hh\\:mm}";
+        }
+
+        return "Custom hours";
+    }
+
+    private static string FormatAlignment(PeriodDefinitionMode mode)
+    {
+        if (mode.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours))
+        {
+            return "Aligns to off-work time based on Settings → Work hours (includes weekends).";
+        }
+
+        if (mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours))
+        {
+            return "Aligns to Settings → Work hours.";
+        }
+
+        return string.Empty;
+    }
+
+    private static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)
+    {
+        bool hasAdHocDefinition = task.AdHocStartTime.HasValue
+            || task.AdHocEndTime.HasValue
+            || task.AdHocWeekdays.HasValue
+            || task.AdHocIsAllDay
+            || task.AdHocMode != PeriodDefinitionMode.None;
+
+        if (!hasAdHocDefinition)
+        {
+            definition = PeriodDefinitionCatalog.Any;
+            return false;
+        }
+
+        definition = new PeriodDefinition
+        {
+            Id = string.Empty,
+            Name = "Ad-hoc",
+            StartTime = task.AdHocStartTime,
+            EndTime = task.AdHocEndTime,
+            Weekdays = task.AdHocWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
+            IsAllDay = task.AdHocIsAllDay,
+            Mode = task.AdHocMode
+        };
+        return true;
+    }
+
+    private static string FormatLegacyCustom(TaskItem task)
+    {
+        if (task.CustomStartTime.HasValue && task.CustomEndTime.HasValue)
+        {
+            return $"Custom hours ({task.CustomStartTime:hh\\:mm}–{task.CustomEndTime:hh\\:mm})";
+        }
+
+        return "Custom hours";
+    }
+}

--- a/ShuffleTask.Presentation/Utilities/PeriodDefinitionFormatter.cs
+++ b/ShuffleTask.Presentation/Utilities/PeriodDefinitionFormatter.cs
@@ -14,12 +14,12 @@ internal static class PeriodDefinitionFormatter
         }
 
         if (!string.IsNullOrWhiteSpace(task.PeriodDefinitionId)
-            && TryBuildAdHocDefinition(task, out PeriodDefinition presetDefinition))
+            && TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition(task, out PeriodDefinition presetDefinition))
         {
             return $"Preset ({DescribeDefinition(presetDefinition)})";
         }
 
-        if (TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
+        if (TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
         {
             return $"Ad-hoc ({DescribeDefinition(adHocDefinition)})";
         }
@@ -150,33 +150,6 @@ internal static class PeriodDefinitionFormatter
         }
 
         return string.Empty;
-    }
-
-    private static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)
-    {
-        bool hasAdHocDefinition = task.AdHocStartTime.HasValue
-            || task.AdHocEndTime.HasValue
-            || task.AdHocWeekdays.HasValue
-            || task.AdHocIsAllDay
-            || task.AdHocMode != PeriodDefinitionMode.None;
-
-        if (!hasAdHocDefinition)
-        {
-            definition = PeriodDefinitionCatalog.Any;
-            return false;
-        }
-
-        definition = new PeriodDefinition
-        {
-            Id = string.Empty,
-            Name = "Ad-hoc",
-            StartTime = task.AdHocStartTime,
-            EndTime = task.AdHocEndTime,
-            Weekdays = task.AdHocWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
-            IsAllDay = task.AdHocIsAllDay,
-            Mode = task.AdHocMode
-        };
-        return true;
     }
 
     private static string FormatLegacyCustom(TaskItem task)

--- a/ShuffleTask.Presentation/Utilities/ViewModelWithWeekdaySelection.cs
+++ b/ShuffleTask.Presentation/Utilities/ViewModelWithWeekdaySelection.cs
@@ -1,0 +1,86 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+public abstract class ViewModelWithWeekdaySelection : ObservableObject
+{
+    private Weekdays _selectedWeekdays;
+
+    public Weekdays SelectedWeekdays
+    {
+        get => _selectedWeekdays;
+        set
+        {
+            if (SetProperty(ref _selectedWeekdays, value))
+            {
+                RaiseWeekdayPropertiesChanged();
+            }
+        }
+    }
+
+    protected static Weekdays ApplyWeekdaySelection(Weekdays current, Weekdays day, bool enabled)
+    {
+        return enabled ? current | day : current & ~day;
+    }
+
+    protected bool GetWeekday(Weekdays day) => _selectedWeekdays.HasFlag(day);
+
+    protected void SetWeekday(Weekdays day, bool isSelected)
+    {
+        SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
+    }
+
+    protected void RaiseWeekdayPropertiesChanged()
+    {
+        OnPropertyChanged(nameof(Sunday));
+        OnPropertyChanged(nameof(Monday));
+        OnPropertyChanged(nameof(Tuesday));
+        OnPropertyChanged(nameof(Wednesday));
+        OnPropertyChanged(nameof(Thursday));
+        OnPropertyChanged(nameof(Friday));
+        OnPropertyChanged(nameof(Saturday));
+    }
+
+    public bool Sunday
+    {
+        get => GetWeekday(Weekdays.Sun);
+        set => SetWeekday(Weekdays.Sun, value);
+    }
+
+    public bool Monday
+    {
+        get => GetWeekday(Weekdays.Mon);
+        set => SetWeekday(Weekdays.Mon, value);
+    }
+
+    public bool Tuesday
+    {
+        get => GetWeekday(Weekdays.Tue);
+        set => SetWeekday(Weekdays.Tue, value);
+    }
+
+    public bool Wednesday
+    {
+        get => GetWeekday(Weekdays.Wed);
+        set => SetWeekday(Weekdays.Wed, value);
+    }
+
+    public bool Thursday
+    {
+        get => GetWeekday(Weekdays.Thu);
+        set => SetWeekday(Weekdays.Thu, value);
+    }
+
+    public bool Friday
+    {
+        get => GetWeekday(Weekdays.Fri);
+        set => SetWeekday(Weekdays.Fri, value);
+    }
+
+    public bool Saturday
+    {
+        get => GetWeekday(Weekdays.Sat);
+        set => SetWeekday(Weekdays.Sat, value);
+    }
+}

--- a/ShuffleTask.Presentation/ViewModels/AlignmentModeOption.cs
+++ b/ShuffleTask.Presentation/ViewModels/AlignmentModeOption.cs
@@ -16,23 +16,4 @@ public sealed class AlignmentModeOption
     public string Description { get; }
 
     public PeriodDefinitionMode Mode { get; }
-
-    public static IReadOnlyList<AlignmentModeOption> CreateDefaults()
-    {
-        return new[]
-        {
-            new AlignmentModeOption(
-                "Fixed time window",
-                "Use the start and end times below.",
-                PeriodDefinitionMode.None),
-            new AlignmentModeOption(
-                "Align with work hours",
-                "Uses Settings → Work hours for the time range.",
-                PeriodDefinitionMode.AlignWithWorkHours),
-            new AlignmentModeOption(
-                "Align with off-work hours",
-                "Schedules outside Settings → Work hours (includes weekends).",
-                PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours)
-        };
-    }
 }

--- a/ShuffleTask.Presentation/ViewModels/AlignmentModeOption.cs
+++ b/ShuffleTask.Presentation/ViewModels/AlignmentModeOption.cs
@@ -1,0 +1,38 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.ViewModels;
+
+public sealed class AlignmentModeOption
+{
+    public AlignmentModeOption(string name, string description, PeriodDefinitionMode mode)
+    {
+        Name = name;
+        Description = description;
+        Mode = mode;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public PeriodDefinitionMode Mode { get; }
+
+    public static IReadOnlyList<AlignmentModeOption> CreateDefaults()
+    {
+        return new[]
+        {
+            new AlignmentModeOption(
+                "Fixed time window",
+                "Use the start and end times below.",
+                PeriodDefinitionMode.None),
+            new AlignmentModeOption(
+                "Align with work hours",
+                "Uses Settings → Work hours for the time range.",
+                PeriodDefinitionMode.AlignWithWorkHours),
+            new AlignmentModeOption(
+                "Align with off-work hours",
+                "Schedules outside Settings → Work hours (includes weekends).",
+                PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours)
+        };
+    }
+}

--- a/ShuffleTask.Presentation/ViewModels/DashboardViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/DashboardViewModel.cs
@@ -662,14 +662,7 @@ public partial class DashboardViewModel : ObservableObject
             _ => "Schedule unknown"
         };
 
-        string allowed = task.AllowedPeriod switch
-        {
-            AllowedPeriod.Any => "Any time",
-            AllowedPeriod.Work => "Work hours (Mon–Fri)",
-            AllowedPeriod.OffWork => "Off hours (includes weekends)",
-            AllowedPeriod.Custom => FormatCustomWindow(task),
-            _ => "Any time"
-        };
+        string allowed = PeriodDefinitionFormatter.FormatAllowedPeriodLabel(task);
 
         return $"{deadline} • {repeat} • {allowed}";
     }
@@ -702,13 +695,5 @@ public partial class DashboardViewModel : ObservableObject
         return string.Join(", ", names);
     }
 
-    private static string FormatCustomWindow(TaskItem task)
-    {
-        if (task.CustomStartTime.HasValue && task.CustomEndTime.HasValue)
-        {
-            return $"Custom hours ({task.CustomStartTime:hh\\:mm}–{task.CustomEndTime:hh\\:mm})";
-        }
-
-        return "Custom hours";
-    }
+    
 }

--- a/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
@@ -310,8 +310,12 @@ public partial class EditTaskViewModel : ObservableObject
         AutoShuffleAllowed = _workingCopy.AutoShuffleAllowed;
         AdHocStartTime = _workingCopy.AdHocStartTime ?? _workingCopy.CustomStartTime ?? new TimeSpan(9, 0, 0);
         AdHocEndTime = _workingCopy.AdHocEndTime ?? _workingCopy.CustomEndTime ?? new TimeSpan(17, 0, 0);
-        AdHocIsAllDay = _workingCopy.AdHocIsAllDay
-            || (_workingCopy.AllowedPeriod == AllowedPeriod.Custom && !_workingCopy.AdHocStartTime.HasValue && !_workingCopy.AdHocEndTime.HasValue);
+        bool isLegacyCustomAllDay = _workingCopy.AllowedPeriod == AllowedPeriod.Custom
+            && string.IsNullOrWhiteSpace(_workingCopy.PeriodDefinitionId)
+            && _workingCopy.AdHocMode == PeriodDefinitionMode.None
+            && !_workingCopy.AdHocStartTime.HasValue
+            && !_workingCopy.AdHocEndTime.HasValue;
+        AdHocIsAllDay = _workingCopy.AdHocIsAllDay || isLegacyCustomAllDay;
         IsPaused = _workingCopy.Paused;
         CutInLineMode = _workingCopy.CutInLineMode;
         SelectedWeekdays = _workingCopy.Weekdays;

--- a/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
@@ -8,14 +8,13 @@ using System.Collections.ObjectModel;
 
 namespace ShuffleTask.ViewModels;
 
-public partial class EditTaskViewModel : ObservableObject
+public partial class EditTaskViewModel : ViewModelWithWeekdaySelection
 {
     private readonly IStorageService _storage;
     private readonly TimeProvider _clock;
 
     private TaskItem _workingCopy = new();
 
-    private Weekdays _selectedWeekdays;
     private Weekdays _selectedAdHocWeekdays;
 
     private static readonly Weekdays AllWeekdays = Weekdays.Sun | Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri | Weekdays.Sat;
@@ -23,24 +22,6 @@ public partial class EditTaskViewModel : ObservableObject
     private const double MinSizePoints = 0.5;
     private const double MaxSizePoints = 13.0;
     private const double DefaultSizePoints = 3.0;
-
-    public Weekdays SelectedWeekdays
-    {
-        get => _selectedWeekdays;
-        set
-        {
-            if (SetProperty(ref _selectedWeekdays, value))
-            {
-                OnPropertyChanged(nameof(Sunday));
-                OnPropertyChanged(nameof(Monday));
-                OnPropertyChanged(nameof(Tuesday));
-                OnPropertyChanged(nameof(Wednesday));
-                OnPropertyChanged(nameof(Thursday));
-                OnPropertyChanged(nameof(Friday));
-                OnPropertyChanged(nameof(Saturday));
-            }
-        }
-    }
 
     public Weekdays SelectedAdHocWeekdays
     {
@@ -186,65 +167,11 @@ public partial class EditTaskViewModel : ObservableObject
         }
     }
 
-    private static Weekdays ApplyWeekdaySelection(Weekdays current, Weekdays day, bool enabled)
-    {
-        return enabled ? current | day : current & ~day;
-    }
-
-    private bool GetWeekday(Weekdays day) => _selectedWeekdays.HasFlag(day);
-
-    private void SetWeekday(Weekdays day, bool isSelected)
-    {
-        SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
-    }
-
     private bool GetAdHocWeekday(Weekdays day) => _selectedAdHocWeekdays.HasFlag(day);
 
     private void SetAdHocWeekday(Weekdays day, bool isSelected)
     {
         SelectedAdHocWeekdays = ApplyWeekdaySelection(SelectedAdHocWeekdays, day, isSelected);
-    }
-
-    public bool Sunday
-    {
-        get => GetWeekday(Weekdays.Sun);
-        set => SetWeekday(Weekdays.Sun, value);
-    }
-
-    public bool Monday
-    {
-        get => GetWeekday(Weekdays.Mon);
-        set => SetWeekday(Weekdays.Mon, value);
-    }
-
-    public bool Tuesday
-    {
-        get => GetWeekday(Weekdays.Tue);
-        set => SetWeekday(Weekdays.Tue, value);
-    }
-
-    public bool Wednesday
-    {
-        get => GetWeekday(Weekdays.Wed);
-        set => SetWeekday(Weekdays.Wed, value);
-    }
-
-    public bool Thursday
-    {
-        get => GetWeekday(Weekdays.Thu);
-        set => SetWeekday(Weekdays.Thu, value);
-    }
-
-    public bool Friday
-    {
-        get => GetWeekday(Weekdays.Fri);
-        set => SetWeekday(Weekdays.Fri, value);
-    }
-
-    public bool Saturday
-    {
-        get => GetWeekday(Weekdays.Sat);
-        set => SetWeekday(Weekdays.Sat, value);
     }
 
     public bool AdHocSunday

--- a/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
@@ -131,7 +131,7 @@ public partial class EditTaskViewModel : ViewModelWithWeekdaySelection
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         AppSettings = appSettings;
         DeadlineDate = GetTodayUtcDate();
-        AlignmentModeOptions = AlignmentModeOption.CreateDefaults();
+        AlignmentModeOptions = AlignmentModeCatalog.Defaults;
         SelectedAlignmentMode = AlignmentModeOptions[0];
     }
 

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
@@ -15,7 +15,7 @@ public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekd
     public PeriodDefinitionEditorViewModel(IStorageService storage)
     {
         _storage = storage;
-        AlignmentModeOptions = AlignmentModeOption.CreateDefaults();
+        AlignmentModeOptions = AlignmentModeCatalog.Defaults;
         SelectedAlignmentMode = AlignmentModeOptions[0];
         SelectedWeekdays = PeriodDefinitionCatalog.AllWeekdays;
     }

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
@@ -2,13 +2,13 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Utilities;
 
 namespace ShuffleTask.ViewModels;
 
-public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
+public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekdaySelection
 {
     private readonly IStorageService _storage;
-    private Weekdays _selectedWeekdays;
     private string? _definitionId;
     private bool _isNew = true;
 
@@ -21,24 +21,6 @@ public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
     }
 
     public IReadOnlyList<AlignmentModeOption> AlignmentModeOptions { get; }
-
-    public Weekdays SelectedWeekdays
-    {
-        get => _selectedWeekdays;
-        set
-        {
-            if (SetProperty(ref _selectedWeekdays, value))
-            {
-                OnPropertyChanged(nameof(Sunday));
-                OnPropertyChanged(nameof(Monday));
-                OnPropertyChanged(nameof(Tuesday));
-                OnPropertyChanged(nameof(Wednesday));
-                OnPropertyChanged(nameof(Thursday));
-                OnPropertyChanged(nameof(Friday));
-                OnPropertyChanged(nameof(Saturday));
-            }
-        }
-    }
 
     [ObservableProperty]
     private string name = string.Empty;
@@ -62,48 +44,6 @@ public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
     {
         get => _isNew;
         private set => SetProperty(ref _isNew, value);
-    }
-
-    public bool Sunday
-    {
-        get => GetWeekday(Weekdays.Sun);
-        set => SetWeekday(Weekdays.Sun, value);
-    }
-
-    public bool Monday
-    {
-        get => GetWeekday(Weekdays.Mon);
-        set => SetWeekday(Weekdays.Mon, value);
-    }
-
-    public bool Tuesday
-    {
-        get => GetWeekday(Weekdays.Tue);
-        set => SetWeekday(Weekdays.Tue, value);
-    }
-
-    public bool Wednesday
-    {
-        get => GetWeekday(Weekdays.Wed);
-        set => SetWeekday(Weekdays.Wed, value);
-    }
-
-    public bool Thursday
-    {
-        get => GetWeekday(Weekdays.Thu);
-        set => SetWeekday(Weekdays.Thu, value);
-    }
-
-    public bool Friday
-    {
-        get => GetWeekday(Weekdays.Fri);
-        set => SetWeekday(Weekdays.Fri, value);
-    }
-
-    public bool Saturday
-    {
-        get => GetWeekday(Weekdays.Sat);
-        set => SetWeekday(Weekdays.Sat, value);
     }
 
     public event EventHandler<PeriodDefinitionSavedEventArgs>? Saved;
@@ -182,15 +122,4 @@ public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
         }
     }
 
-    private static Weekdays ApplyWeekdaySelection(Weekdays current, Weekdays day, bool enabled)
-    {
-        return enabled ? current | day : current & ~day;
-    }
-
-    private bool GetWeekday(Weekdays day) => _selectedWeekdays.HasFlag(day);
-
-    private void SetWeekday(Weekdays day, bool isSelected)
-    {
-        SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
-    }
 }

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
@@ -1,0 +1,196 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.ViewModels;
+
+public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
+{
+    private readonly IStorageService _storage;
+    private Weekdays _selectedWeekdays;
+    private string? _definitionId;
+    private bool _isNew = true;
+
+    public PeriodDefinitionEditorViewModel(IStorageService storage)
+    {
+        _storage = storage;
+        AlignmentModeOptions = AlignmentModeOption.CreateDefaults();
+        SelectedAlignmentMode = AlignmentModeOptions[0];
+        SelectedWeekdays = PeriodDefinitionCatalog.AllWeekdays;
+    }
+
+    public IReadOnlyList<AlignmentModeOption> AlignmentModeOptions { get; }
+
+    public Weekdays SelectedWeekdays
+    {
+        get => _selectedWeekdays;
+        set
+        {
+            if (SetProperty(ref _selectedWeekdays, value))
+            {
+                OnPropertyChanged(nameof(Sunday));
+                OnPropertyChanged(nameof(Monday));
+                OnPropertyChanged(nameof(Tuesday));
+                OnPropertyChanged(nameof(Wednesday));
+                OnPropertyChanged(nameof(Thursday));
+                OnPropertyChanged(nameof(Friday));
+                OnPropertyChanged(nameof(Saturday));
+            }
+        }
+    }
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private bool isAllDay;
+
+    [ObservableProperty]
+    private TimeSpan startTime = new(9, 0, 0);
+
+    [ObservableProperty]
+    private TimeSpan endTime = new(17, 0, 0);
+
+    [ObservableProperty]
+    private AlignmentModeOption selectedAlignmentMode;
+
+    [ObservableProperty]
+    private bool isBusy;
+
+    public bool IsNew
+    {
+        get => _isNew;
+        private set => SetProperty(ref _isNew, value);
+    }
+
+    public bool Sunday
+    {
+        get => GetWeekday(Weekdays.Sun);
+        set => SetWeekday(Weekdays.Sun, value);
+    }
+
+    public bool Monday
+    {
+        get => GetWeekday(Weekdays.Mon);
+        set => SetWeekday(Weekdays.Mon, value);
+    }
+
+    public bool Tuesday
+    {
+        get => GetWeekday(Weekdays.Tue);
+        set => SetWeekday(Weekdays.Tue, value);
+    }
+
+    public bool Wednesday
+    {
+        get => GetWeekday(Weekdays.Wed);
+        set => SetWeekday(Weekdays.Wed, value);
+    }
+
+    public bool Thursday
+    {
+        get => GetWeekday(Weekdays.Thu);
+        set => SetWeekday(Weekdays.Thu, value);
+    }
+
+    public bool Friday
+    {
+        get => GetWeekday(Weekdays.Fri);
+        set => SetWeekday(Weekdays.Fri, value);
+    }
+
+    public bool Saturday
+    {
+        get => GetWeekday(Weekdays.Sat);
+        set => SetWeekday(Weekdays.Sat, value);
+    }
+
+    public event EventHandler<PeriodDefinitionSavedEventArgs>? Saved;
+
+    public void Load(PeriodDefinition? definition)
+    {
+        if (definition == null)
+        {
+            _definitionId = null;
+            IsNew = true;
+            Name = string.Empty;
+            SelectedWeekdays = PeriodDefinitionCatalog.AllWeekdays;
+            IsAllDay = false;
+            StartTime = new TimeSpan(9, 0, 0);
+            EndTime = new TimeSpan(17, 0, 0);
+            SelectedAlignmentMode = AlignmentModeOptions[0];
+            return;
+        }
+
+        _definitionId = definition.Id;
+        IsNew = string.IsNullOrWhiteSpace(definition.Id);
+        Name = definition.Name;
+        SelectedWeekdays = definition.Weekdays == Weekdays.None ? PeriodDefinitionCatalog.AllWeekdays : definition.Weekdays;
+        IsAllDay = definition.IsAllDay;
+        StartTime = definition.StartTime ?? new TimeSpan(9, 0, 0);
+        EndTime = definition.EndTime ?? new TimeSpan(17, 0, 0);
+        SelectedAlignmentMode = AlignmentModeOptions.FirstOrDefault(option => option.Mode == definition.Mode)
+            ?? AlignmentModeOptions[0];
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Name))
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await _storage.InitializeAsync();
+
+            var definition = new PeriodDefinition
+            {
+                Id = _definitionId ?? string.Empty,
+                Name = Name.Trim(),
+                Weekdays = SelectedWeekdays == Weekdays.None ? PeriodDefinitionCatalog.AllWeekdays : SelectedWeekdays,
+                IsAllDay = IsAllDay,
+                StartTime = IsAllDay ? null : StartTime,
+                EndTime = IsAllDay ? null : EndTime,
+                Mode = SelectedAlignmentMode.Mode
+            };
+
+            if (string.IsNullOrWhiteSpace(_definitionId))
+            {
+                await _storage.AddPeriodDefinitionAsync(definition);
+                _definitionId = definition.Id;
+                IsNew = false;
+            }
+            else
+            {
+                await _storage.UpdatePeriodDefinitionAsync(definition);
+            }
+
+            Saved?.Invoke(this, new PeriodDefinitionSavedEventArgs(definition));
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static Weekdays ApplyWeekdaySelection(Weekdays current, Weekdays day, bool enabled)
+    {
+        return enabled ? current | day : current & ~day;
+    }
+
+    private bool GetWeekday(Weekdays day) => _selectedWeekdays.HasFlag(day);
+
+    private void SetWeekday(Weekdays day, bool isSelected)
+    {
+        SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
+    }
+}

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionOption.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionOption.cs
@@ -1,0 +1,30 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.ViewModels;
+
+public sealed class PeriodDefinitionOption
+{
+    public PeriodDefinitionOption(string id, string name, string description, PeriodDefinition? definition, bool isAdHoc, bool isCoreBuiltIn)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+        Definition = definition;
+        IsAdHoc = isAdHoc;
+        IsCoreBuiltIn = isCoreBuiltIn;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public PeriodDefinition? Definition { get; }
+
+    public bool IsAdHoc { get; }
+
+    public bool IsCoreBuiltIn { get; }
+
+    public bool IsEditable => !IsAdHoc && !IsCoreBuiltIn;
+}

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionSavedEventArgs.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionSavedEventArgs.cs
@@ -1,0 +1,13 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.ViewModels;
+
+public sealed class PeriodDefinitionSavedEventArgs : EventArgs
+{
+    public PeriodDefinitionSavedEventArgs(PeriodDefinition definition)
+    {
+        Definition = definition;
+    }
+
+    public PeriodDefinition Definition { get; }
+}

--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -5,6 +5,7 @@ using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
 using ShuffleTask.Application.Services;
 using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Utilities;
 
 namespace ShuffleTask.ViewModels;
 
@@ -223,14 +224,7 @@ public class TaskListItem
         string importanceStars = new string('★', importance).PadRight(5, '☆');
         string importanceText = $"Importance: {importanceStars} ({importance}/5)";
 
-        string allowedPeriodText = task.AllowedPeriod switch
-        {
-            AllowedPeriod.Any => "Auto shuffle: Any time",
-            AllowedPeriod.Work => "Auto shuffle: Work hours (Mon–Fri)",
-            AllowedPeriod.OffWork => "Auto shuffle: Off hours (includes weekends)",
-            AllowedPeriod.Custom => "Auto shuffle: Custom hours",
-            _ => "Auto shuffle: Any time"
-        };
+        string allowedPeriodText = $"Auto shuffle: {PeriodDefinitionFormatter.FormatAllowedPeriodLabel(task)}";
 
         TaskStatusPresentation status = BuildStatusPresentation(task, now);
         ImportanceUrgencyScore score = ImportanceUrgencyCalculator.Calculate(task, now, settings);

--- a/ShuffleTask.Presentation/Views/EditTaskPage.xaml
+++ b/ShuffleTask.Presentation/Views/EditTaskPage.xaml
@@ -27,7 +27,6 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <Entry Grid.Row="0"
@@ -159,15 +158,107 @@
                                          HorizontalOptions="Start" />
             </Grid>
 
-            <Picker Grid.Row="8"
-                    Title="Allowed period"
-                    ItemsSource="{Binding AllowedPeriodOptions}"
-                    SelectedItem="{Binding AllowedPeriod}" />
+            <VerticalStackLayout Grid.Row="8"
+                                 Spacing="8">
+                <Label Text="Allowed period"
+                       FontAttributes="Bold" />
+                <Picker Title="Allowed period"
+                        ItemsSource="{Binding PeriodDefinitionOptions}"
+                        SelectedItem="{Binding SelectedPeriodDefinition}"
+                        ItemDisplayBinding="{Binding Name}"
+                        SemanticProperties.Description="{Binding SelectedPeriodDefinitionDescription}" />
+                <Label Text="{Binding SelectedPeriodDefinitionDescription}"
+                       FontSize="12"
+                       TextColor="#6B7280" />
+                <Grid ColumnDefinitions="*,*"
+                      ColumnSpacing="12">
+                    <Button Grid.Column="0"
+                            Text="New preset"
+                            Clicked="OnCreatePeriodDefinitionClicked" />
+                    <Button Grid.Column="1"
+                            Text="Edit selected"
+                            IsEnabled="{Binding CanEditSelectedDefinition}"
+                            Clicked="OnEditSelectedPeriodDefinitionClicked" />
+                </Grid>
+            </VerticalStackLayout>
 
-            <Label Grid.Row="9"
-                   Text="Work hours apply to weekdays (Mon–Fri). Custom hours use the task's weekday and time range."
-                   FontSize="12"
-                   TextColor="#6B7280" />
+            <Grid Grid.Row="9"
+                  RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                  RowSpacing="8"
+                  IsVisible="{Binding IsAdHocSelection}">
+                <Label Grid.Row="0"
+                       Text="Ad-hoc custom"
+                       FontAttributes="Bold" />
+                <Grid Grid.Row="1"
+                      ColumnDefinitions="Auto,Auto"
+                      ColumnSpacing="12">
+                    <Label Text="All day"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Column="1"
+                            IsToggled="{Binding AdHocIsAllDay}"
+                            SemanticProperties.Description="All-day windows ignore the time range below." />
+                </Grid>
+                <Grid Grid.Row="2"
+                      ColumnDefinitions="*,*"
+                      ColumnSpacing="12">
+                    <TimePicker Grid.Column="0"
+                                Time="{Binding AdHocStartTime}">
+                        <TimePicker.Triggers>
+                            <DataTrigger TargetType="TimePicker"
+                                         Binding="{Binding AdHocIsAllDay}"
+                                         Value="True">
+                                <Setter Property="IsEnabled" Value="False" />
+                            </DataTrigger>
+                        </TimePicker.Triggers>
+                    </TimePicker>
+                    <TimePicker Grid.Column="1"
+                                Time="{Binding AdHocEndTime}">
+                        <TimePicker.Triggers>
+                            <DataTrigger TargetType="TimePicker"
+                                         Binding="{Binding AdHocIsAllDay}"
+                                         Value="True">
+                                <Setter Property="IsEnabled" Value="False" />
+                            </DataTrigger>
+                        </TimePicker.Triggers>
+                    </TimePicker>
+                </Grid>
+                <Grid Grid.Row="3"
+                      ColumnDefinitions="Auto,*"
+                      ColumnSpacing="12">
+                    <Label Text="Alignment mode"
+                           VerticalOptions="Center" />
+                    <Picker Grid.Column="1"
+                            ItemsSource="{Binding AlignmentModeOptions}"
+                            SelectedItem="{Binding SelectedAlignmentMode}"
+                            ItemDisplayBinding="{Binding Name}"
+                            SemanticProperties.Description="{Binding SelectedAlignmentMode.Description}" />
+                </Grid>
+                <Label Grid.Row="4"
+                       Text="{Binding SelectedAlignmentMode.Description}"
+                       FontSize="12"
+                       TextColor="#6B7280" />
+                <Label Grid.Row="5"
+                       Text="Weekdays" />
+                <Grid Grid.Row="6"
+                      RowDefinitions="Auto,Auto"
+                      ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                      ColumnSpacing="8">
+                    <CheckBox Grid.Row="0" Grid.Column="0" IsChecked="{Binding AdHocSunday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" IsChecked="{Binding AdHocMonday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="2" IsChecked="{Binding AdHocTuesday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="3" IsChecked="{Binding AdHocWednesday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="4" IsChecked="{Binding AdHocThursday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="5" IsChecked="{Binding AdHocFriday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="6" IsChecked="{Binding AdHocSaturday}" />
+                    <Label Grid.Row="1" Grid.Column="0" Text="Sun" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="1" Text="Mon" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="2" Text="Tue" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="3" Text="Wed" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="4" Text="Thu" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="5" Text="Fri" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="6" Text="Sat" HorizontalOptions="Center" />
+                </Grid>
+            </Grid>
 
             <Grid Grid.Row="10"
                   ColumnDefinitions="Auto,*"
@@ -190,50 +281,6 @@
             </Grid>
 
             <Grid Grid.Row="12"
-                  RowDefinitions="Auto,Auto,Auto,Auto"
-                  RowSpacing="8"
-                  IsVisible="False">
-                <Grid.Triggers>
-                    <DataTrigger TargetType="Grid"
-                                Binding="{Binding AllowedPeriod}"
-                                Value="Custom">
-                        <Setter Property="IsVisible" Value="True" />
-                    </DataTrigger>
-                </Grid.Triggers>
-                <Label Grid.Row="0"
-                       Text="Custom time range" />
-                <Grid Grid.Row="1"
-                      ColumnDefinitions="*,*"
-                      ColumnSpacing="12">
-                    <TimePicker Grid.Column="0"
-                                Time="{Binding CustomStartTime}" />
-                    <TimePicker Grid.Column="1"
-                                Time="{Binding CustomEndTime}" />
-                </Grid>
-                <Label Grid.Row="2"
-                       Text="Custom weekdays" />
-                <Grid Grid.Row="3"
-                      RowDefinitions="Auto,Auto"
-                      ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
-                      ColumnSpacing="8">
-                    <CheckBox Grid.Row="0" Grid.Column="0" IsChecked="{Binding CustomSunday}" />
-                    <CheckBox Grid.Row="0" Grid.Column="1" IsChecked="{Binding CustomMonday}" />
-                    <CheckBox Grid.Row="0" Grid.Column="2" IsChecked="{Binding CustomTuesday}" />
-                    <CheckBox Grid.Row="0" Grid.Column="3" IsChecked="{Binding CustomWednesday}" />
-                    <CheckBox Grid.Row="0" Grid.Column="4" IsChecked="{Binding CustomThursday}" />
-                    <CheckBox Grid.Row="0" Grid.Column="5" IsChecked="{Binding CustomFriday}" />
-                    <CheckBox Grid.Row="0" Grid.Column="6" IsChecked="{Binding CustomSaturday}" />
-                    <Label Grid.Row="1" Grid.Column="0" Text="Sun" HorizontalOptions="Center" />
-                    <Label Grid.Row="1" Grid.Column="1" Text="Mon" HorizontalOptions="Center" />
-                    <Label Grid.Row="1" Grid.Column="2" Text="Tue" HorizontalOptions="Center" />
-                    <Label Grid.Row="1" Grid.Column="3" Text="Wed" HorizontalOptions="Center" />
-                    <Label Grid.Row="1" Grid.Column="4" Text="Thu" HorizontalOptions="Center" />
-                    <Label Grid.Row="1" Grid.Column="5" Text="Fri" HorizontalOptions="Center" />
-                    <Label Grid.Row="1" Grid.Column="6" Text="Sat" HorizontalOptions="Center" />
-                </Grid>
-            </Grid>
-
-            <Grid Grid.Row="13"
                   ColumnDefinitions="Auto,Auto"
                   ColumnSpacing="12">
                 <Label Text="Paused"
@@ -243,7 +290,7 @@
             </Grid>
 
             <!-- Custom Timer Override Section -->
-            <Grid Grid.Row="14"
+            <Grid Grid.Row="13"
                   RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
                   RowSpacing="8">
                 <Grid Grid.Row="0"
@@ -332,7 +379,7 @@
                 </Grid>
             </Grid>
 
-            <Grid Grid.Row="15"
+            <Grid Grid.Row="14"
                   ColumnDefinitions="*,*"
                   ColumnSpacing="16">
                 <Button Grid.Column="0"
@@ -343,7 +390,7 @@
                         Clicked="OnCancelClicked" />
             </Grid>
 
-            <ActivityIndicator Grid.Row="16"
+            <ActivityIndicator Grid.Row="15"
                                IsVisible="{Binding IsBusy}"
                                IsRunning="{Binding IsBusy}"
                                HorizontalOptions="Center" />

--- a/ShuffleTask.Presentation/Views/PeriodDefinitionEditorPage.xaml
+++ b/ShuffleTask.Presentation/Views/PeriodDefinitionEditorPage.xaml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xaml-comp compile="true"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:ShuffleTask.ViewModels"
+             x:Class="ShuffleTask.Views.PeriodDefinitionEditorPage"
+             x:DataType="vm:PeriodDefinitionEditorViewModel"
+             Title="Period definition">
+    <ScrollView>
+        <Grid Padding="20"
+              RowSpacing="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Entry Grid.Row="0"
+                   Text="{Binding Name}"
+                   Placeholder="Name"
+                   SemanticProperties.Description="Name this time window so it can be reused in tasks." />
+
+            <Grid Grid.Row="1"
+                  RowDefinitions="Auto,Auto"
+                  RowSpacing="8">
+                <Label Grid.Row="0"
+                       Text="Weekdays"
+                       FontAttributes="Bold" />
+                <Grid Grid.Row="1"
+                      RowDefinitions="Auto,Auto"
+                      ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                      ColumnSpacing="8">
+                    <CheckBox Grid.Row="0" Grid.Column="0" IsChecked="{Binding Sunday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" IsChecked="{Binding Monday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="2" IsChecked="{Binding Tuesday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="3" IsChecked="{Binding Wednesday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="4" IsChecked="{Binding Thursday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="5" IsChecked="{Binding Friday}" />
+                    <CheckBox Grid.Row="0" Grid.Column="6" IsChecked="{Binding Saturday}" />
+                    <Label Grid.Row="1" Grid.Column="0" Text="Sun" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="1" Text="Mon" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="2" Text="Tue" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="3" Text="Wed" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="4" Text="Thu" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="5" Text="Fri" HorizontalOptions="Center" />
+                    <Label Grid.Row="1" Grid.Column="6" Text="Sat" HorizontalOptions="Center" />
+                </Grid>
+            </Grid>
+
+            <Grid Grid.Row="2"
+                  ColumnDefinitions="Auto,Auto"
+                  ColumnSpacing="12">
+                <Label Text="All day"
+                       VerticalOptions="Center" />
+                <Switch Grid.Column="1"
+                        IsToggled="{Binding IsAllDay}"
+                        SemanticProperties.Description="All-day periods ignore start and end times." />
+            </Grid>
+
+            <Grid Grid.Row="3"
+                  ColumnDefinitions="*,*"
+                  ColumnSpacing="12">
+                <TimePicker Grid.Column="0"
+                            Time="{Binding StartTime}">
+                    <TimePicker.Triggers>
+                        <DataTrigger TargetType="TimePicker"
+                                     Binding="{Binding IsAllDay}"
+                                     Value="True">
+                            <Setter Property="IsEnabled" Value="False" />
+                        </DataTrigger>
+                    </TimePicker.Triggers>
+                </TimePicker>
+                <TimePicker Grid.Column="1"
+                            Time="{Binding EndTime}">
+                    <TimePicker.Triggers>
+                        <DataTrigger TargetType="TimePicker"
+                                     Binding="{Binding IsAllDay}"
+                                     Value="True">
+                            <Setter Property="IsEnabled" Value="False" />
+                        </DataTrigger>
+                    </TimePicker.Triggers>
+                </TimePicker>
+            </Grid>
+
+            <Grid Grid.Row="4"
+                  ColumnDefinitions="Auto,*"
+                  ColumnSpacing="12">
+                <Label Text="Alignment mode"
+                       VerticalOptions="Center" />
+                <Picker Grid.Column="1"
+                        ItemsSource="{Binding AlignmentModeOptions}"
+                        SelectedItem="{Binding SelectedAlignmentMode}"
+                        ItemDisplayBinding="{Binding Name}"
+                        SemanticProperties.Description="{Binding SelectedAlignmentMode.Description}" />
+            </Grid>
+
+            <Label Grid.Row="5"
+                   Text="{Binding SelectedAlignmentMode.Description}"
+                   FontSize="12"
+                   TextColor="#6B7280" />
+
+            <Grid Grid.Row="6"
+                  ColumnDefinitions="*,*"
+                  ColumnSpacing="16">
+                <Button Grid.Column="0"
+                        Text="Save"
+                        Command="{Binding SaveCommand}" />
+                <Button Grid.Column="1"
+                        Text="Cancel"
+                        Clicked="OnCancelClicked" />
+            </Grid>
+        </Grid>
+    </ScrollView>
+</ContentPage>

--- a/ShuffleTask.Presentation/Views/PeriodDefinitionEditorPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/PeriodDefinitionEditorPage.xaml.cs
@@ -1,0 +1,74 @@
+using ShuffleTask.ViewModels;
+
+namespace ShuffleTask.Views;
+
+public partial class PeriodDefinitionEditorPage : ContentPage
+{
+    private PeriodDefinitionEditorViewModel? _viewModel;
+    private bool _eventsSubscribed;
+
+    public PeriodDefinitionEditorPage(PeriodDefinitionEditorViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _viewModel = BindingContext as PeriodDefinitionEditorViewModel;
+        SubscribeToViewModel();
+        UpdateTitle();
+    }
+
+    protected override void OnBindingContextChanged()
+    {
+        UnsubscribeFromViewModel();
+        base.OnBindingContextChanged();
+        _viewModel = BindingContext as PeriodDefinitionEditorViewModel;
+        SubscribeToViewModel();
+        UpdateTitle();
+    }
+
+    private async void OnSaved(object? sender, PeriodDefinitionSavedEventArgs e)
+    {
+        UnsubscribeFromViewModel();
+        await Navigation.PopModalAsync();
+    }
+
+    private async void OnCancelClicked(object sender, EventArgs e)
+    {
+        UnsubscribeFromViewModel();
+        await Navigation.PopModalAsync();
+    }
+
+    private void SubscribeToViewModel()
+    {
+        if (_viewModel == null || _eventsSubscribed)
+        {
+            return;
+        }
+
+        _viewModel.Saved += OnSaved;
+        _eventsSubscribed = true;
+    }
+
+    private void UnsubscribeFromViewModel()
+    {
+        if (_viewModel == null || !_eventsSubscribed)
+        {
+            return;
+        }
+
+        _viewModel.Saved -= OnSaved;
+        _eventsSubscribed = false;
+    }
+
+    private void UpdateTitle()
+    {
+        if (_viewModel != null)
+        {
+            Title = _viewModel.IsNew ? "New period definition" : "Edit period definition";
+        }
+    }
+}

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml.cs
@@ -119,7 +119,7 @@ public partial class TasksPage : ContentPage
     {
         var page = _services.GetRequiredService<EditTaskPage>();
         var editorVm = _services.GetRequiredService<EditTaskViewModel>();
-        editorVm.Load(task);
+        await editorVm.LoadAsync(task);
         editorVm.Saved -= OnEditorSaved;
         editorVm.Saved += OnEditorSaved;
 


### PR DESCRIPTION
### Motivation
- Replace the simple enum-based `AllowedPeriod` picker with a richer, reusable concept so tasks can reference named period definitions or an ad-hoc custom window. 
- Provide a small UI for creating/editing named period definitions (name, weekdays, all-day, times, alignment mode) so presets can be managed by users.
- Make descriptions and alignment behavior explicit so users understand how presets and work/off-work alignment interact.

### Description
- Replaced the old `AllowedPeriod` picker UI in `Views/EditTaskPage.xaml` with a period-definition selector bound to `PeriodDefinitionOptions` and an ad‑hoc option, and added in-place description text and `New preset` / `Edit selected` buttons.  The ad‑hoc editor is shown when the ad‑hoc option is selected. (`ShuffleTask.Presentation/Views/EditTaskPage.xaml`, `EditTaskPage.xaml.cs`)
- Implemented `EditTaskViewModel` support for loading, selecting, applying and saving period definitions and ad‑hoc values, including `AdHocIsAllDay` (which disables start/end time pickers) and alignment mode handling; added `PeriodDefinitionOption`, `AlignmentModeOption`, and related helper methods. (`ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs`, `ShuffleTask.Presentation/ViewModels/PeriodDefinitionOption.cs`, `ShuffleTask.Presentation/ViewModels/AlignmentModeOption.cs`)
- Added a modal editor for period definitions: `PeriodDefinitionEditorPage` (XAML + code-behind) and `PeriodDefinitionEditorViewModel` to create/edit named presets with weekdays, all-day toggle, start/end times and alignment mode; the all-day toggle disables the time pickers in the editor via `DataTrigger`. (`ShuffleTask.Presentation/Views/PeriodDefinitionEditorPage.xaml`, `PeriodDefinitionEditorPage.xaml.cs`, `ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs`)
- Added `PeriodDefinitionFormatter` utility to generate human-friendly labels/descriptions for presets, ad-hoc definitions and legacy custom windows, and wired it into task presentation text in `TasksViewModel` and `DashboardViewModel`. (`ShuffleTask.Presentation/Utilities/PeriodDefinitionFormatter.cs`, `ShuffleTask.Presentation/ViewModels/TasksViewModel.cs`, `ShuffleTask.Presentation/ViewModels/DashboardViewModel.cs`)
- Registered the new view and view model in DI and added the new XAML page to the project file so the modal editor can be resolved from `MauiProgram`. (`ShuffleTask.Presentation/MauiProgram.cs`, `ShuffleTask.Presentation/ShuffleTask.Presentation.csproj`)

### Testing
- No automated tests were added or executed as part of this change.
- Manual checks performed while implementing: building type-level changes and updating bindings (no full app run in CI performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cdcbf4d883269cf01ea7a82aa9e5)