### PR TITLE
Add sort options (Score / Importance / Deadline) to Tasks page

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -13,6 +13,10 @@ namespace ShuffleTask.ViewModels;
 
 public partial class TasksViewModel : ObservableObject
 {
+    private const string SortScore = "Score";
+    private const string SortImportance = "Importance";
+    private const string SortDeadline = "Deadline";
+
     private readonly IStorageService _storage;
     private readonly INetworkSyncService _networkSyncService;
     private readonly TimeProvider _clock;
@@ -31,6 +35,7 @@ public partial class TasksViewModel : ObservableObject
     public ObservableCollection<TaskListItem> ActiveTasks { get; } = [];
     public ObservableCollection<TaskListItem> DoneTasks { get; } = [];
     public ObservableCollection<TaskGroup> TaskGroups { get; } = [];
+    public IReadOnlyList<string> SortOptions { get; } = new[] { SortScore, SortImportance, SortDeadline };
 
     public bool HasActiveTasks => ActiveTasks.Count > 0;
     public bool HasDoneTasks => DoneTasks.Count > 0;
@@ -38,6 +43,9 @@ public partial class TasksViewModel : ObservableObject
 
     [ObservableProperty]
     private bool isBusy;
+
+    [ObservableProperty]
+    private string selectedSort = SortScore;
 
     public async Task LoadAsync(string? userId = null, string? deviceId = null)
     {
@@ -60,9 +68,9 @@ public partial class TasksViewModel : ObservableObject
             ActiveTasks.Clear();
             DoneTasks.Clear();
             TaskGroups.Clear();
-            foreach (TaskListItem? entry in items
-                .Select(task => TaskListItem.From(task, settings, now))
-                .OrderByDescending(x => x.PriorityScore))
+            IEnumerable<TaskListItem> sortedItems = ApplySort(items
+                .Select(task => TaskListItem.From(task, settings, now)));
+            foreach (TaskListItem? entry in sortedItems)
             {
                 Tasks.Add(entry);
                 if (entry.Task.Status == TaskLifecycleStatus.Completed)
@@ -93,6 +101,32 @@ public partial class TasksViewModel : ObservableObject
         {
             IsBusy = false;
         }
+    }
+
+    partial void OnSelectedSortChanged(string value)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        _ = LoadAsync();
+    }
+
+    private IEnumerable<TaskListItem> ApplySort(IEnumerable<TaskListItem> items)
+    {
+        return SelectedSort switch
+        {
+            SortImportance => items
+                .OrderByDescending(item => item.Task.Importance)
+                .ThenByDescending(item => item.PriorityScore)
+                .ThenBy(item => item.Task.Deadline ?? DateTime.MaxValue),
+            SortDeadline => items
+                .OrderBy(item => item.Task.Deadline ?? DateTime.MaxValue)
+                .ThenByDescending(item => item.Task.Importance)
+                .ThenByDescending(item => item.PriorityScore),
+            _ => items.OrderByDescending(item => item.PriorityScore)
+        };
     }
 
     public async Task TogglePauseAsync(TaskItem task)

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml
@@ -184,8 +184,21 @@
                      Clicked="OnAddClicked" />
     </ContentPage.ToolbarItems>
 
-    <Grid>
-        <CollectionView IsVisible="{Binding HasTasks}"
+    <Grid RowDefinitions="Auto,*">
+        <HorizontalStackLayout Padding="12,8"
+                               Spacing="12">
+            <Label Text="Sort by"
+                   FontSize="14"
+                   VerticalOptions="Center"
+                   TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
+            <Picker ItemsSource="{Binding SortOptions}"
+                    SelectedItem="{Binding SelectedSort}"
+                    Title="Sort"
+                    HorizontalOptions="EndAndExpand" />
+        </HorizontalStackLayout>
+
+        <CollectionView Grid.Row="1"
+                        IsVisible="{Binding HasTasks}"
                         ItemsSource="{Binding TaskGroups}"
                         IsGrouped="True"
                         Margin="0"
@@ -206,7 +219,8 @@
                 </DataTemplate>
             </CollectionView.GroupHeaderTemplate>
         </CollectionView>
-        <Grid IsVisible="False">
+        <Grid Grid.Row="1"
+              IsVisible="False">
             <Grid.Triggers>
                 <DataTrigger TargetType="Grid"
                              Binding="{Binding HasTasks}"


### PR DESCRIPTION
### Motivation
- Provide users the ability to change task ordering between Score, Importance, and Deadline views while preserving the existing Score-first behavior.
- Make sorting deterministic with explicit tie-breakers to avoid flicker when task lists update.
- Ensure `Deadline` sorting treats null deadlines as last so one-off/no-deadline tasks don't appear as due soon.

### Description
- Added a sort selector to the tasks UI by updating `Views/TasksPage.xaml` to include a `Picker` bound to `SortOptions` above the task list.
- Extended `ViewModels/TasksViewModel.cs` with `SortOptions`, an observable `SelectedSort`, and an `ApplySort` method that switches between `Score`, `Importance`, and `Deadline` sorting modes.
- Replaced the previous unconditional `OrderByDescending(x => x.PriorityScore)` with a call to `ApplySort(...)`, and wired `OnSelectedSortChanged` to reload the list when `SelectedSort` changes.
- Implemented deterministic tie-breakers and null-deadline handling using `DateTime.MaxValue` in the `ApplySort` logic so `Deadline` places nulls last and importance/score ties are consistent.

### Testing
- No automated tests were executed against these changes (per local instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984888c9a6c8326bb202edf78913830)