### PR TITLE
Separate active and completed tasks into sections in Tasks tab

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -27,6 +27,12 @@ public partial class TasksViewModel : ObservableObject
     }
 
     public ObservableCollection<TaskListItem> Tasks { get; } = [];
+    public ObservableCollection<TaskListItem> ActiveTasks { get; } = [];
+    public ObservableCollection<TaskListItem> DoneTasks { get; } = [];
+
+    public bool HasActiveTasks => ActiveTasks.Count > 0;
+    public bool HasDoneTasks => DoneTasks.Count > 0;
+    public bool HasTasks => HasActiveTasks || HasDoneTasks;
 
     [ObservableProperty]
     private bool isBusy;
@@ -49,12 +55,26 @@ public partial class TasksViewModel : ObservableObject
             DateTimeOffset now = _clock.GetUtcNow();
 
             Tasks.Clear();
+            ActiveTasks.Clear();
+            DoneTasks.Clear();
             foreach (TaskListItem? entry in items
                 .Select(task => TaskListItem.From(task, settings, now))
                 .OrderByDescending(x => x.PriorityScore))
             {
                 Tasks.Add(entry);
+                if (entry.Task.Status == TaskLifecycleStatus.Completed)
+                {
+                    DoneTasks.Add(entry);
+                }
+                else
+                {
+                    ActiveTasks.Add(entry);
+                }
             }
