### PR TITLE
Fix crash when changing task sort

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -70,36 +70,33 @@ public partial class TasksViewModel : ObservableObject
             TaskGroups.Clear();
             IEnumerable<TaskListItem> sortedItems = ApplySort(items
                 .Select(task => TaskListItem.From(task, settings, now)));
-            foreach (TaskListItem? entry in sortedItems)
-            {
-                Tasks.Add(entry);
-                if (entry.Task.Status == TaskLifecycleStatus.Completed)
-                {
-                    DoneTasks.Add(entry);
-                }
-                else
-                {
-                    ActiveTasks.Add(entry);
-                }
-            }
-
-            if (ActiveTasks.Count > 0)
-            {
-                TaskGroups.Add(new TaskGroup("Active Tasks", false, ActiveTasks));
-            }
-
-            if (DoneTasks.Count > 0)
-            {
-                TaskGroups.Add(new TaskGroup("Done Tasks", ActiveTasks.Count > 0, DoneTasks));
-            }
-
-            OnPropertyChanged(nameof(HasActiveTasks));
-            OnPropertyChanged(nameof(HasDoneTasks));
-            OnPropertyChanged(nameof(HasTasks));
+            SeparateTasksToActiveAndDone(sortedItems);
+            AddAppropriateTaskGroups();
+            OnTaskBooleansChanged();
         }
         finally
         {
             IsBusy = false;
+        }
+    }
+
+    private void OnTaskBooleansChanged()
+    {
+        OnPropertyChanged(nameof(HasActiveTasks));
+        OnPropertyChanged(nameof(HasDoneTasks));
+        OnPropertyChanged(nameof(HasTasks));
+    }
+
+    private void AddAppropriateTaskGroups()
+    {
+        if (ActiveTasks.Count > 0)
+        {
+            TaskGroups.Add(new TaskGroup("Active Tasks", false, ActiveTasks));
+        }
+
+        if (DoneTasks.Count > 0)
+        {
+            TaskGroups.Add(new TaskGroup("Done Tasks", ActiveTasks.Count > 0, DoneTasks));
         }
     }
 
@@ -137,7 +134,15 @@ public partial class TasksViewModel : ObservableObject
         DoneTasks.Clear();
         TaskGroups.Clear();
 
-        foreach (TaskListItem entry in ApplySort(items))
+        IEnumerable<TaskListItem> sortedItems = ApplySort(items);
+        SeparateTasksToActiveAndDone(sortedItems);
+        AddAppropriateTaskGroups();
+        OnTaskBooleansChanged();
+    }
+
+    private void SeparateTasksToActiveAndDone(IEnumerable<TaskListItem> sortedItems)
+    {
+        foreach (TaskListItem entry in sortedItems)
         {
             Tasks.Add(entry);
             if (entry.Task.Status == TaskLifecycleStatus.Completed)
@@ -149,20 +154,6 @@ public partial class TasksViewModel : ObservableObject
                 ActiveTasks.Add(entry);
             }
         }
-
-        if (ActiveTasks.Count > 0)
-        {
-            TaskGroups.Add(new TaskGroup("Active Tasks", false, ActiveTasks));
-        }
-
-        if (DoneTasks.Count > 0)
-        {
-            TaskGroups.Add(new TaskGroup("Done Tasks", ActiveTasks.Count > 0, DoneTasks));
-        }
-
-        OnPropertyChanged(nameof(HasActiveTasks));
-        OnPropertyChanged(nameof(HasDoneTasks));
-        OnPropertyChanged(nameof(HasTasks));
     }
 
     public async Task TogglePauseAsync(TaskItem task)

