### PR TITLE
Normalize legacy period definitions on task load

### DIFF
--- a/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
+++ b/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
@@ -222,6 +222,7 @@ internal sealed class InMemoryStorageService : IStorageService
 
     private void ApplyPeriodDefinition(TaskItem task)
     {
+        NormalizeLegacyPeriodDefinition(task);
         if (string.IsNullOrWhiteSpace(task.PeriodDefinitionId))
         {
             return;
@@ -242,6 +243,44 @@ internal sealed class InMemoryStorageService : IStorageService
         task.AdHocWeekdays = definition.Weekdays;
         task.AdHocIsAllDay = definition.IsAllDay;
         task.AdHocMode = definition.Mode;
+    }
+
+    private static void NormalizeLegacyPeriodDefinition(TaskItem task)
+    {
+        if (!string.IsNullOrWhiteSpace(task.PeriodDefinitionId) || HasAdHocDefinition(task))
+        {
+            return;
+        }
+
+        if (task.AllowedPeriod == AllowedPeriod.Custom)
+        {
+            if (task.CustomStartTime.HasValue || task.CustomEndTime.HasValue || task.CustomWeekdays.HasValue)
+            {
+                task.AdHocStartTime = task.CustomStartTime;
+                task.AdHocEndTime = task.CustomEndTime;
+                task.AdHocWeekdays = task.CustomWeekdays;
+                task.AdHocIsAllDay = !task.CustomStartTime.HasValue || !task.CustomEndTime.HasValue;
+                task.AdHocMode = PeriodDefinitionMode.None;
+            }
+
+            return;
+        }
+
+        task.PeriodDefinitionId = task.AllowedPeriod switch
+        {
+            AllowedPeriod.Work => PeriodDefinitionCatalog.WorkId,
+            AllowedPeriod.OffWork => PeriodDefinitionCatalog.OffWorkId,
+            _ => PeriodDefinitionCatalog.AnyId
+        };
+    }
+
+    private static bool HasAdHocDefinition(TaskItem task)
+    {
+        return task.AdHocStartTime.HasValue
+            || task.AdHocEndTime.HasValue
+            || task.AdHocWeekdays.HasValue
+            || task.AdHocIsAllDay
+            || task.AdHocMode != PeriodDefinitionMode.None;
     }
 
     private static DateTime EnsureUtc(DateTime value) => value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();

--- a/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
+++ b/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
@@ -222,7 +222,7 @@ internal sealed class InMemoryStorageService : IStorageService
 
     private void ApplyPeriodDefinition(TaskItem task)
     {
-        NormalizeLegacyPeriodDefinition(task);
+        TaskItemPeriodDefinitionHelper.NormalizeLegacyPeriodDefinition(task);
         if (string.IsNullOrWhiteSpace(task.PeriodDefinitionId))
         {
             return;
@@ -243,44 +243,6 @@ internal sealed class InMemoryStorageService : IStorageService
         task.AdHocWeekdays = definition.Weekdays;
         task.AdHocIsAllDay = definition.IsAllDay;
         task.AdHocMode = definition.Mode;
-    }
-
-    private static void NormalizeLegacyPeriodDefinition(TaskItem task)
-    {
-        if (!string.IsNullOrWhiteSpace(task.PeriodDefinitionId) || HasAdHocDefinition(task))
-        {
-            return;
-        }
-
-        if (task.AllowedPeriod == AllowedPeriod.Custom)
-        {
-            if (task.CustomStartTime.HasValue || task.CustomEndTime.HasValue || task.CustomWeekdays.HasValue)
-            {
-                task.AdHocStartTime = task.CustomStartTime;
-                task.AdHocEndTime = task.CustomEndTime;
-                task.AdHocWeekdays = task.CustomWeekdays;
-                task.AdHocIsAllDay = !task.CustomStartTime.HasValue || !task.CustomEndTime.HasValue;
-                task.AdHocMode = PeriodDefinitionMode.None;
-            }
-
-            return;
-        }
-
-        task.PeriodDefinitionId = task.AllowedPeriod switch
-        {
-            AllowedPeriod.Work => PeriodDefinitionCatalog.WorkId,
-            AllowedPeriod.OffWork => PeriodDefinitionCatalog.OffWorkId,
-            _ => PeriodDefinitionCatalog.AnyId
-        };
-    }
-
-    private static bool HasAdHocDefinition(TaskItem task)
-    {
-        return task.AdHocStartTime.HasValue
-            || task.AdHocEndTime.HasValue
-            || task.AdHocWeekdays.HasValue
-            || task.AdHocIsAllDay
-            || task.AdHocMode != PeriodDefinitionMode.None;
     }
 
     private static DateTime EnsureUtc(DateTime value) => value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();

--- a/ShuffleTask.Application/Utilities/PeriodDefinitionFormatter.cs
+++ b/ShuffleTask.Application/Utilities/PeriodDefinitionFormatter.cs
@@ -1,8 +1,8 @@
 using ShuffleTask.Domain.Entities;
 
-namespace ShuffleTask.Presentation.Utilities;
+namespace ShuffleTask.Application.Utilities;
 
-internal static class PeriodDefinitionFormatter
+public static class PeriodDefinitionFormatter
 {
     public static string FormatAllowedPeriodLabel(TaskItem task)
     {

--- a/ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs
+++ b/ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs
@@ -2,11 +2,15 @@ namespace ShuffleTask.Domain.Entities;
 
 public static class TaskItemPeriodDefinitionHelper
 {
-    public static bool HasAdHocDefinition(TaskItem task)
+    public static bool HasAdHocDefinition(TaskItemData task)
     {
         ArgumentNullException.ThrowIfNull(task);
 
-        return HasAdHocDefinition(task);
+        return task.AdHocStartTime.HasValue
+            || task.AdHocEndTime.HasValue
+            || task.AdHocWeekdays.HasValue
+            || task.AdHocIsAllDay
+            || task.AdHocMode != PeriodDefinitionMode.None;
     }
 
     public static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)
@@ -61,14 +65,5 @@ public static class TaskItemPeriodDefinitionHelper
             AllowedPeriod.OffWork => PeriodDefinitionCatalog.OffWorkId,
             _ => PeriodDefinitionCatalog.AnyId
         };
-    }
-
-    private static bool HasAdHocDefinition(TaskItemData task)
-    {
-        return task.AdHocStartTime.HasValue
-            || task.AdHocEndTime.HasValue
-            || task.AdHocWeekdays.HasValue
-            || task.AdHocIsAllDay
-            || task.AdHocMode != PeriodDefinitionMode.None;
     }
 }

--- a/ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs
+++ b/ShuffleTask.Domain/TaskItemPeriodDefinitionHelper.cs
@@ -6,7 +6,7 @@ public static class TaskItemPeriodDefinitionHelper
     {
         ArgumentNullException.ThrowIfNull(task);
 
-        return HasAdHocDefinition((TaskItemData)task);
+        return HasAdHocDefinition(task);
     }
 
     public static bool TryBuildAdHocDefinition(TaskItem task, out PeriodDefinition definition)

--- a/ShuffleTask.Persistence/Models/TaskItemRecord.cs
+++ b/ShuffleTask.Persistence/Models/TaskItemRecord.cs
@@ -54,7 +54,7 @@ internal sealed class TaskItemRecord : TaskItemData
             AllowedPeriod = AllowedPeriod.OffWork;
         }
 
