### PR TITLE
Persist settings-aligned period modes and migrate preset definitions

### DIFF
--- a/ShuffleTask.Persistence/Models/PeriodDefinitionRecord.cs
+++ b/ShuffleTask.Persistence/Models/PeriodDefinitionRecord.cs
@@ -21,6 +21,15 @@ internal sealed class PeriodDefinitionRecord
 
     public PeriodDefinitionMode Mode { get; set; }
 
+    private static bool IsSettingsAligned(PeriodDefinitionMode mode)
+    {
+        return mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours)
+            || mode.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours)
+            || mode.HasFlag(PeriodDefinitionMode.Morning)
+            || mode.HasFlag(PeriodDefinitionMode.Lunch)
+            || mode.HasFlag(PeriodDefinitionMode.Evening);
+    }
+
     public static PeriodDefinitionRecord FromDomain(PeriodDefinition definition)
     {
         ArgumentNullException.ThrowIfNull(definition);
@@ -30,8 +39,8 @@ internal sealed class PeriodDefinitionRecord
             Id = definition.Id,
             Name = definition.Name,
             Weekdays = definition.Weekdays,
-            StartTime = definition.StartTime,
-            EndTime = definition.EndTime,
+            StartTime = IsSettingsAligned(definition.Mode) ? null : definition.StartTime,
+            EndTime = IsSettingsAligned(definition.Mode) ? null : definition.EndTime,
             IsAllDay = definition.IsAllDay,
             Mode = definition.Mode
         };
