### PR TITLE
Align morning/lunch/evening periods with settings-driven slots

### DIFF
--- a/ShuffleTask.Application/AppSettings.cs
+++ b/ShuffleTask.Application/AppSettings.cs
@@ -25,6 +25,24 @@ public partial class AppSettings : ObservableObject
 
     [ObservableProperty]
     private TimeSpan workEnd = new(17, 0, 0); // default 17:00
+
+    [ObservableProperty]
+    private TimeSpan morningStart = new(7, 0, 0);
+
+    [ObservableProperty]
+    private TimeSpan morningEnd = new(10, 0, 0);
+
+    [ObservableProperty]
+    private TimeSpan lunchStart = new(12, 0, 0);
+
+    [ObservableProperty]
+    private TimeSpan lunchEnd = new(13, 0, 0);
+
+    [ObservableProperty]
+    private TimeSpan eveningStart = new(18, 0, 0);
+
+    [ObservableProperty]
+    private TimeSpan eveningEnd = new(21, 0, 0);
     public TimerMode TimerMode { get; set; } = TimerMode.LongInterval;
 
     public int FocusMinutes { get; set; } = 15;
@@ -119,6 +137,12 @@ public partial class AppSettings : ObservableObject
 
         WorkStart = source.WorkStart;
         WorkEnd = source.WorkEnd;
+        MorningStart = source.MorningStart;
+        MorningEnd = source.MorningEnd;
+        LunchStart = source.LunchStart;
+        LunchEnd = source.LunchEnd;
+        EveningStart = source.EveningStart;
+        EveningEnd = source.EveningEnd;
         TimerMode = source.TimerMode;
         FocusMinutes = source.FocusMinutes;
         BreakMinutes = source.BreakMinutes;

--- a/ShuffleTask.Application/Services/TimeWindowService.cs
+++ b/ShuffleTask.Application/Services/TimeWindowService.cs
@@ -174,6 +174,21 @@ public static class TimeWindowService
             return (s.WorkStart, s.WorkEnd);
         }
 
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Morning))
+        {
+            return (s.MorningStart, s.MorningEnd);
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Lunch))
+        {
+            return (s.LunchStart, s.LunchEnd);
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Evening))
+        {
+            return (s.EveningStart, s.EveningEnd);
+        }
+
         return (definition.StartTime ?? TimeSpan.Zero, definition.EndTime ?? TimeSpan.Zero);
     }
 

--- a/ShuffleTask.Application/Utilities/PeriodDefinitionFormatter.cs
+++ b/ShuffleTask.Application/Utilities/PeriodDefinitionFormatter.cs
@@ -124,6 +124,21 @@ public static class PeriodDefinitionFormatter
             return "Work hours";
         }
 
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Morning))
+        {
+            return "Morning hours";
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Lunch))
+        {
+            return "Lunch break";
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Evening))
+        {
+            return "Evening hours";
+        }
+
         if (definition.IsAllDay)
         {
             return "All day";
@@ -147,6 +162,21 @@ public static class PeriodDefinitionFormatter
         if (mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours))
         {
             return "Aligns to Settings → Work hours.";
+        }
+
+        if (mode.HasFlag(PeriodDefinitionMode.Morning))
+        {
+            return "Aligns to Settings → Morning hours.";
+        }
+
+        if (mode.HasFlag(PeriodDefinitionMode.Lunch))
+        {
+            return "Aligns to Settings → Lunch break.";
+        }
+
+        if (mode.HasFlag(PeriodDefinitionMode.Evening))
+        {
+            return "Aligns to Settings → Evening hours.";
         }
 
         return string.Empty;

--- a/ShuffleTask.Domain/PeriodDefinition.cs
+++ b/ShuffleTask.Domain/PeriodDefinition.cs
@@ -5,7 +5,10 @@ public enum PeriodDefinitionMode
 {
     None = 0,
     AlignWithWorkHours = 1,
-    OffWorkRelativeToWorkHours = 2
+    OffWorkRelativeToWorkHours = 2,
+    Morning = 4,
+    Lunch = 8,
+    Evening = 16
 }
 
 public class PeriodDefinition