-        NormalizeLegacyPeriodDefinition();
+        TaskItemPeriodDefinitionHelper.NormalizeLegacyPeriodDefinition(this);
 
         if (UpdatedAt == default)
         {
@@ -64,41 +64,4 @@ internal sealed class TaskItemRecord : TaskItemData
         return TaskItem.FromData(this);
     }
 
-    private void NormalizeLegacyPeriodDefinition()
-    {
-        if (!string.IsNullOrWhiteSpace(PeriodDefinitionId) || HasAdHocDefinition())
-        {
-            return;
-        }
-
-        if (AllowedPeriod == AllowedPeriod.Custom)
-        {
-            if (CustomStartTime.HasValue || CustomEndTime.HasValue || CustomWeekdays.HasValue)
-            {
-                AdHocStartTime = CustomStartTime;
-                AdHocEndTime = CustomEndTime;
-                AdHocWeekdays = CustomWeekdays;
-                AdHocIsAllDay = !CustomStartTime.HasValue || !CustomEndTime.HasValue;
-                AdHocMode = PeriodDefinitionMode.None;
-            }
-
-            return;
-        }
-
-        PeriodDefinitionId = AllowedPeriod switch
-        {
-            AllowedPeriod.Work => PeriodDefinitionCatalog.WorkId,
-            AllowedPeriod.OffWork => PeriodDefinitionCatalog.OffWorkId,
-            _ => PeriodDefinitionCatalog.AnyId
-        };
-    }
-
-    private bool HasAdHocDefinition()
-    {
-        return AdHocStartTime.HasValue
-            || AdHocEndTime.HasValue
-            || AdHocWeekdays.HasValue
-            || AdHocIsAllDay
-            || AdHocMode != PeriodDefinitionMode.None;
-    }
 }

