### PR TITLE
Add AlignmentModeCatalog and centralize alignment mode defaults

### DIFF
--- a/ShuffleTask.Presentation/Utilities/AlignmentModeCatalog.cs
+++ b/ShuffleTask.Presentation/Utilities/AlignmentModeCatalog.cs
@@ -1,0 +1,24 @@
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.ViewModels;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+public static class AlignmentModeCatalog
+{
+    public static IReadOnlyList<AlignmentModeOption> Defaults { get; } =
+        new[]
+        {
+            new AlignmentModeOption(
+                "Fixed time window",
+                "Use the start and end times below.",
+                PeriodDefinitionMode.None),
+            new AlignmentModeOption(
+                "Align with work hours",
+                "Uses Settings → Work hours for the time range.",
+                PeriodDefinitionMode.AlignWithWorkHours),
+            new AlignmentModeOption(
+                "Align with off-work hours",
+                "Schedules outside Settings → Work hours (includes weekends).",
+                PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours)
+        };
+}

--- a/ShuffleTask.Presentation/ViewModels/AlignmentModeOption.cs
+++ b/ShuffleTask.Presentation/ViewModels/AlignmentModeOption.cs
@@ -16,23 +16,4 @@ public sealed class AlignmentModeOption
     public string Description { get; }
 
     public PeriodDefinitionMode Mode { get; }
-
-    public static IReadOnlyList<AlignmentModeOption> CreateDefaults()
-    {
-        return new[]
-        {
-            new AlignmentModeOption(
-                "Fixed time window",
-                "Use the start and end times below.",
-                PeriodDefinitionMode.None),
-            new AlignmentModeOption(
-                "Align with work hours",
-                "Uses Settings → Work hours for the time range.",
-                PeriodDefinitionMode.AlignWithWorkHours),
-            new AlignmentModeOption(
-                "Align with off-work hours",
-                "Schedules outside Settings → Work hours (includes weekends).",
-                PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours)
-        };
-    }
 }

--- a/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
@@ -131,7 +131,7 @@ public partial class EditTaskViewModel : ViewModelWithWeekdaySelection
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         AppSettings = appSettings;
         DeadlineDate = GetTodayUtcDate();
-        AlignmentModeOptions = AlignmentModeOption.CreateDefaults();
+        AlignmentModeOptions = AlignmentModeCatalog.Defaults;
         SelectedAlignmentMode = AlignmentModeOptions[0];
     }
 

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
@@ -15,7 +15,7 @@ public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekd
     public PeriodDefinitionEditorViewModel(IStorageService storage)
     {
         _storage = storage;
-        AlignmentModeOptions = AlignmentModeOption.CreateDefaults();
+        AlignmentModeOptions = AlignmentModeCatalog.Defaults;
         SelectedAlignmentMode = AlignmentModeOptions[0];
         SelectedWeekdays = PeriodDefinitionCatalog.AllWeekdays;
     }


### PR DESCRIPTION
### Motivation
- Centralize the default `AlignmentModeOption` list so multiple view models share the same static catalog and avoid duplicated defaults.

### Description
- Add `ShuffleTask.Presentation.Utilities.AlignmentModeCatalog` with a `Defaults` property exposing the default `AlignmentModeOption` entries.
- Remove the `AlignmentModeOption.CreateDefaults()` usage and update `EditTaskViewModel` and `PeriodDefinitionEditorViewModel` to use `AlignmentModeCatalog.Defaults` instead.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a6366d0dc83269372716a66a55594)