@@ -39,15 +48,41 @@ internal sealed class PeriodDefinitionRecord
 
     public PeriodDefinition ToDomain()
     {
+        PeriodDefinitionMode mode = Mode;
+
+        if (mode == PeriodDefinitionMode.None)
+        {
+            if (string.Equals(Id, PeriodDefinitionCatalog.WorkId, StringComparison.OrdinalIgnoreCase))
+            {
+                mode = PeriodDefinitionMode.AlignWithWorkHours;
+            }
+            else if (string.Equals(Id, PeriodDefinitionCatalog.OffWorkId, StringComparison.OrdinalIgnoreCase))
+            {
+                mode = PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours;
+            }
+            else if (string.Equals(Id, PeriodDefinitionCatalog.MorningsId, StringComparison.OrdinalIgnoreCase))
+            {
+                mode = PeriodDefinitionMode.Morning;
+            }
+            else if (string.Equals(Id, PeriodDefinitionCatalog.LunchBreakId, StringComparison.OrdinalIgnoreCase))
+            {
+                mode = PeriodDefinitionMode.Lunch;
+            }
+            else if (string.Equals(Id, PeriodDefinitionCatalog.EveningsId, StringComparison.OrdinalIgnoreCase))
+            {
+                mode = PeriodDefinitionMode.Evening;
+            }
+        }
+
         return new PeriodDefinition
         {
             Id = Id,
             Name = Name,
             Weekdays = Weekdays,
-            StartTime = StartTime,
-            EndTime = EndTime,
+            StartTime = IsSettingsAligned(mode) ? null : StartTime,
+            EndTime = IsSettingsAligned(mode) ? null : EndTime,
             IsAllDay = IsAllDay,
-            Mode = Mode
+            Mode = mode
         };
     }
 }

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -11,6 +11,7 @@ public class StorageService : IStorageService
 {
     private const string SettingsKey = "app_settings";
     private const string IntegerSqlType = "INTEGER";
+    private readonly record struct SchemaColumn(string Name, string SqlType, string DefaultSql);
 
     private readonly TimeProvider _clock;
     private readonly string _dbPath;
@@ -51,60 +52,47 @@ public class StorageService : IStorageService
 
     private async Task EnsureTaskSchemaAsync()
     {
-        try
-        {
-            var infos = await Db.QueryAsync<TableInfo>("PRAGMA table_info(TaskItem);");
-            var cols = new HashSet<string>(infos.Select(i => i.name), StringComparer.OrdinalIgnoreCase);
-            async Task AddCol(string name, string sqlType, string defaultSql)
+        await EnsureSchemaAsync(
+            "TaskItem",
+            new[]
             {
-                if (!cols.Contains(name))
-                {
-                    string alter = $"ALTER TABLE TaskItem ADD COLUMN {name} {sqlType} DEFAULT {defaultSql}";
-                    await Db.ExecuteAsync(alter);
-                }
-            }
-
-            await AddCol("Title", "TEXT", "''");
-            await AddCol("Importance", IntegerSqlType, "1");
-            await AddCol("SizePoints", "REAL", "3");
-            await AddCol("Deadline", "TEXT", "NULL");
-            await AddCol("Repeat", IntegerSqlType, "0");
-            await AddCol("Weekdays", IntegerSqlType, "0");
-            await AddCol("IntervalDays", IntegerSqlType, "0");
-            await AddCol("LastDoneAt", "TEXT", "NULL");
-            await AddCol("AllowedPeriod", IntegerSqlType, "0");
-            await AddCol("PeriodDefinitionId", "TEXT", "NULL");
-            await AddCol("AdHocStartTime", "TEXT", "NULL");
-            await AddCol("AdHocEndTime", "TEXT", "NULL");
-            await AddCol("AdHocWeekdays", IntegerSqlType, "NULL");
-            await AddCol("AdHocIsAllDay", IntegerSqlType, "0");
-            await AddCol("AdHocMode", IntegerSqlType, "0");
-            await AddCol("AutoShuffleAllowed", IntegerSqlType, "1");
-            await AddCol("CustomStartTime", "TEXT", "NULL");
-            await AddCol("CustomEndTime", "TEXT", "NULL");
-            await AddCol("CustomWeekdays", IntegerSqlType, "NULL");
-            await AddCol("Paused", IntegerSqlType, "0");
-            await AddCol("CreatedAt", "TEXT", "CURRENT_TIMESTAMP");
-            await AddCol("UpdatedAt", "TEXT", "CURRENT_TIMESTAMP");
-            await AddCol("Description", "TEXT", "''");
-            await AddCol("Status", IntegerSqlType, "0");
-            await AddCol("SnoozedUntil", "TEXT", "NULL");
-            await AddCol("CompletedAt", "TEXT", "NULL");
-            await AddCol("NextEligibleAt", "TEXT", "NULL");
-            await AddCol("CustomTimerMode", IntegerSqlType, "NULL");
-            await AddCol("CustomReminderMinutes", IntegerSqlType, "NULL");
-            await AddCol("CustomFocusMinutes", IntegerSqlType, "NULL");
-            await AddCol("CustomBreakMinutes", IntegerSqlType, "NULL");
-            await AddCol("CustomPomodoroCycles", IntegerSqlType, "NULL");
-            await AddCol("CutInLineMode", IntegerSqlType, "0");
-            await AddCol("EventVersion", IntegerSqlType, "0");
-            await AddCol("DeviceId", "TEXT", "''");
-            await AddCol("UserId", "TEXT", "NULL");
-        }
-        catch
-        {
-            // best-effort; ignore migration errors
-        }
+                new SchemaColumn("Title", "TEXT", "''"),
+                new SchemaColumn("Importance", IntegerSqlType, "1"),
+                new SchemaColumn("SizePoints", "REAL", "3"),
+                new SchemaColumn("Deadline", "TEXT", "NULL"),
+                new SchemaColumn("Repeat", IntegerSqlType, "0"),
+                new SchemaColumn("Weekdays", IntegerSqlType, "0"),
+                new SchemaColumn("IntervalDays", IntegerSqlType, "0"),
+                new SchemaColumn("LastDoneAt", "TEXT", "NULL"),
+                new SchemaColumn("AllowedPeriod", IntegerSqlType, "0"),
+                new SchemaColumn("PeriodDefinitionId", "TEXT", "NULL"),
+                new SchemaColumn("AdHocStartTime", "TEXT", "NULL"),
+                new SchemaColumn("AdHocEndTime", "TEXT", "NULL"),
+                new SchemaColumn("AdHocWeekdays", IntegerSqlType, "NULL"),
+                new SchemaColumn("AdHocIsAllDay", IntegerSqlType, "0"),
+                new SchemaColumn("AdHocMode", IntegerSqlType, "0"),
+                new SchemaColumn("AutoShuffleAllowed", IntegerSqlType, "1"),
+                new SchemaColumn("CustomStartTime", "TEXT", "NULL"),
+                new SchemaColumn("CustomEndTime", "TEXT", "NULL"),
+                new SchemaColumn("CustomWeekdays", IntegerSqlType, "NULL"),
+                new SchemaColumn("Paused", IntegerSqlType, "0"),
+                new SchemaColumn("CreatedAt", "TEXT", "CURRENT_TIMESTAMP"),
+                new SchemaColumn("UpdatedAt", "TEXT", "CURRENT_TIMESTAMP"),
+                new SchemaColumn("Description", "TEXT", "''"),
+                new SchemaColumn("Status", IntegerSqlType, "0"),
+                new SchemaColumn("SnoozedUntil", "TEXT", "NULL"),
+                new SchemaColumn("CompletedAt", "TEXT", "NULL"),
+                new SchemaColumn("NextEligibleAt", "TEXT", "NULL"),
+                new SchemaColumn("CustomTimerMode", IntegerSqlType, "NULL"),
+                new SchemaColumn("CustomReminderMinutes", IntegerSqlType, "NULL"),
+                new SchemaColumn("CustomFocusMinutes", IntegerSqlType, "NULL"),
+                new SchemaColumn("CustomBreakMinutes", IntegerSqlType, "NULL"),
+                new SchemaColumn("CustomPomodoroCycles", IntegerSqlType, "NULL"),
+                new SchemaColumn("CutInLineMode", IntegerSqlType, "0"),
+                new SchemaColumn("EventVersion", IntegerSqlType, "0"),
+                new SchemaColumn("DeviceId", "TEXT", "''"),
+                new SchemaColumn("UserId", "TEXT", "NULL")
+            });
     }
 
     private async Task EnsurePresetPeriodDefinitionsAsync()