--- a/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/EditTaskViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Utilities;
 using ShuffleTask.Domain.Entities;
 using ShuffleTask.Presentation.Utilities;
 using System.Collections.ObjectModel;

--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
 using ShuffleTask.Application.Services;
+using ShuffleTask.Application.Utilities;
 using ShuffleTask.Domain.Entities;
 using ShuffleTask.Presentation.Utilities;
 

--- a/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
+++ b/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
@@ -451,7 +451,7 @@ public class StorageServiceStub : IStorageService
 
     private void ApplyPeriodDefinition(TaskItem task)
     {
-        NormalizeLegacyPeriodDefinition(task);
+        TaskItemPeriodDefinitionHelper.NormalizeLegacyPeriodDefinition(task);
         if (string.IsNullOrWhiteSpace(task.PeriodDefinitionId))
         {
             return;
@@ -472,44 +472,6 @@ public class StorageServiceStub : IStorageService
         task.AdHocWeekdays = definition.Weekdays;
         task.AdHocIsAllDay = definition.IsAllDay;
         task.AdHocMode = definition.Mode;
-    }
-
-    private static void NormalizeLegacyPeriodDefinition(TaskItem task)
-    {
-        if (!string.IsNullOrWhiteSpace(task.PeriodDefinitionId) || HasAdHocDefinition(task))
-        {
-            return;
-        }
-
-        if (task.AllowedPeriod == AllowedPeriod.Custom)
-        {
-            if (task.CustomStartTime.HasValue || task.CustomEndTime.HasValue || task.CustomWeekdays.HasValue)
-            {
-                task.AdHocStartTime = task.CustomStartTime;
-                task.AdHocEndTime = task.CustomEndTime;
-                task.AdHocWeekdays = task.CustomWeekdays;
-                task.AdHocIsAllDay = !task.CustomStartTime.HasValue || !task.CustomEndTime.HasValue;
-                task.AdHocMode = PeriodDefinitionMode.None;
-            }
-
-            return;
-        }
-
-        task.PeriodDefinitionId = task.AllowedPeriod switch
-        {
-            AllowedPeriod.Work => PeriodDefinitionCatalog.WorkId,
-            AllowedPeriod.OffWork => PeriodDefinitionCatalog.OffWorkId,
-            _ => PeriodDefinitionCatalog.AnyId
-        };
-    }
-
-    private static bool HasAdHocDefinition(TaskItem task)
-    {
-        return task.AdHocStartTime.HasValue
-            || task.AdHocEndTime.HasValue
-            || task.AdHocWeekdays.HasValue
-            || task.AdHocIsAllDay
-            || task.AdHocMode != PeriodDefinitionMode.None;
     }
 
     private static DateTime EnsureUtc(DateTime value)

--- a/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
+++ b/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
@@ -451,6 +451,7 @@ public class StorageServiceStub : IStorageService
 
     private void ApplyPeriodDefinition(TaskItem task)
     {
+        NormalizeLegacyPeriodDefinition(task);
         if (string.IsNullOrWhiteSpace(task.PeriodDefinitionId))
         {
             return;
@@ -471,6 +472,44 @@ public class StorageServiceStub : IStorageService
         task.AdHocWeekdays = definition.Weekdays;
         task.AdHocIsAllDay = definition.IsAllDay;
         task.AdHocMode = definition.Mode;
+    }
+
+    private static void NormalizeLegacyPeriodDefinition(TaskItem task)
+    {
+        if (!string.IsNullOrWhiteSpace(task.PeriodDefinitionId) || HasAdHocDefinition(task))
+        {
+            return;
+        }
+
+        if (task.AllowedPeriod == AllowedPeriod.Custom)
+        {
+            if (task.CustomStartTime.HasValue || task.CustomEndTime.HasValue || task.CustomWeekdays.HasValue)
+            {
+                task.AdHocStartTime = task.CustomStartTime;
+                task.AdHocEndTime = task.CustomEndTime;
+                task.AdHocWeekdays = task.CustomWeekdays;
+                task.AdHocIsAllDay = !task.CustomStartTime.HasValue || !task.CustomEndTime.HasValue;
+                task.AdHocMode = PeriodDefinitionMode.None;
+            }
+
+            return;
+        }
+
+        task.PeriodDefinitionId = task.AllowedPeriod switch
+        {
+            AllowedPeriod.Work => PeriodDefinitionCatalog.WorkId,
+            AllowedPeriod.OffWork => PeriodDefinitionCatalog.OffWorkId,
+            _ => PeriodDefinitionCatalog.AnyId
+        };
+    }
+
+    private static bool HasAdHocDefinition(TaskItem task)
+    {
+        return task.AdHocStartTime.HasValue
+            || task.AdHocEndTime.HasValue
+            || task.AdHocWeekdays.HasValue
+            || task.AdHocIsAllDay
+            || task.AdHocMode != PeriodDefinitionMode.None;
     }
 
     private static DateTime EnsureUtc(DateTime value)


### PR DESCRIPTION
### Motivation
- Preserve behavior for upgraded installs by mapping legacy `AllowedPeriod` enum values and custom window fields into the new `PeriodDefinition` model at load time.
- Ensure tasks that previously used the legacy “Custom” variant keep their ad‑hoc time/weekdays behavior without creating rows in the named period table.
- Keep migration logic resilient so existing tasks behave identically after upgrade.

### Description
- Added `NormalizeLegacyPeriodDefinition()` to `TaskItemRecord.ToDomain()` to convert legacy `AllowedPeriod` values into built‑in period IDs or into ad‑hoc fields when `AllowedPeriod.Custom` has custom time/weekdays, while leaving existing `PeriodDefinitionId` or ad‑hoc definitions untouched.
- Updated test doubles `StorageServiceStub` and `InMemoryStorageService` to call `NormalizeLegacyPeriodDefinition(task)` before applying stored `PeriodDefinition` records so tests emulate real loading behavior.
- Implemented `HasAdHocDefinition()` helpers to avoid clobbering explicit ad‑hoc definitions and ensured the conversion does not persist new `PeriodDefinition` records (ad‑hoc fields are applied inline only).

### Testing
- No automated tests were executed as part of this change; test doubles were updated to reflect the new normalization behavior for unit tests that run elsewhere.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b184f78708326a110444cf144c79a)