### PR TITLE
Add tests for period definitions, ad‑hoc periods and time windows

### DIFF
--- a/ShuffleTask.Tests/Domain/TaskItemTests.cs
+++ b/ShuffleTask.Tests/Domain/TaskItemTests.cs
@@ -97,6 +97,14 @@ public class TaskItemTests
             IntervalDays = 2,
             LastDoneAt = new DateTime(2025, 9, 10, 12, 0, 0, DateTimeKind.Utc),
             AllowedPeriod = AllowedPeriod.Work,
+            PeriodDefinitionId = "afternoon",
+            AdHocStartTime = new TimeSpan(9, 30, 0),
+            AdHocEndTime = new TimeSpan(11, 15, 0),
+            AdHocWeekdays = Weekdays.Mon | Weekdays.Fri,
+            AdHocIsAllDay = false,
+            AdHocMode = PeriodDefinitionMode.AlignWithWorkHours,
+            CustomStartTime = new TimeSpan(8, 0, 0),
+            CustomEndTime = new TimeSpan(9, 0, 0),
             CustomWeekdays = Weekdays.Mon | Weekdays.Wed,
             Paused = true,
             CreatedAt = new DateTime(2025, 9, 1, 9, 0, 0, DateTimeKind.Utc),
@@ -128,6 +136,14 @@ public class TaskItemTests
             Assert.That(actual.IntervalDays, Is.EqualTo(expected.IntervalDays));
             Assert.That(actual.LastDoneAt, Is.EqualTo(expected.LastDoneAt));
             Assert.That(actual.AllowedPeriod, Is.EqualTo(expected.AllowedPeriod));
+            Assert.That(actual.PeriodDefinitionId, Is.EqualTo(expected.PeriodDefinitionId));
+            Assert.That(actual.AdHocStartTime, Is.EqualTo(expected.AdHocStartTime));
+            Assert.That(actual.AdHocEndTime, Is.EqualTo(expected.AdHocEndTime));
+            Assert.That(actual.AdHocWeekdays, Is.EqualTo(expected.AdHocWeekdays));
+            Assert.That(actual.AdHocIsAllDay, Is.EqualTo(expected.AdHocIsAllDay));
+            Assert.That(actual.AdHocMode, Is.EqualTo(expected.AdHocMode));
+            Assert.That(actual.CustomStartTime, Is.EqualTo(expected.CustomStartTime));
+            Assert.That(actual.CustomEndTime, Is.EqualTo(expected.CustomEndTime));
             Assert.That(actual.CustomWeekdays, Is.EqualTo(expected.CustomWeekdays));
             Assert.That(actual.Paused, Is.EqualTo(expected.Paused));
             Assert.That(actual.CreatedAt, Is.EqualTo(expected.CreatedAt));


### PR DESCRIPTION
### Motivation
- Increase coverage around scheduling rules by exercising all-day period definitions constrained by weekdays.
- Verify persistence behavior for named `PeriodDefinition` records and ensure task-level ad‑hoc periods do not create named records unintentionally.
- Ensure task cloning/copying includes the new period-related fields so domain invariants are preserved.

### Description
- Added TimeWindowService unit tests in `ShuffleTask.Tests/TimeWindowServiceTests.cs` covering all-day weekday-scoped periods, work/off-work alignment with `AppSettings`, and preset ranges for Mornings/Evenings/Lunch.
- Added persistence tests in `ShuffleTask.Tests/TestDoubles/StorageServiceStubTests.cs` to assert that named `PeriodDefinition` records round-trip via the storage stub and that ad‑hoc custom periods persist on tasks without adding new named definitions.
- Updated `ShuffleTask.Tests/Domain/TaskItemTests.cs` to include `PeriodDefinitionId`, ad‑hoc time/weekdays fields and legacy `CustomStartTime`/`CustomEndTime` in `CreateTaskItem` and in `AssertSameData` so clone/copy assertions cover the new fields.

### Testing
- Attempted to run automated tests with `dotnet test ShuffleTask.Tests/ShuffleTask.Tests.csproj`, but the `dotnet` command is not available in the current environment so tests were not executed.
- The changes are limited to test files and were committed locally; no test failures were observed since tests could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca8f74a308326ab545ab3ed00d3a7)