@@ -151,25 +139,36 @@ public class StorageService : IStorageService
 
     private async Task EnsurePeriodDefinitionSchemaAsync()
     {
+        await EnsureSchemaAsync(
+            "PeriodDefinition",
+            new[]
+            {
+                new SchemaColumn("Name", "TEXT", "''"),
+                new SchemaColumn("Weekdays", IntegerSqlType, "0"),
+                new SchemaColumn("StartTime", "TEXT", "NULL"),
+                new SchemaColumn("EndTime", "TEXT", "NULL"),
+                new SchemaColumn("IsAllDay", IntegerSqlType, "0"),
+                new SchemaColumn("Mode", IntegerSqlType, "0")
+            });
+    }
+
+    private async Task EnsureSchemaAsync(string tableName, IReadOnlyCollection<SchemaColumn> columns)
+    {
         try
         {
-            var infos = await Db.QueryAsync<TableInfo>("PRAGMA table_info(PeriodDefinition);");
+            var infos = await Db.QueryAsync<TableInfo>($"PRAGMA table_info({tableName});");
             var cols = new HashSet<string>(infos.Select(i => i.name), StringComparer.OrdinalIgnoreCase);
-            async Task AddCol(string name, string sqlType, string defaultSql)
-            {
-                if (!cols.Contains(name))
-                {
-                    string alter = $"ALTER TABLE PeriodDefinition ADD COLUMN {name} {sqlType} DEFAULT {defaultSql}";
-                    await Db.ExecuteAsync(alter);
-                }
-            }
 
-            await AddCol("Name", "TEXT", "''");
-            await AddCol("Weekdays", IntegerSqlType, "0");
-            await AddCol("StartTime", "TEXT", "NULL");
-            await AddCol("EndTime", "TEXT", "NULL");
-            await AddCol("IsAllDay", IntegerSqlType, "0");
-            await AddCol("Mode", IntegerSqlType, "0");
+            foreach (var column in columns)
+            {
+                if (cols.Contains(column.Name))
+                {
+                    continue;
+                }
+
+                string alter = $"ALTER TABLE {tableName} ADD COLUMN {column.Name} {column.SqlType} DEFAULT {column.DefaultSql}";
+                await Db.ExecuteAsync(alter);
+            }
         }
         catch
         {

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -45,6 +45,7 @@ public class StorageService : IStorageService
 
         // Ensure schema has all columns; add columns if missing with sensible defaults.
         await EnsureTaskSchemaAsync();
+        await EnsurePeriodDefinitionSchemaAsync();
         await EnsurePresetPeriodDefinitionsAsync();
     }
 
@@ -122,13 +123,57 @@ public class StorageService : IStorageService
 
         foreach (var preset in presets)
         {
+            var record = PeriodDefinitionRecord.FromDomain(preset);
+
             if (existingIds.Contains(preset.Id))
             {
+                var existingRecord = existing.First(existingItem =>
+                    string.Equals(existingItem.Id, preset.Id, StringComparison.OrdinalIgnoreCase));
+
+                bool needsUpdate = existingRecord.Mode != record.Mode;
+                bool shouldClearTimes = record.StartTime is null && record.EndTime is null
+                    && (existingRecord.StartTime.HasValue || existingRecord.EndTime.HasValue);
+
+                if (needsUpdate || shouldClearTimes)
+                {
+                    existingRecord.Mode = record.Mode;
+                    existingRecord.StartTime = record.StartTime;
+                    existingRecord.EndTime = record.EndTime;
+                    await Db.UpdateAsync(existingRecord);
+                }
+
                 continue;
             }
 
-            var record = PeriodDefinitionRecord.FromDomain(preset);
             await Db.InsertAsync(record);
+        }
+    }
+
+    private async Task EnsurePeriodDefinitionSchemaAsync()
+    {
+        try
+        {
+            var infos = await Db.QueryAsync<TableInfo>("PRAGMA table_info(PeriodDefinition);");
+            var cols = new HashSet<string>(infos.Select(i => i.name), StringComparer.OrdinalIgnoreCase);
+            async Task AddCol(string name, string sqlType, string defaultSql)
+            {
+                if (!cols.Contains(name))
+                {
+                    string alter = $"ALTER TABLE PeriodDefinition ADD COLUMN {name} {sqlType} DEFAULT {defaultSql}";
+                    await Db.ExecuteAsync(alter);
+                }
+            }
+
+            await AddCol("Name", "TEXT", "''");
+            await AddCol("Weekdays", IntegerSqlType, "0");
+            await AddCol("StartTime", "TEXT", "NULL");
+            await AddCol("EndTime", "TEXT", "NULL");
+            await AddCol("IsAllDay", IntegerSqlType, "0");
+            await AddCol("Mode", IntegerSqlType, "0");
+        }
+        catch
+        {
+            // best-effort; ignore migration errors
         }
     }
 