--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -13,6 +13,10 @@ namespace ShuffleTask.ViewModels;
 
 public partial class TasksViewModel : ObservableObject
 {
+    private const string SortScore = "Score";
+    private const string SortImportance = "Importance";
+    private const string SortDeadline = "Deadline";
+
     private readonly IStorageService _storage;
     private readonly INetworkSyncService _networkSyncService;
     private readonly TimeProvider _clock;
@@ -31,6 +35,7 @@ public partial class TasksViewModel : ObservableObject
     public ObservableCollection<TaskListItem> ActiveTasks { get; } = [];
     public ObservableCollection<TaskListItem> DoneTasks { get; } = [];
     public ObservableCollection<TaskGroup> TaskGroups { get; } = [];
+    public IReadOnlyList<string> SortOptions { get; } = new[] { SortScore, SortImportance, SortDeadline };
 
     public bool HasActiveTasks => ActiveTasks.Count > 0;
     public bool HasDoneTasks => DoneTasks.Count > 0;
@@ -38,6 +43,9 @@ public partial class TasksViewModel : ObservableObject
 
     [ObservableProperty]
     private bool isBusy;
+
+    [ObservableProperty]
+    private string selectedSort = SortScore;
 
     public async Task LoadAsync(string? userId = null, string? deviceId = null)
     {
@@ -60,9 +68,9 @@ public partial class TasksViewModel : ObservableObject
             ActiveTasks.Clear();
             DoneTasks.Clear();
             TaskGroups.Clear();
-            foreach (TaskListItem? entry in items
-                .Select(task => TaskListItem.From(task, settings, now))
-                .OrderByDescending(x => x.PriorityScore))
+            IEnumerable<TaskListItem> sortedItems = ApplySort(items
+                .Select(task => TaskListItem.From(task, settings, now)));
+            foreach (TaskListItem? entry in sortedItems)
             {
                 Tasks.Add(entry);
                 if (entry.Task.Status == TaskLifecycleStatus.Completed)
@@ -93,6 +101,68 @@ public partial class TasksViewModel : ObservableObject
         {
             IsBusy = false;
         }
+    }
+
+    partial void OnSelectedSortChanged(string value)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        ApplySortToCollections();
+    }
+
+    private IEnumerable<TaskListItem> ApplySort(IEnumerable<TaskListItem> items)
+    {
+        return SelectedSort switch
+        {
+            SortImportance => items
+                .OrderByDescending(item => item.Task.Importance)
+                .ThenByDescending(item => item.PriorityScore)
+                .ThenBy(item => item.Task.Deadline ?? DateTime.MaxValue),
+            SortDeadline => items
+                .OrderBy(item => item.Task.Deadline ?? DateTime.MaxValue)
+                .ThenByDescending(item => item.Task.Importance)
+                .ThenByDescending(item => item.PriorityScore),
+            _ => items.OrderByDescending(item => item.PriorityScore)
+        };
+    }
+
+    private void ApplySortToCollections()
+    {
+        List<TaskListItem> items = Tasks.ToList();
+        Tasks.Clear();
+        ActiveTasks.Clear();
+        DoneTasks.Clear();
+        TaskGroups.Clear();
+
+        foreach (TaskListItem entry in ApplySort(items))
+        {
+            Tasks.Add(entry);
+            if (entry.Task.Status == TaskLifecycleStatus.Completed)
+            {
+                DoneTasks.Add(entry);
+            }
+            else
+            {
+                ActiveTasks.Add(entry);
+            }
+        }
+
+        if (ActiveTasks.Count > 0)
+        {
+            TaskGroups.Add(new TaskGroup("Active Tasks", false, ActiveTasks));
+        }
+
+        if (DoneTasks.Count > 0)
+        {
+            TaskGroups.Add(new TaskGroup("Done Tasks", ActiveTasks.Count > 0, DoneTasks));
+        }
+
+        OnPropertyChanged(nameof(HasActiveTasks));
+        OnPropertyChanged(nameof(HasDoneTasks));
+        OnPropertyChanged(nameof(HasTasks));
     }
 
     public async Task TogglePauseAsync(TaskItem task)

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml
@@ -184,8 +184,21 @@
                      Clicked="OnAddClicked" />
     </ContentPage.ToolbarItems>
 
-    <Grid>
-        <CollectionView IsVisible="{Binding HasTasks}"
+    <Grid RowDefinitions="Auto,*">
+        <HorizontalStackLayout Padding="12,8"
+                               Spacing="12">
+            <Label Text="Sort by"
+                   FontSize="14"
+                   VerticalOptions="Center"
+                   TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
+            <Picker ItemsSource="{Binding SortOptions}"
+                    SelectedItem="{Binding SelectedSort}"
+                    Title="Sort"
+                    HorizontalOptions="EndAndExpand" />
+        </HorizontalStackLayout>
+
+        <CollectionView Grid.Row="1"
+                        IsVisible="{Binding HasTasks}"
                         ItemsSource="{Binding TaskGroups}"
                         IsGrouped="True"
                         Margin="0"
@@ -206,7 +219,8 @@
                 </DataTemplate>
             </CollectionView.GroupHeaderTemplate>
         </CollectionView>
-        <Grid IsVisible="False">
+        <Grid Grid.Row="1"
+              IsVisible="False">
             <Grid.Triggers>
                 <DataTrigger TargetType="Grid"
                              Binding="{Binding HasTasks}"


### PR DESCRIPTION
### Motivation
- Fix a runtime crash that occurred when changing the sort option (app exited with code 0xc000027b) by removing the unsafe reload path.
- Avoid reloading from storage/network just to change ordering and instead operate on the in-memory collections to make the operation safe and responsive.
- Preserve deterministic sorting (tie-breakers and null-deadline handling) while allowing the UI to switch sort modes without side effects.

### Description
- Added sort option constants (`SortScore`, `SortImportance`, `SortDeadline`) and an observable `SelectedSort` defaulting to `SortScore` and exposed `SortOptions` as an `IReadOnlyList<string>`.
- Replaced the previous `OnSelectedSortChanged` call to `_ = LoadAsync()` with `ApplySortToCollections()`, which re-sorts `Tasks` in-memory, repopulates `ActiveTasks`/`DoneTasks`, and rebuilds `TaskGroups`.
- Introduced `ApplySort(IEnumerable<TaskListItem>)` to centralize sort logic and wired it into `LoadAsync` so initial loads use the selected sort order.
- Updated `Views/TasksPage.xaml` to add a `Picker` bound to `SortOptions`/`SelectedSort` and adjusted the layout so the picker appears above the task list.

### Testing
- No automated tests were executed for this change (per local instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984888c9a6c8326bb202edf78913830)