### PR TITLE
Centralize ad-hoc period definition helper

### DIFF
--- a/ShuffleTask.Application/Services/TimeWindowService.cs
+++ b/ShuffleTask.Application/Services/TimeWindowService.cs
@@ -111,7 +111,7 @@ public static class TimeWindowService
             return definition;
         }
 
-        if (TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
+        if (TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
         {
             return adHocDefinition;
         }
@@ -121,33 +121,6 @@ public static class TimeWindowService
             AllowedPeriod.Custom => BuildLegacyCustomDefinition(task),
             _ => GetDefinitionForAllowedPeriod(task.AllowedPeriod)
         };
-    }
-
-    private static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)
-    {
-        bool hasAdHocDefinition = task.AdHocStartTime.HasValue
-            || task.AdHocEndTime.HasValue
-            || task.AdHocWeekdays.HasValue
-            || task.AdHocIsAllDay
-            || task.AdHocMode != PeriodDefinitionMode.None;
-
-        if (!hasAdHocDefinition)
-        {
-            definition = PeriodDefinitionCatalog.Any;
-            return false;
-        }
-
-        definition = new PeriodDefinition
-        {
-            Id = string.Empty,
-            Name = "Ad-hoc",
-            StartTime = task.AdHocStartTime,
-            EndTime = task.AdHocEndTime,
-            Weekdays = task.AdHocWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
-            IsAllDay = task.AdHocIsAllDay,
-            Mode = task.AdHocMode
-        };
-        return true;
     }
 
     private static PeriodDefinition BuildLegacyCustomDefinition(TaskItem task)

--- a/ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs
+++ b/ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs
@@ -1,0 +1,38 @@
+namespace ShuffleTask.Domain.Entities;
+
+public static class TaskItemPeriodDefinitionHelper
+{
+    public static bool HasAdHocDefinition(TaskItem task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        return task.AdHocStartTime.HasValue
+            || task.AdHocEndTime.HasValue
+            || task.AdHocWeekdays.HasValue
+            || task.AdHocIsAllDay
+            || task.AdHocMode != PeriodDefinitionMode.None;
+    }
+
+    public static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        if (!HasAdHocDefinition(task))
+        {
+            definition = PeriodDefinitionCatalog.Any;
+            return false;
+        }
+
+        definition = new PeriodDefinition
+        {
+            Id = string.Empty,
+            Name = "Ad-hoc",
+            StartTime = task.AdHocStartTime,
+            EndTime = task.AdHocEndTime,
+            Weekdays = task.AdHocWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
+            IsAllDay = task.AdHocIsAllDay,
+            Mode = task.AdHocMode
+        };
+        return true;
+    }
+}

--- a/ShuffleTask.Presentation/Utilities/PeriodDefinitionFormatter.cs
+++ b/ShuffleTask.Presentation/Utilities/PeriodDefinitionFormatter.cs
@@ -14,12 +14,12 @@ internal static class PeriodDefinitionFormatter
         }
 
         if (!string.IsNullOrWhiteSpace(task.PeriodDefinitionId)
-            && TryBuildAdHocDefinition(task, out PeriodDefinition presetDefinition))
+            && TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition(task, out PeriodDefinition presetDefinition))
         {
             return $"Preset ({DescribeDefinition(presetDefinition)})";
         }
 
-        if (TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
+        if (TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
         {
             return $"Ad-hoc ({DescribeDefinition(adHocDefinition)})";
         }
@@ -150,33 +150,6 @@ internal static class PeriodDefinitionFormatter
         }
 
         return string.Empty;
-    }
-
-    private static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)
-    {
-        bool hasAdHocDefinition = task.AdHocStartTime.HasValue
-            || task.AdHocEndTime.HasValue
-            || task.AdHocWeekdays.HasValue
-            || task.AdHocIsAllDay
-            || task.AdHocMode != PeriodDefinitionMode.None;
-
-        if (!hasAdHocDefinition)
-        {
-            definition = PeriodDefinitionCatalog.Any;
-            return false;
-        }
-
-        definition = new PeriodDefinition
-        {
-            Id = string.Empty,
-            Name = "Ad-hoc",
-            StartTime = task.AdHocStartTime,
-            EndTime = task.AdHocEndTime,
-            Weekdays = task.AdHocWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
-            IsAllDay = task.AdHocIsAllDay,
-            Mode = task.AdHocMode
-        };
-        return true;
     }
 
     private static string FormatLegacyCustom(TaskItem task)


### PR DESCRIPTION
### Motivation
- Eliminate duplicated ad‑hoc period detection/build logic that lived in both `TimeWindowService` and `PeriodDefinitionFormatter` to prevent divergence.
- Move responsibility to the domain layer so period-building behavior is a single source of truth and easier to maintain.

### Description
- Add `ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs` with `HasAdHocDefinition` and `TryBuildAdHocDefinition` to detect and construct ad‑hoc `PeriodDefinition` instances.
- Replace the ad‑hoc construction calls in `ShuffleTask.Application/Services/TimeWindowService` and `ShuffleTask.Presentation/Utilities/PeriodDefinitionFormatter` with `TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition` to reuse the shared logic.
- Preserve previous behavior and shape of the produced `PeriodDefinition` (the helper constructs the same `Id`, `Name`, `StartTime`, `EndTime`, `Weekdays`, `IsAllDay`, and `Mode` values as before).

### Testing
- No automated tests were run as part of this change; no test results to report.
- To validate locally, run `dotnet test` across the test projects (for example `ShuffleTask.Application.Tests`, `ShuffleTask.Presentation.Tests`, and `ShuffleTask.Tests`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979eef99c508326801136e411ff1d11)