### PR TITLE
Support settings-aligned Morning/Lunch/Evening modes in Period Editor

### DIFF
--- a/ShuffleTask.Presentation/Utilities/AlignmentModeCatalog.cs
+++ b/ShuffleTask.Presentation/Utilities/AlignmentModeCatalog.cs
@@ -19,6 +19,18 @@ public static class AlignmentModeCatalog
             new AlignmentModeOption(
                 "Align with off-work hours",
                 "Schedules outside Settings → Work hours (includes weekends).",
-                PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours)
+                PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours),
+            new AlignmentModeOption(
+                "Morning (settings)",
+                "Uses Settings → Morning hours for the time range.",
+                PeriodDefinitionMode.Morning),
+            new AlignmentModeOption(
+                "Lunch (settings)",
+                "Uses Settings → Lunch hours for the time range.",
+                PeriodDefinitionMode.Lunch),
+            new AlignmentModeOption(
+                "Evening (settings)",
+                "Uses Settings → Evening hours for the time range.",
+                PeriodDefinitionMode.Evening)
         };
 }

--- a/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/PeriodDefinitionEditorViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
 using ShuffleTask.Domain.Entities;
 using ShuffleTask.Presentation.Utilities;
 
@@ -9,6 +10,7 @@ namespace ShuffleTask.ViewModels;
 public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekdaySelection
 {
     private readonly IStorageService _storage;
+    private AppSettings _settings = new();
     private string? _definitionId;
     private bool _isNew = true;
 
@@ -40,6 +42,10 @@ public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekd
     [ObservableProperty]
     private bool isBusy;
 
+    public bool IsAlignmentFromSettings => IsSettingsAlignedMode(SelectedAlignmentMode?.Mode ?? PeriodDefinitionMode.None);
+
+    public string SettingsResolvedTimeRange => GetSettingsRangeText(SelectedAlignmentMode?.Mode ?? PeriodDefinitionMode.None);
+
     public bool IsNew
     {
         get => _isNew;
@@ -48,7 +54,15 @@ public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekd
 
     public event EventHandler<PeriodDefinitionSavedEventArgs>? Saved;
 
-    public void Load(PeriodDefinition? definition)
+    public async Task LoadAsync(PeriodDefinition? definition)
+    {
+        await _storage.InitializeAsync();
+        _settings = await _storage.GetSettingsAsync();
+        ApplyDefinition(definition);
+        OnPropertyChanged(nameof(SettingsResolvedTimeRange));
+    }
+
+    private void ApplyDefinition(PeriodDefinition? definition)
     {
         if (definition == null)
         {
@@ -122,4 +136,38 @@ public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekd
         }
     }
 
+    partial void OnSelectedAlignmentModeChanged(AlignmentModeOption? value)
+    {
+        OnPropertyChanged(nameof(IsAlignmentFromSettings));
+        OnPropertyChanged(nameof(SettingsResolvedTimeRange));
+    }
+
+    private static bool IsSettingsAlignedMode(PeriodDefinitionMode mode)
+    {
+        return mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours)
+            || mode.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours)
+            || mode.HasFlag(PeriodDefinitionMode.Morning)
+            || mode.HasFlag(PeriodDefinitionMode.Lunch)
+            || mode.HasFlag(PeriodDefinitionMode.Evening);
+    }
+
+    private string GetSettingsRangeText(PeriodDefinitionMode mode)
+    {
+        (string label, TimeSpan start, TimeSpan end) = mode switch
+        {
+            var m when m.HasFlag(PeriodDefinitionMode.Morning) => ("Morning hours", _settings.MorningStart, _settings.MorningEnd),
+            var m when m.HasFlag(PeriodDefinitionMode.Lunch) => ("Lunch hours", _settings.LunchStart, _settings.LunchEnd),
+            var m when m.HasFlag(PeriodDefinitionMode.Evening) => ("Evening hours", _settings.EveningStart, _settings.EveningEnd),
+            var m when m.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours) => ("Work hours (off-work)", _settings.WorkStart, _settings.WorkEnd),
+            var m when m.HasFlag(PeriodDefinitionMode.AlignWithWorkHours) => ("Work hours", _settings.WorkStart, _settings.WorkEnd),
+            _ => (string.Empty, TimeSpan.Zero, TimeSpan.Zero)
+        };
+
+        if (string.IsNullOrWhiteSpace(label))
+        {
+            return string.Empty;
+        }
+
+        return $"Settings time range: {label} {start:hh\\:mm}–{end:hh\\:mm}";
+    }
 }

