### PR TITLE
Update period editor helper text and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Timer → Platform Notification → Fallback Alert → Logging
 **Background Notifications:**
 Auto-shuffle notifications fire reliably even when the app is backgrounded, using OS-native scheduled notification APIs (AlarmManager on Android, UNUserNotificationCenter on iOS/macOS, ScheduledToastNotification on Windows).
 
+## Allowed periods & presets
+
+Each task can define when it is allowed to be shuffled. The period editor lets you pick a preset (such as a workday or custom window) or create a new preset to reuse across tasks. Presets provide default weekday/time windows; editing a preset updates those defaults for future tasks that choose it.
+
+When using the ad-hoc editor, the **All-day** toggle ignores the start/end time pickers, while alignment modes help snap the window to work or off-work hours. Work/off-work alignment uses the **Work start/end** times from Settings, and off-work covers all remaining hours.
+
 
 ## Prioritization formula
 

--- a/ShuffleTask.Presentation/Views/EditTaskPage.xaml
+++ b/ShuffleTask.Presentation/Views/EditTaskPage.xaml
@@ -180,10 +180,13 @@
                             IsEnabled="{Binding CanEditSelectedDefinition}"
                             Clicked="OnEditSelectedPeriodDefinitionClicked" />
                 </Grid>
+                <Label Text="Presets set default allowed windows; choose one or edit it to update the schedule for future tasks."
+                       FontSize="12"
+                       TextColor="#6B7280" />
             </VerticalStackLayout>
 
             <Grid Grid.Row="9"
-                  RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                  RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                   RowSpacing="8"
                   IsVisible="{Binding IsAdHocSelection}">
                 <Label Grid.Row="0"
@@ -198,7 +201,11 @@
                             IsToggled="{Binding AdHocIsAllDay}"
                             SemanticProperties.Description="All-day windows ignore the time range below." />
                 </Grid>
-                <Grid Grid.Row="2"
+                <Label Grid.Row="2"
+                       Text="All-day ignores the time range; toggle off to set a specific start and end time."
+                       FontSize="12"
+                       TextColor="#6B7280" />
+                <Grid Grid.Row="3"
                       ColumnDefinitions="*,*"
                       ColumnSpacing="12">
                     <TimePicker Grid.Column="0"
@@ -222,7 +229,7 @@
                         </TimePicker.Triggers>
                     </TimePicker>
                 </Grid>
-                <Grid Grid.Row="3"
+                <Grid Grid.Row="4"
                       ColumnDefinitions="Auto,*"
                       ColumnSpacing="12">
                     <Label Text="Alignment mode"
@@ -233,13 +240,17 @@
                             ItemDisplayBinding="{Binding Name}"
                             SemanticProperties.Description="{Binding SelectedAlignmentMode.Description}" />
                 </Grid>
-                <Label Grid.Row="4"
+                <Label Grid.Row="5"
                        Text="{Binding SelectedAlignmentMode.Description}"
                        FontSize="12"
                        TextColor="#6B7280" />
-                <Label Grid.Row="5"
+                <Label Grid.Row="6"
+                       Text="Work/off-work alignment uses the Work start/end times from Settings."
+                       FontSize="12"
+                       TextColor="#6B7280" />
+                <Label Grid.Row="7"
                        Text="Weekdays" />
-                <Grid Grid.Row="6"
+                <Grid Grid.Row="8"
                       RowDefinitions="Auto,Auto"
                       ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       ColumnSpacing="8">

--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -78,7 +78,7 @@
 
             <Label Grid.Row="3"
                    Grid.ColumnSpan="2"
-                   Text="Work hours apply to weekdays (Mon–Fri). Custom hours use the task's weekdays and time range."
+                   Text="Work hours apply to weekdays (Mon–Fri). They power the Workday preset and work/off-work alignment; custom hours use the task's weekdays and time range."
                    FontSize="12"
                    TextColor="#6B7280" />
 


### PR DESCRIPTION
### Motivation
- Clarify UI helper text for the new period/preset workflow so users understand presets, the ad-hoc "All-day" toggle, and work/off-work alignment behavior, and update documentation to match the in-app text.

### Description
- Updated UI copy in `ShuffleTask.Presentation/Views/EditTaskPage.xaml` to add helper lines explaining presets, that the `All-day` toggle disables time pickers, and that work/off-work alignment uses Work start/end times from Settings; adjusted grid rows accordingly.
- Clarified the settings guidance in `ShuffleTask.Presentation/Views/SettingsPage.xaml` to mention the `Workday` preset and alignment behavior, and added a new `Allowed periods & presets` section to `README.md` describing presets, ad-hoc behavior, and alignment.

### Testing
- No automated tests were run for these text/documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69831014c2f48326a34bd8d49cd77b3a)