@@ -92,7 +95,7 @@ public static class PeriodDefinitionCatalog
         StartTime = new TimeSpan(7, 0, 0),
         EndTime = new TimeSpan(10, 0, 0),
         IsAllDay = false,
-        Mode = PeriodDefinitionMode.None
+        Mode = PeriodDefinitionMode.Morning
     };
 
     public static readonly PeriodDefinition Evenings = new()
@@ -103,7 +106,7 @@ public static class PeriodDefinitionCatalog
         StartTime = new TimeSpan(18, 0, 0),
         EndTime = new TimeSpan(21, 0, 0),
         IsAllDay = false,
-        Mode = PeriodDefinitionMode.None
+        Mode = PeriodDefinitionMode.Evening
     };
 
     public static readonly PeriodDefinition LunchBreak = new()
@@ -114,7 +117,7 @@ public static class PeriodDefinitionCatalog
         StartTime = new TimeSpan(12, 0, 0),
         EndTime = new TimeSpan(13, 0, 0),
         IsAllDay = false,
-        Mode = PeriodDefinitionMode.None
+        Mode = PeriodDefinitionMode.Lunch
     };
 
     private static readonly IReadOnlyDictionary<string, PeriodDefinition> BuiltIns =

--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -125,6 +125,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         {
             bool wasAnonymous = _lastAnonymousMode;
             ApplyValidation();
+            SyncSlotSettingsFromViewModel();
             await PersistSettingsAsync();
             await PersistPresetDefinitionsAsync();
             bool sessionChanged = wasAnonymous != IsAnonymousSession || !string.Equals(_lastUserId, Settings.Network.UserId, StringComparison.Ordinal);
@@ -299,6 +300,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         ApplyDefinitionTimes(_morningDefinition, PeriodDefinitionCatalog.Mornings, start => MorningStart = start, end => MorningEnd = end);
         ApplyDefinitionTimes(_eveningDefinition, PeriodDefinitionCatalog.Evenings, start => EveningStart = start, end => EveningEnd = end);
         ApplyDefinitionTimes(_lunchDefinition, PeriodDefinitionCatalog.LunchBreak, start => LunchStart = start, end => LunchEnd = end);
+        SyncSlotSettingsFromViewModel();
     }
 
     private async Task PersistPresetDefinitionsAsync()
@@ -325,7 +327,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         definition.StartTime = start;
         definition.EndTime = end;
         definition.IsAllDay = false;
-        definition.Mode = PeriodDefinitionMode.None;
+        definition.Mode = fallback.Mode;
 
         if (string.IsNullOrWhiteSpace(definition.Id))
         {
@@ -338,6 +340,16 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         }
 
         await _storage.UpdatePeriodDefinitionAsync(definition);
+    }
+
+    private void SyncSlotSettingsFromViewModel()
+    {
+        Settings.MorningStart = MorningStart;
+        Settings.MorningEnd = MorningEnd;
+        Settings.LunchStart = LunchStart;
+        Settings.LunchEnd = LunchEnd;
+        Settings.EveningStart = EveningStart;
+        Settings.EveningEnd = EveningEnd;
     }
 
     private void ApplyValidation()

--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -297,10 +297,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _eveningDefinition = await _storage.GetPeriodDefinitionAsync(PeriodDefinitionCatalog.EveningsId);
         _lunchDefinition = await _storage.GetPeriodDefinitionAsync(PeriodDefinitionCatalog.LunchBreakId);
 
-        ApplyDefinitionTimes(_morningDefinition, PeriodDefinitionCatalog.Mornings, start => MorningStart = start, end => MorningEnd = end);
-        ApplyDefinitionTimes(_eveningDefinition, PeriodDefinitionCatalog.Evenings, start => EveningStart = start, end => EveningEnd = end);
-        ApplyDefinitionTimes(_lunchDefinition, PeriodDefinitionCatalog.LunchBreak, start => LunchStart = start, end => LunchEnd = end);
-        SyncSlotSettingsFromViewModel();
+        ApplySlotSettingsFromSettings();
     }
 
     private async Task PersistPresetDefinitionsAsync()
