### PR TITLE
Add shared WeekdaySelectionHelper and refactor view models to use it

### DIFF
--- a/ShuffleTask.Presentation/Utilities/ViewModelWithWeekdaySelection.cs
+++ b/ShuffleTask.Presentation/Utilities/ViewModelWithWeekdaySelection.cs
@@ -3,7 +3,7 @@ using ShuffleTask.Domain.Entities;
 
 namespace ShuffleTask.Presentation.Utilities;
 
-public abstract class WeekdaySelectionHelper : ObservableObject
+public abstract class ViewModelWithWeekdaySelection : ObservableObject
 {
     private Weekdays _selectedWeekdays;
 

--- a/ShuffleTask.Presentation/Utilities/WeekdaySelectionHelper.cs
+++ b/ShuffleTask.Presentation/Utilities/WeekdaySelectionHelper.cs
@@ -1,0 +1,86 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+public abstract class WeekdaySelectionHelper : ObservableObject
+{
+    private Weekdays _selectedWeekdays;
+
+    public Weekdays SelectedWeekdays
+    {
+        get => _selectedWeekdays;
+        set
+        {
+            if (SetProperty(ref _selectedWeekdays, value))
+            {
+                RaiseWeekdayPropertiesChanged();
+            }
+        }
+    }
+
+    protected static Weekdays ApplyWeekdaySelection(Weekdays current, Weekdays day, bool enabled)
+    {
+        return enabled ? current | day : current & ~day;
+    }
+
+    protected bool GetWeekday(Weekdays day) => _selectedWeekdays.HasFlag(day);
+
+    protected void SetWeekday(Weekdays day, bool isSelected)
+    {
+        SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
+    }
+
+    protected void RaiseWeekdayPropertiesChanged()
+    {
+        OnPropertyChanged(nameof(Sunday));
+        OnPropertyChanged(nameof(Monday));
+        OnPropertyChanged(nameof(Tuesday));
+        OnPropertyChanged(nameof(Wednesday));
+        OnPropertyChanged(nameof(Thursday));
+        OnPropertyChanged(nameof(Friday));
+        OnPropertyChanged(nameof(Saturday));
+    }
+
+    public bool Sunday
+    {
+        get => GetWeekday(Weekdays.Sun);
+        set => SetWeekday(Weekdays.Sun, value);
+    }
+
+    public bool Monday
+    {
+        get => GetWeekday(Weekdays.Mon);
+        set => SetWeekday(Weekdays.Mon, value);
+    }
+
+    public bool Tuesday
+    {
+        get => GetWeekday(Weekdays.Tue);
+        set => SetWeekday(Weekdays.Tue, value);
+    }
+
+    public bool Wednesday
+    {
+        get => GetWeekday(Weekdays.Wed);
+        set => SetWeekday(Weekdays.Wed, value);
+    }
+
+    public bool Thursday
+    {
+        get => GetWeekday(Weekdays.Thu);
+        set => SetWeekday(Weekdays.Thu, value);
+    }
+
+    public bool Friday
+    {
+        get => GetWeekday(Weekdays.Fri);
+        set => SetWeekday(Weekdays.Fri, value);
+    }
+
+    public bool Saturday
+    {
+        get => GetWeekday(Weekdays.Sat);
+        set => SetWeekday(Weekdays.Sat, value);
+    }
+}

--- a/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
@@ -8,7 +8,7 @@ using System.Collections.ObjectModel;
 
 namespace ShuffleTask.ViewModels;
 
-public partial class EditTaskViewModel : WeekdaySelectionHelper
+public partial class EditTaskViewModel : ViewModelWithWeekdaySelection
 {
     private readonly IStorageService _storage;
     private readonly TimeProvider _clock;

--- a/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
@@ -8,14 +8,13 @@ using System.Collections.ObjectModel;
 
 namespace ShuffleTask.ViewModels;
 
-public partial class EditTaskViewModel : ObservableObject
+public partial class EditTaskViewModel : WeekdaySelectionHelper
 {
     private readonly IStorageService _storage;
     private readonly TimeProvider _clock;
 
     private TaskItem _workingCopy = new();
 
-    private Weekdays _selectedWeekdays;
     private Weekdays _selectedAdHocWeekdays;
 
     private static readonly Weekdays AllWeekdays = Weekdays.Sun | Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri | Weekdays.Sat;
@@ -23,24 +22,6 @@ public partial class EditTaskViewModel : ObservableObject
     private const double MinSizePoints = 0.5;
     private const double MaxSizePoints = 13.0;
     private const double DefaultSizePoints = 3.0;
-
-    public Weekdays SelectedWeekdays
-    {
-        get => _selectedWeekdays;
-        set
-        {
-            if (SetProperty(ref _selectedWeekdays, value))
-            {
-                OnPropertyChanged(nameof(Sunday));
-                OnPropertyChanged(nameof(Monday));
-                OnPropertyChanged(nameof(Tuesday));
-                OnPropertyChanged(nameof(Wednesday));
-                OnPropertyChanged(nameof(Thursday));
-                OnPropertyChanged(nameof(Friday));
-                OnPropertyChanged(nameof(Saturday));
-            }
-        }
-    }
 
     public Weekdays SelectedAdHocWeekdays
     {
@@ -186,65 +167,11 @@ public partial class EditTaskViewModel : ObservableObject
         }
     }
 
-    private static Weekdays ApplyWeekdaySelection(Weekdays current, Weekdays day, bool enabled)
-    {
-        return enabled ? current | day : current & ~day;
-    }
-
-    private bool GetWeekday(Weekdays day) => _selectedWeekdays.HasFlag(day);
-
-    private void SetWeekday(Weekdays day, bool isSelected)
-    {
-        SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
-    }
-
     private bool GetAdHocWeekday(Weekdays day) => _selectedAdHocWeekdays.HasFlag(day);
 
     private void SetAdHocWeekday(Weekdays day, bool isSelected)
     {
         SelectedAdHocWeekdays = ApplyWeekdaySelection(SelectedAdHocWeekdays, day, isSelected);
-    }
-
-    public bool Sunday
-    {
-        get => GetWeekday(Weekdays.Sun);
-        set => SetWeekday(Weekdays.Sun, value);
-    }
-
-    public bool Monday
-    {
-        get => GetWeekday(Weekdays.Mon);
-        set => SetWeekday(Weekdays.Mon, value);
-    }
-
-    public bool Tuesday
-    {
-        get => GetWeekday(Weekdays.Tue);
-        set => SetWeekday(Weekdays.Tue, value);
-    }
-
-    public bool Wednesday
-    {
-        get => GetWeekday(Weekdays.Wed);
-        set => SetWeekday(Weekdays.Wed, value);
-    }
-
-    public bool Thursday
-    {
-        get => GetWeekday(Weekdays.Thu);
-        set => SetWeekday(Weekdays.Thu, value);
-    }
-
-    public bool Friday
-    {
-        get => GetWeekday(Weekdays.Fri);
-        set => SetWeekday(Weekdays.Fri, value);
-    }
-
-    public bool Saturday
-    {
-        get => GetWeekday(Weekdays.Sat);
-        set => SetWeekday(Weekdays.Sat, value);
     }
 
     public bool AdHocSunday

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
@@ -2,13 +2,13 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Utilities;
 
 namespace ShuffleTask.ViewModels;
 
-public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
+public sealed partial class PeriodDefinitionEditorViewModel : WeekdaySelectionHelper
 {
     private readonly IStorageService _storage;
-    private Weekdays _selectedWeekdays;
     private string? _definitionId;
     private bool _isNew = true;
 
@@ -21,24 +21,6 @@ public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
     }
 
     public IReadOnlyList<AlignmentModeOption> AlignmentModeOptions { get; }
-
-    public Weekdays SelectedWeekdays
-    {
-        get => _selectedWeekdays;
-        set
-        {
-            if (SetProperty(ref _selectedWeekdays, value))
-            {
-                OnPropertyChanged(nameof(Sunday));
-                OnPropertyChanged(nameof(Monday));
-                OnPropertyChanged(nameof(Tuesday));
-                OnPropertyChanged(nameof(Wednesday));
-                OnPropertyChanged(nameof(Thursday));
-                OnPropertyChanged(nameof(Friday));
-                OnPropertyChanged(nameof(Saturday));
-            }
-        }
-    }
 
     [ObservableProperty]
     private string name = string.Empty;
@@ -62,48 +44,6 @@ public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
     {
         get => _isNew;
         private set => SetProperty(ref _isNew, value);
-    }
-
-    public bool Sunday
-    {
-        get => GetWeekday(Weekdays.Sun);
-        set => SetWeekday(Weekdays.Sun, value);
-    }
-
-    public bool Monday
-    {
-        get => GetWeekday(Weekdays.Mon);
-        set => SetWeekday(Weekdays.Mon, value);
-    }
-
-    public bool Tuesday
-    {
-        get => GetWeekday(Weekdays.Tue);
-        set => SetWeekday(Weekdays.Tue, value);
-    }
-
-    public bool Wednesday
-    {
-        get => GetWeekday(Weekdays.Wed);
-        set => SetWeekday(Weekdays.Wed, value);
-    }
-
-    public bool Thursday
-    {
-        get => GetWeekday(Weekdays.Thu);
-        set => SetWeekday(Weekdays.Thu, value);
-    }
-
-    public bool Friday
-    {
-        get => GetWeekday(Weekdays.Fri);
-        set => SetWeekday(Weekdays.Fri, value);
-    }
-
-    public bool Saturday
-    {
-        get => GetWeekday(Weekdays.Sat);
-        set => SetWeekday(Weekdays.Sat, value);
     }
 
     public event EventHandler<PeriodDefinitionSavedEventArgs>? Saved;
@@ -182,15 +122,4 @@ public sealed partial class PeriodDefinitionEditorViewModel : ObservableObject
         }
     }
 