--- a/ShuffleTask.Presentation/Views/EditTaskPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/EditTaskPage.xaml.cs
@@ -81,7 +81,7 @@ public partial class EditTaskPage : ContentPage
 
         var editorPage = MauiProgram.Services.GetRequiredService<PeriodDefinitionEditorPage>();
         var editorViewModel = MauiProgram.Services.GetRequiredService<PeriodDefinitionEditorViewModel>();
-        editorViewModel.Load(definition);
+        await editorViewModel.LoadAsync(definition);
 
         void OnSaved(object? sender, PeriodDefinitionSavedEventArgs args)
         {

--- a/ShuffleTask.Presentation/Views/PeriodDefinitionEditorPage.xaml
+++ b/ShuffleTask.Presentation/Views/PeriodDefinitionEditorPage.xaml
@@ -62,9 +62,12 @@
             </Grid>
 
             <Grid Grid.Row="3"
+                  RowDefinitions="Auto,Auto"
                   ColumnDefinitions="*,*"
-                  ColumnSpacing="12">
-                <TimePicker Grid.Column="0"
+                  ColumnSpacing="12"
+                  RowSpacing="8">
+                <TimePicker Grid.Row="0"
+                            Grid.Column="0"
                             Time="{Binding StartTime}">
                     <TimePicker.Triggers>
                         <DataTrigger TargetType="TimePicker"
@@ -72,9 +75,15 @@
                                      Value="True">
                             <Setter Property="IsEnabled" Value="False" />
                         </DataTrigger>
+                        <DataTrigger TargetType="TimePicker"
+                                     Binding="{Binding IsAlignmentFromSettings}"
+                                     Value="True">
+                            <Setter Property="IsEnabled" Value="False" />
+                        </DataTrigger>
                     </TimePicker.Triggers>
                 </TimePicker>
-                <TimePicker Grid.Column="1"
+                <TimePicker Grid.Row="0"
+                            Grid.Column="1"
                             Time="{Binding EndTime}">
                     <TimePicker.Triggers>
                         <DataTrigger TargetType="TimePicker"
@@ -82,8 +91,26 @@
                                      Value="True">
                             <Setter Property="IsEnabled" Value="False" />
                         </DataTrigger>
+                        <DataTrigger TargetType="TimePicker"
+                                     Binding="{Binding IsAlignmentFromSettings}"
+                                     Value="True">
+                            <Setter Property="IsEnabled" Value="False" />
+                        </DataTrigger>
                     </TimePicker.Triggers>
                 </TimePicker>
+                <Label Grid.Row="1"
+                       Grid.ColumnSpan="2"
+                       Text="{Binding SettingsResolvedTimeRange}"
+                       FontSize="12"
+                       TextColor="#6B7280">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding IsAlignmentFromSettings}"
+                                     Value="False">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
             </Grid>
 
             <Grid Grid.Row="4"


### PR DESCRIPTION
### Motivation
- Expose new settings-aligned alignment modes so users can pick Morning/Lunch/Evening variants alongside Work/Off-Work in the period editor.
- When a settings-aligned mode is chosen, the editor should prevent editing start/end times and instead show the resolved time range from app settings.
- Weekday selection must remain available so users can scope settings-aligned modes to specific days (e.g., "Monday mornings").

### Description
- Added three new alignment options to the picker: "Morning (settings)", "Lunch (settings)", and "Evening (settings)" in `AlignmentModeCatalog`.
- Reworked the period editor view model to asynchronously load `AppSettings` via `IStorageService` (`LoadAsync`) and exposed `IsAlignmentFromSettings` and `SettingsResolvedTimeRange` properties to the UI; extracted `ApplyDefinition` to keep loading separate from applying data.
- Implemented `OnSelectedAlignmentModeChanged` and `GetSettingsRangeText` to compute whether a mode is settings-aligned and to format the resolved settings time range for display.
- Updated the editor XAML to disable the `TimePicker` controls when a settings-aligned mode (or all-day) is selected and to show a read-only label with the resolved settings range; updated callers to use `LoadAsync` in `EditTaskPage`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f4a907d88326851fdeba1a65fd7a)