@@ -310,12 +307,14 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         await UpsertPresetDefinitionAsync(_lunchDefinition, PeriodDefinitionCatalog.LunchBreak, LunchStart, LunchEnd);
     }
 
-    private static void ApplyDefinitionTimes(PeriodDefinition? definition, PeriodDefinition fallback, Action<TimeSpan> setStart, Action<TimeSpan> setEnd)
+    private void ApplySlotSettingsFromSettings()
     {
-        TimeSpan start = definition?.StartTime ?? fallback.StartTime ?? TimeSpan.Zero;
-        TimeSpan end = definition?.EndTime ?? fallback.EndTime ?? TimeSpan.Zero;
-        setStart(start);
-        setEnd(end);
+        MorningStart = Settings.MorningStart;
+        MorningEnd = Settings.MorningEnd;
+        LunchStart = Settings.LunchStart;
+        LunchEnd = Settings.LunchEnd;
+        EveningStart = Settings.EveningStart;
+        EveningEnd = Settings.EveningEnd;
     }
 
     private async Task UpsertPresetDefinitionAsync(PeriodDefinition? definition, PeriodDefinition fallback, TimeSpan start, TimeSpan end)

--- a/ShuffleTask.Tests/TimeWindowServiceTests.cs
+++ b/ShuffleTask.Tests/TimeWindowServiceTests.cs
@@ -135,13 +135,19 @@ public class TimeWindowServiceTests
         var settings = new AppSettings
         {
             WorkStart = new TimeSpan(9, 0, 0),
-            WorkEnd = new TimeSpan(17, 0, 0)
+            WorkEnd = new TimeSpan(17, 0, 0),
+            MorningStart = new TimeSpan(6, 0, 0),
+            MorningEnd = new TimeSpan(9, 0, 0),
+            LunchStart = new TimeSpan(11, 30, 0),
+            LunchEnd = new TimeSpan(12, 30, 0),
+            EveningStart = new TimeSpan(19, 0, 0),
+            EveningEnd = new TimeSpan(22, 0, 0)
         };
-        var morningInside = LocalDate(2024, 1, 2, 8, 0);
-        var morningOutside = LocalDate(2024, 1, 2, 11, 0);
-        var eveningInside = LocalDate(2024, 1, 2, 19, 0);
+        var morningInside = LocalDate(2024, 1, 2, 7, 30);
+        var morningOutside = LocalDate(2024, 1, 2, 10, 0);
+        var eveningInside = LocalDate(2024, 1, 2, 21, 0);
         var eveningOutside = LocalDate(2024, 1, 2, 10, 0);
-        var lunchInside = LocalDate(2024, 1, 2, 12, 30);
+        var lunchInside = LocalDate(2024, 1, 2, 12, 0);
         var lunchOutside = LocalDate(2024, 1, 2, 14, 0);
 
         Assert.Multiple(() =>


### PR DESCRIPTION
### Motivation
- Make the built-in Mornings/Lunch/Evenings period definitions use user-configurable slots from settings instead of fixed times. 
- Preserve existing Work/OffWork alignment behavior while enabling settings-driven resolution for the new presets. 

### Description
- Added new flagged enum values `Morning`, `Lunch`, and `Evening` to `PeriodDefinitionMode` and set the corresponding presets to use those modes in `PeriodDefinitionCatalog`.
- Added morning/lunch/evening start/end properties to `AppSettings` and wired them into `CopyFrom` so settings are persisted and round-tripped.
- Updated `TimeWindowService.ResolveTimeWindow` to resolve Morning/Lunch/Evening modes by pulling times from `AppSettings` while keeping `AlignWithWorkHours`/`OffWorkRelativeToWorkHours` behavior intact.
- Updated `PeriodDefinitionFormatter` to format the new modes; updated `SettingsViewModel` to sync slot values between the view model and `AppSettings` and to preserve the preset `Mode` when persisting preset definitions.
- Adjusted unit expectations in `ShuffleTask.Tests/TimeWindowServiceTests.cs` to reflect the settings-driven default slot ranges.

### Testing
- Updated unit test file: `ShuffleTask.Tests/TimeWindowServiceTests.cs` to assert behavior against the new configurable slot times.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697de7884c848326b21adba361fbb81c)