+
+            OnPropertyChanged(nameof(HasActiveTasks));
+            OnPropertyChanged(nameof(HasDoneTasks));
+            OnPropertyChanged(nameof(HasTasks));
         }
         finally
         {

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml
@@ -6,6 +6,177 @@
             x:Class="ShuffleTask.Views.TasksPage"
             x:DataType="vm:TasksViewModel"
              Title="Tasks">
+    <ContentPage.Resources>
+        <DataTemplate x:Key="TaskItemTemplate" x:DataType="vm:TaskListItem">
+            <SwipeView>
+                <SwipeView.RightItems>
+                    <SwipeItems Mode="Reveal">
+                        <SwipeItem Text="Edit"
+                                   BackgroundColor="#2d9cdb"
+                                   CommandParameter="{Binding Task}"
+                                   Invoked="OnEditSwipe" />
+                        <SwipeItem Text="Toggle Pause"
+                                   BackgroundColor="#f2c94c"
+                                   CommandParameter="{Binding Task}"
+                                   Invoked="OnTogglePauseSwipe" />
+                        <SwipeItem Text="Cut-In Once"
+                                   BackgroundColor="#38b2ac"
+                                   CommandParameter="{Binding Task}"
+                                   Invoked="OnCutInOnceSwipe" />
+                        <SwipeItem Text="Cut-In Until Done"
+                                   BackgroundColor="#f59e0b"
+                                   CommandParameter="{Binding Task}"
+                                   Invoked="OnCutInUntilDoneSwipe" />
+                        <SwipeItem Text="Clear Cut-In"
+                                   BackgroundColor="#9ca3af"
+                                   CommandParameter="{Binding Task}"
+                                   Invoked="OnClearCutInSwipe" />
+                        <SwipeItem Text="Delete"
+                                   BackgroundColor="#eb5757"
+                                   CommandParameter="{Binding Task}"
+                                   Invoked="OnDeleteSwipe" />
+                    </SwipeItems>
+                </SwipeView.RightItems>
+
+                <Border StrokeShape="RoundRectangle 12"
+                        Padding="16"
+                        Margin="12,8"
+                        BackgroundColor="{AppThemeBinding Light=#ffffff, Dark=#1f1f1f}"
+                        Stroke="{AppThemeBinding Light=#e0e0e0, Dark=#2c2c2c}"
+                        StrokeThickness="1">
+                    <Grid RowSpacing="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0"
+                              ColumnDefinitions="*,Auto"
+                              ColumnSpacing="8">
+                            <Label Text="{Binding Title}"
+                                   FontSize="18"
+                                   FontAttributes="Bold" />
+                            <Border Grid.Column="1"
+                                    Padding="8,4"
+                                    StrokeThickness="0"
+                                    BackgroundColor="{Binding CutInLineBadgeBackgroundColor}"
+                                    StrokeShape="RoundRectangle 8"
+                                    IsVisible="{Binding HasCutInLineBadge}">
+                                <Label Text="{Binding CutInLineBadgeText}"
+                                       FontSize="12"
+                                       TextColor="{Binding CutInLineBadgeTextColor}" />
+                            </Border>
+                        </Grid>
+
+                        <Label Grid.Row="1"
+                               Text="{Binding Description}"
+                               FontSize="14"
+                               TextColor="{AppThemeBinding Light=#4f4f4f, Dark=#d0d0d0}"
+                               LineBreakMode="WordWrap" />
+
+                        <Grid Grid.Row="2"
+                              ColumnDefinitions="*,Auto"
+                              ColumnSpacing="12">
+                            <Grid Grid.Column="0"
+                                  RowDefinitions="Auto,Auto,Auto,Auto,Auto"
+                                  RowSpacing="2">
+                                <Label Grid.Row="0"
+                                       Text="{Binding RepeatText}"
+                                       FontSize="12"
+                                       TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
+                                <Label Grid.Row="1"
+                                       Text="{Binding ScheduleText}"
+                                       FontSize="12"
+                                       TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
+                                <Label Grid.Row="2"
+                                       Text="{Binding ImportanceText}"
+                                       FontSize="12"
+                                       TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
+                                <Label Grid.Row="3"
+                                       Text="{Binding AllowedPeriodText}"
+                                       FontSize="12"
+                                       TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
+                                <Label Grid.Row="4"
+                                       Text="{Binding ScoreText}"
+                                       FontSize="12"
+                                       TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
+                            </Grid>
+
+                            <VerticalStackLayout Grid.Column="1"
+                                                 Spacing="6"
+                                                 HorizontalOptions="End"
+                                                 VerticalOptions="Start">
+                                <Button Text="Mark Done"
+                                        FontSize="12"
+                                        Padding="12,4"
+                                        BackgroundColor="#2f855a"
+                                        TextColor="White"
+                                        BorderColor="#2f855a"
+                                        CornerRadius="8"
+                                        HorizontalOptions="End"
+                                        Clicked="OnMarkDoneButtonClicked"
+                                        CommandParameter="{Binding Task}"
+                                        SemanticProperties.Description="{Binding Title, StringFormat='Mark task {0} as done'}" />
+                                <Button Text="Edit"
+                                        FontSize="12"
+                                        Padding="12,4"
+                                        BackgroundColor="Transparent"
+                                        TextColor="#2d9cdb"
+                                        BorderColor="Transparent"
+                                        HorizontalOptions="End"
+                                        Clicked="OnEditButtonClicked"
+                                        CommandParameter="{Binding Task}" />
+                                <Button Text="Delete"
+                                        FontSize="12"
+                                        Padding="12,4"
+                                        BackgroundColor="#eb5757"
+                                        TextColor="White"
+                                        BorderColor="#eb5757"
+                                        CornerRadius="8"
+                                        HorizontalOptions="End"
+                                        Clicked="OnDeleteSwipe"
+                                        CommandParameter="{Binding Task}"
+                                        SemanticProperties.Description="{Binding Title, StringFormat='Delete task {0}'}" />
+                                <Label Text="{Binding StatusText}"
+                                       FontSize="12"
+                                       HorizontalOptions="End"
+                                       TextColor="{AppThemeBinding Light=#2f855a, Dark=#9ae6b4}">
+                                    <Label.Triggers>
+                                        <DataTrigger TargetType="Label"
+                                                    Binding="{Binding Task.Paused}"
+                                                    Value="True">
+                                            <Setter Property="TextColor" Value="#c53030" />
+                                        </DataTrigger>
+                                    </Label.Triggers>
+                                </Label>
+                                <Button Text="Resume"
+                                        FontSize="12"
+                                        Padding="12,4"
+                                        BackgroundColor="Transparent"
+                                        TextColor="#2f855a"
+                                        BorderColor="Transparent"
+                                        HorizontalOptions="End"
+                                        IsVisible="{Binding CanResume}"
+                                        Clicked="OnResumeButtonClicked"
+                                        CommandParameter="{Binding Task}" />
+                                <Border StrokeThickness="0"
+                                        Padding="8,4"
+                                        StrokeShape="RoundRectangle 8"
+                                        BackgroundColor="{Binding StatusBackgroundColor}"
+                                        IsVisible="{Binding HasStatusBadge}"
+                                        HorizontalOptions="End">
+                                    <Label Text="{Binding StatusText}"
+                                           FontSize="12"
+                                           TextColor="{Binding StatusTextColor}" />
+                                </Border>
+                            </VerticalStackLayout>
+                        </Grid>
+                    </Grid>
+                </Border>
+            </SwipeView>
+        </DataTemplate>
+    </ContentPage.Resources>
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="+"
                      Priority="0"
@@ -13,9 +184,51 @@
                      Clicked="OnAddClicked" />
     </ContentPage.ToolbarItems>
 
-    <CollectionView ItemsSource="{Binding Tasks}"
-                    SelectionMode="None">
-        <CollectionView.EmptyView>
+    <Grid>
+        <Grid>
+            <Grid.Triggers>
+                <DataTrigger TargetType="Grid"
+                             Binding="{Binding HasTasks}"
+                             Value="False">
+                    <Setter Property="IsVisible" Value="False" />
+                </DataTrigger>
+            </Grid.Triggers>
+
+            <VerticalStackLayout Spacing="12"
+                                 Padding="12,8">
+                <Label Text="Active Tasks"
+                       FontSize="16"
+                       FontAttributes="Bold"
+                       TextColor="{AppThemeBinding Light=#2d3748, Dark=#e2e8f0}"
+                       IsVisible="{Binding HasActiveTasks}" />
+                <CollectionView ItemsSource="{Binding ActiveTasks}"
+                                SelectionMode="None"
+                                ItemTemplate="{StaticResource TaskItemTemplate}"
+                                IsVisible="{Binding HasActiveTasks}" />
+                <BoxView HeightRequest="1"
+                         BackgroundColor="{AppThemeBinding Light=#e2e8f0, Dark=#2d3748}"
+                         Margin="0,4"
+                         IsVisible="{Binding HasDoneTasks}" />
+                <Label Text="Done Tasks"
+                       FontSize="16"
+                       FontAttributes="Bold"
+                       TextColor="{AppThemeBinding Light=#2d3748, Dark=#e2e8f0}"
+                       IsVisible="{Binding HasDoneTasks}" />
+                <CollectionView ItemsSource="{Binding DoneTasks}"
+                                SelectionMode="None"
+                                ItemTemplate="{StaticResource TaskItemTemplate}"
+                                IsVisible="{Binding HasDoneTasks}" />
+            </VerticalStackLayout>
+        </Grid>
+        <Grid IsVisible="False">
+            <Grid.Triggers>
+                <DataTrigger TargetType="Grid"
+                             Binding="{Binding HasTasks}"
+                             Value="False">
+                    <Setter Property="IsVisible" Value="True" />
+                </DataTrigger>
+            </Grid.Triggers>
+
             <Grid Padding="32"
                   RowSpacing="8"
                   HorizontalOptions="Center"
@@ -35,178 +248,6 @@
                        HorizontalTextAlignment="Center"
                        TextColor="Gray" />
             </Grid>
-        </CollectionView.EmptyView>
-
-        <CollectionView.ItemTemplate>
-            <DataTemplate x:DataType="vm:TaskListItem">
-                <SwipeView>
-                    <SwipeView.RightItems>
-                        <SwipeItems Mode="Reveal">
-                            <SwipeItem Text="Edit"
-                                       BackgroundColor="#2d9cdb"
-                                       CommandParameter="{Binding Task}"
-                                       Invoked="OnEditSwipe" />
-                            <SwipeItem Text="Toggle Pause"
-                                       BackgroundColor="#f2c94c"
-                                       CommandParameter="{Binding Task}"
-                                       Invoked="OnTogglePauseSwipe" />
-                            <SwipeItem Text="Cut-In Once"
-                                       BackgroundColor="#38b2ac"
-                                       CommandParameter="{Binding Task}"
-                                       Invoked="OnCutInOnceSwipe" />
-                            <SwipeItem Text="Cut-In Until Done"
-                                       BackgroundColor="#f59e0b"
-                                       CommandParameter="{Binding Task}"
-                                       Invoked="OnCutInUntilDoneSwipe" />
-                            <SwipeItem Text="Clear Cut-In"
-                                       BackgroundColor="#9ca3af"
-                                       CommandParameter="{Binding Task}"
-                                       Invoked="OnClearCutInSwipe" />
-                            <SwipeItem Text="Delete"
-                                       BackgroundColor="#eb5757"
-                                       CommandParameter="{Binding Task}"
-                                       Invoked="OnDeleteSwipe" />
-                        </SwipeItems>
-                    </SwipeView.RightItems>
-
-                    <Border StrokeShape="RoundRectangle 12"
-                            Padding="16"
-                            Margin="12,8"
-                            BackgroundColor="{AppThemeBinding Light=#ffffff, Dark=#1f1f1f}"
-                            Stroke="{AppThemeBinding Light=#e0e0e0, Dark=#2c2c2c}"
-                            StrokeThickness="1">
-                        <Grid RowSpacing="8">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
-
-                            <Grid Grid.Row="0"
-                                  ColumnDefinitions="*,Auto"
-                                  ColumnSpacing="8">
-                                <Label Text="{Binding Title}"
-                                       FontSize="18"
-                                       FontAttributes="Bold" />
-                                <Border Grid.Column="1"
-                                        Padding="8,4"
-                                        StrokeThickness="0"
-                                        BackgroundColor="{Binding CutInLineBadgeBackgroundColor}"
-                                        StrokeShape="RoundRectangle 8"
-                                        IsVisible="{Binding HasCutInLineBadge}">
-                                    <Label Text="{Binding CutInLineBadgeText}"
-                                           FontSize="12"
-                                           TextColor="{Binding CutInLineBadgeTextColor}" />
-                                </Border>
-                            </Grid>
-
-                            <Label Grid.Row="1"
-                                   Text="{Binding Description}"
-                                   FontSize="14"
-                                   TextColor="{AppThemeBinding Light=#4f4f4f, Dark=#d0d0d0}"
-                                   LineBreakMode="WordWrap" />
-
-                            <Grid Grid.Row="2"
-                                  ColumnDefinitions="*,Auto"
-                                  ColumnSpacing="12">
-                                <Grid Grid.Column="0"
-                                      RowDefinitions="Auto,Auto,Auto,Auto,Auto"
-                                      RowSpacing="2">
-                                    <Label Grid.Row="0"
-                                           Text="{Binding RepeatText}"
-                                           FontSize="12"
-                                           TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
-                                    <Label Grid.Row="1"
-                                           Text="{Binding ScheduleText}"
-                                           FontSize="12"
-                                           TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
-                                    <Label Grid.Row="2"
-                                           Text="{Binding ImportanceText}"
-                                           FontSize="12"
-                                           TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
-                                    <Label Grid.Row="3"
-                                           Text="{Binding AllowedPeriodText}"
-                                           FontSize="12"
-                                           TextColor="{AppThemeBinding Light=#6e6e6e, Dark=#b0b0b0}" />
-                                    <Label Grid.Row="4"
-                                           Text="{Binding ScoreText}"
-                                           FontSize="12"
-                                           TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
-                                </Grid>
-
-                                <VerticalStackLayout Grid.Column="1"
-                                                     Spacing="6"
-                                                     HorizontalOptions="End"
-                                                     VerticalOptions="Start">
-                                    <Button Text="Mark Done"
-                                            FontSize="12"
-                                            Padding="12,4"
-                                            BackgroundColor="#2f855a"
-                                            TextColor="White"
-                                            BorderColor="#2f855a"
-                                            CornerRadius="8"
-                                            HorizontalOptions="End"
-                                            Clicked="OnMarkDoneButtonClicked"
-                                            CommandParameter="{Binding Task}"
-                                            SemanticProperties.Description="{Binding Title, StringFormat='Mark task {0} as done'}" />
-                                    <Button Text="Edit"
-                                            FontSize="12"
-                                            Padding="12,4"
-                                            BackgroundColor="Transparent"
-                                            TextColor="#2d9cdb"
-                                            BorderColor="Transparent"
-                                            HorizontalOptions="End"
-                                            Clicked="OnEditButtonClicked"
-                                            CommandParameter="{Binding Task}" />
-                                    <Button Text="Delete"
-                                            FontSize="12"
-                                            Padding="12,4"
-                                            BackgroundColor="#eb5757"
-                                            TextColor="White"
-                                            BorderColor="#eb5757"
-                                            CornerRadius="8"
-                                            HorizontalOptions="End"
-                                            Clicked="OnDeleteSwipe"
-                                            CommandParameter="{Binding Task}"
-                                            SemanticProperties.Description="{Binding Title, StringFormat='Delete task {0}'}" />
-                                    <Label Text="{Binding StatusText}"
-                                           FontSize="12"
-                                           HorizontalOptions="End"
-                                           TextColor="{AppThemeBinding Light=#2f855a, Dark=#9ae6b4}">
-                                        <Label.Triggers>
-                                            <DataTrigger TargetType="Label"
-                                                        Binding="{Binding Task.Paused}"
-                                                        Value="True">
-                                                <Setter Property="TextColor" Value="#c53030" />
-                                            </DataTrigger>
-                                        </Label.Triggers>
-                                    </Label>
-                                    <Button Text="Resume"
-                                            FontSize="12"
-                                            Padding="12,4"
-                                            BackgroundColor="Transparent"
-                                            TextColor="#2f855a"
-                                            BorderColor="Transparent"
-                                            HorizontalOptions="End"
-                                            IsVisible="{Binding CanResume}"
-                                            Clicked="OnResumeButtonClicked"
-                                            CommandParameter="{Binding Task}" />
-                                    <Border StrokeThickness="0"
-                                            Padding="8,4"
-                                            StrokeShape="RoundRectangle 8"
-                                            BackgroundColor="{Binding StatusBackgroundColor}"
-                                            IsVisible="{Binding HasStatusBadge}"
-                                            HorizontalOptions="End">
-                                        <Label Text="{Binding StatusText}"
-                                               FontSize="12"
-                                               TextColor="{Binding StatusTextColor}" />
-                                    </Border>
-                                </VerticalStackLayout>
-                            </Grid>
-                        </Grid>
-                    </Border>
-                </SwipeView>
-            </DataTemplate>
-        </CollectionView.ItemTemplate>
-    </CollectionView>
+        </Grid>
+    </Grid>
 </ContentPage>


### PR DESCRIPTION
### Motivation
- Improve task list clarity by showing completed tasks in a separate `Done` section below active tasks while preserving score-based sorting and existing task logic.
- Keep this change presentation-only and avoid touching persistence, scoring, or domain behavior.

### Description
- In `TasksViewModel`, added `ActiveTasks` and `DoneTasks` (`ObservableCollection<TaskListItem>`) and visibility helpers `HasActiveTasks`, `HasDoneTasks`, and `HasTasks` to expose sectioned data to the view.
- Updated `LoadAsync` to populate `ActiveTasks` and `DoneTasks` from the same loaded items, sorting by `PriorityScore` via the existing `.OrderByDescending(x => x.PriorityScore)` and splitting by `TaskLifecycleStatus.Completed` without changing stored task state.
- Reworked `TasksPage.xaml` to introduce a shared `DataTemplate` resource (`TaskItemTemplate`) and render two `CollectionView`s with headers (`Active Tasks`, `Done Tasks`), a divider (`BoxView`), and an empty-state view that shows only when there are no tasks.
- Kept original item UI and swipe/command handlers intact by reusing the same item template and command bindings; only presentation and bindings changed (`Tasks` list still populated for compatibility).

### Testing
- No automated tests were executed for this change per rollout instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847be4e1a48326831f7c7c3ac45762)