### PR TITLE
Ignore time windows for all-day period definitions while preserving weekday filtering

### DIFF
--- a/ShuffleTask.Application/Services/TimeWindowService.cs
+++ b/ShuffleTask.Application/Services/TimeWindowService.cs
@@ -76,17 +76,15 @@ public static class TimeWindowService
         ArgumentNullException.ThrowIfNull(definition);
 
         Weekdays weekdays = NormalizeWeekdays(definition.Weekdays);
-        (TimeSpan start, TimeSpan end) = ResolveTimeWindow(definition, s);
         bool isAllDay = definition.IsAllDay;
 
         if (isAllDay)
         {
-            if (!IsWithinWeekdayScopeForAllDay(now, weekdays))
-            {
-                return false;
-            }
+            return IsWithinWeekdayScopeForAllDay(now, weekdays);
         }
-        else if (!IsWithinWeekdayScope(now, weekdays, start, end))
+
+        (TimeSpan start, TimeSpan end) = ResolveTimeWindow(definition, s);
+        if (!IsWithinWeekdayScope(now, weekdays, start, end))
         {
             return false;
         }
@@ -101,7 +99,7 @@ public static class TimeWindowService
             return !IsWithinWorkHours(now, start, end);
         }
 
-        return isAllDay || IsWithinWorkHours(now, start, end);
+        return IsWithinWorkHours(now, start, end);
     }
 
     private static PeriodDefinition ResolveDefinition(TaskItem task)

--- a/ShuffleTask.Application/Services/TimeWindowService.cs
+++ b/ShuffleTask.Application/Services/TimeWindowService.cs
@@ -80,7 +80,23 @@ public static class TimeWindowService
 
         if (isAllDay)
         {
-            return IsWithinWeekdayScopeForAllDay(now, weekdays);
+            if (!IsWithinWeekdayScopeForAllDay(now, weekdays))
+            {
+                return false;
+            }
+
+            if (definition.Mode.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours))
+            {
+                (TimeSpan start, TimeSpan end) = ResolveTimeWindow(definition, s);
+                if (IsWeekend(now))
+                {
+                    return true;
+                }
+
+                return !IsWithinWorkHours(now, start, end);
+            }
+
+            return true;
         }
 
         (TimeSpan start, TimeSpan end) = ResolveTimeWindow(definition, s);


### PR DESCRIPTION
### Motivation
- Ensure `IsAllDay` period definitions are evaluated only by weekdays and not by time-of-day windows.
- Keep weekday filtering behavior consistent when resolving effective time windows for other period definitions.

### Description
- Updated `TimeWindowService.AllowedNow` to early-return weekday-only eligibility for `IsAllDay` definitions by calling `IsWithinWeekdayScopeForAllDay` and skipping time-window checks.
- Deferred calling `ResolveTimeWindow` until after `IsAllDay` handling and kept the weekday check via `IsWithinWeekdayScope(now, weekdays, start, end)` for timed definitions.
- Simplified the final return to use `IsWithinWorkHours(now, start, end)` (the `IsAllDay` case now returns earlier), and left `OffWorkRelativeToWorkHours` handling unchanged.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2c6fe9048326827ffd361ed476da)