### PR DESCRIPTION
### Motivation
- Preserve new `PeriodDefinitionMode` enum values in persistence so the app can rely on mode instead of stored times for settings-aligned presets.
- Avoid data drift where preset period start/end times become stale when a preset should align to user `AppSettings` windows.
- Ensure legacy records that predate the `Mode` field map to the correct mode values for built-in presets.

### Description
- Add `IsSettingsAligned` helper and update `PeriodDefinitionRecord.FromDomain` to omit `StartTime`/`EndTime` when the `Mode` indicates alignment to settings (e.g., `AlignWithWorkHours`, `Morning`, `Lunch`, `Evening`, `OffWorkRelativeToWorkHours`).
- Update `PeriodDefinitionRecord.ToDomain` to infer legacy mode values when stored `Mode == PeriodDefinitionMode.None` by checking known preset `Id`s, and to keep `StartTime`/`EndTime` null for settings-aligned modes.
- Add `EnsurePeriodDefinitionSchemaAsync` in `StorageService` to migrate the `PeriodDefinition` table and add missing columns including `Mode`.
- Enhance `EnsurePresetPeriodDefinitionsAsync` to backfill or update existing preset records: it inserts missing presets, updates `Mode` when changed, and clears stored times for presets that are now settings-aligned.

### Testing
- No automated tests were executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807869b9ac8326877ddeaac8d030fc)