-    private static Weekdays ApplyWeekdaySelection(Weekdays current, Weekdays day, bool enabled)
-    {
-        return enabled ? current | day : current & ~day;
-    }
-
-    private bool GetWeekday(Weekdays day) => _selectedWeekdays.HasFlag(day);
-
-    private void SetWeekday(Weekdays day, bool isSelected)
-    {
-        SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
-    }
 }

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
@@ -6,7 +6,7 @@ using ShuffleTask.Presentation.Utilities;
 
 namespace ShuffleTask.ViewModels;
 
-public sealed partial class PeriodDefinitionEditorViewModel : WeekdaySelectionHelper
+public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekdaySelection
 {
     private readonly IStorageService _storage;
     private string? _definitionId;


### PR DESCRIPTION
### Motivation
- Remove duplicated weekday state and accessors from multiple view models and centralize weekday logic for easier maintenance.
- Ensure consistent change-notification behavior for weekday properties across `EditTaskViewModel` and `PeriodDefinitionEditorViewModel`.

### Description
- Add `WeekdaySelectionHelper` (`ShuffleTask.Presentation/Utilities/WeekdaySelectionHelper.cs`) which exposes a `SelectedWeekdays` backing field, `GetWeekday`/`SetWeekday` methods, boolean `Sunday`–`Saturday` accessors, an `ApplyWeekdaySelection` helper, and `RaiseWeekdayPropertiesChanged` to notify weekday property changes.
- Update `EditTaskViewModel` (`ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs`) to inherit from `WeekdaySelectionHelper` and remove duplicated weekday fields, accessors, and helper methods while keeping ad-hoc weekday handling intact.
- Update `PeriodDefinitionEditorViewModel` (`ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs`) to inherit from `WeekdaySelectionHelper` and remove its duplicated weekday implementations.
- Preserve existing behavior and public APIs of the modified view models while consolidating implementation into the new helper.

### Testing
- No automated tests were executed for this change.
- Manual compilation or runtime verification was not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e30f45fc832684c676da0272bb4d)