### PR TITLE
Stabilize task grouping after sort change

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -70,32 +70,9 @@ public partial class TasksViewModel : ObservableObject
             TaskGroups.Clear();
             IEnumerable<TaskListItem> sortedItems = ApplySort(items
                 .Select(task => TaskListItem.From(task, settings, now)));
-            foreach (TaskListItem? entry in sortedItems)
-            {
-                Tasks.Add(entry);
-                if (entry.Task.Status == TaskLifecycleStatus.Completed)
-                {
-                    DoneTasks.Add(entry);
-                }
-                else
-                {
-                    ActiveTasks.Add(entry);
-                }
-            }
-
-            if (ActiveTasks.Count > 0)
-            {
-                TaskGroups.Add(new TaskGroup("Active Tasks", false, ActiveTasks));
-            }
-
-            if (DoneTasks.Count > 0)
-            {
-                TaskGroups.Add(new TaskGroup("Done Tasks", ActiveTasks.Count > 0, DoneTasks));
-            }
-
-            OnPropertyChanged(nameof(HasActiveTasks));
-            OnPropertyChanged(nameof(HasDoneTasks));
-            OnPropertyChanged(nameof(HasTasks));
+            SeparateTasksToActiveAndDone(sortedItems);
+            AddAppropriateTaskGroups();
+            OnTaskBooleansChanged();
         }
         finally
         {
@@ -132,27 +109,36 @@ public partial class TasksViewModel : ObservableObject
     private void ApplySortToCollections()
     {
         List<TaskListItem> items = Tasks.ToList();
-        List<TaskListItem> activeItems = [];
-        List<TaskListItem> doneItems = [];
         Tasks.Clear();
         ActiveTasks.Clear();
         DoneTasks.Clear();
         TaskGroups.Clear();
 
-        foreach (TaskListItem entry in ApplySort(items))
+        SeparateTasksToActiveAndDone(ApplySort(items));
+        AddAppropriateTaskGroups();
+        OnTaskBooleansChanged();
+    }
+
+    private void SeparateTasksToActiveAndDone(IEnumerable<TaskListItem> sortedItems)
+    {
+        foreach (TaskListItem entry in sortedItems)
         {
             Tasks.Add(entry);
             if (entry.Task.Status == TaskLifecycleStatus.Completed)
             {
                 DoneTasks.Add(entry);
-                doneItems.Add(entry);
             }
             else
             {
                 ActiveTasks.Add(entry);
-                activeItems.Add(entry);
             }
         }
+    }
+
+    private void AddAppropriateTaskGroups()
+    {
+        List<TaskListItem> activeItems = ActiveTasks.ToList();
+        List<TaskListItem> doneItems = DoneTasks.ToList();
 
         if (activeItems.Count > 0)
         {
@@ -163,7 +149,10 @@ public partial class TasksViewModel : ObservableObject
         {
             TaskGroups.Add(new TaskGroup("Done Tasks", activeItems.Count > 0, doneItems));
         }
+    }
 
+    private void OnTaskBooleansChanged()
+    {
         OnPropertyChanged(nameof(HasActiveTasks));
         OnPropertyChanged(nameof(HasDoneTasks));
         OnPropertyChanged(nameof(HasTasks));

--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -13,6 +13,10 @@ namespace ShuffleTask.ViewModels;
 
 public partial class TasksViewModel : ObservableObject
 {
+    private const string SortScore = "Score";
+    private const string SortImportance = "Importance";
+    private const string SortDeadline = "Deadline";
+
     private readonly IStorageService _storage;
     private readonly INetworkSyncService _networkSyncService;
     private readonly TimeProvider _clock;
@@ -31,6 +35,7 @@ public partial class TasksViewModel : ObservableObject
     public ObservableCollection<TaskListItem> ActiveTasks { get; } = [];
     public ObservableCollection<TaskListItem> DoneTasks { get; } = [];
     public ObservableCollection<TaskGroup> TaskGroups { get; } = [];
+    public IReadOnlyList<string> SortOptions { get; } = new[] { SortScore, SortImportance, SortDeadline };
 
     public bool HasActiveTasks => ActiveTasks.Count > 0;
     public bool HasDoneTasks => DoneTasks.Count > 0;
@@ -38,6 +43,9 @@ public partial class TasksViewModel : ObservableObject
 
     [ObservableProperty]
     private bool isBusy;
+
+    [ObservableProperty]
+    private string selectedSort = SortScore;
 
     public async Task LoadAsync(string? userId = null, string? deviceId = null)
     {
@@ -60,9 +68,9 @@ public partial class TasksViewModel : ObservableObject
             ActiveTasks.Clear();
             DoneTasks.Clear();
             TaskGroups.Clear();
-            foreach (TaskListItem? entry in items
-                .Select(task => TaskListItem.From(task, settings, now))
-                .OrderByDescending(x => x.PriorityScore))
+            IEnumerable<TaskListItem> sortedItems = ApplySort(items
+                .Select(task => TaskListItem.From(task, settings, now)));
+            foreach (TaskListItem? entry in sortedItems)
             {
                 Tasks.Add(entry);
                 if (entry.Task.Status == TaskLifecycleStatus.Completed)
@@ -93,6 +101,72 @@ public partial class TasksViewModel : ObservableObject
         {
             IsBusy = false;
         }
+    }
+
+    partial void OnSelectedSortChanged(string value)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        ApplySortToCollections();
+    }
+
+    private IEnumerable<TaskListItem> ApplySort(IEnumerable<TaskListItem> items)
+    {
+        return SelectedSort switch
+        {
+            SortImportance => items
+                .OrderByDescending(item => item.Task.Importance)
+                .ThenByDescending(item => item.PriorityScore)
+                .ThenBy(item => item.Task.Deadline ?? DateTime.MaxValue),
+            SortDeadline => items
+                .OrderBy(item => item.Task.Deadline ?? DateTime.MaxValue)
+                .ThenByDescending(item => item.Task.Importance)
+                .ThenByDescending(item => item.PriorityScore),
+            _ => items.OrderByDescending(item => item.PriorityScore)
+        };
+    }
+
+    private void ApplySortToCollections()
+    {
+        List<TaskListItem> items = Tasks.ToList();
+        List<TaskListItem> activeItems = [];
+        List<TaskListItem> doneItems = [];
+        Tasks.Clear();
+        ActiveTasks.Clear();
+        DoneTasks.Clear();
+        TaskGroups.Clear();
+
+        foreach (TaskListItem entry in ApplySort(items))
+        {
+            Tasks.Add(entry);
+            if (entry.Task.Status == TaskLifecycleStatus.Completed)
+            {
+                DoneTasks.Add(entry);
+                doneItems.Add(entry);
+            }
+            else
+            {
+                ActiveTasks.Add(entry);
+                activeItems.Add(entry);
+            }
+        }
+
+        if (activeItems.Count > 0)
+        {
+            TaskGroups.Add(new TaskGroup("Active Tasks", false, activeItems));
+        }
+
+        if (doneItems.Count > 0)
+        {
+            TaskGroups.Add(new TaskGroup("Done Tasks", activeItems.Count > 0, doneItems));
+        }
+
+        OnPropertyChanged(nameof(HasActiveTasks));
+        OnPropertyChanged(nameof(HasDoneTasks));
+        OnPropertyChanged(nameof(HasTasks));
     }
 
     public async Task TogglePauseAsync(TaskItem task)

--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -21,6 +21,7 @@ public partial class TasksViewModel : ObservableObject
     private readonly INetworkSyncService _networkSyncService;
     private readonly TimeProvider _clock;
     private readonly AppSettings _settings;
+    private bool _pendingSort;
 
     public TasksViewModel(IStorageService storage, TimeProvider clock, INetworkSyncService networkSyncService, AppSettings settings)
     {
@@ -77,6 +78,11 @@ public partial class TasksViewModel : ObservableObject
         finally
         {
             IsBusy = false;
+            if (_pendingSort)
+            {
+                _pendingSort = false;
+                ApplySortToCollections();
+            }
         }
     }
 
@@ -84,6 +90,7 @@ public partial class TasksViewModel : ObservableObject
     {
         if (IsBusy)
         {
+            _pendingSort = true;
             return;
         }
 

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml
@@ -184,8 +184,21 @@
                      Clicked="OnAddClicked" />
     </ContentPage.ToolbarItems>
 
-    <Grid>
-        <CollectionView IsVisible="{Binding HasTasks}"
+    <Grid RowDefinitions="Auto,*">
+        <HorizontalStackLayout Padding="12,8"
+                               Spacing="12">
+            <Label Text="Sort by"
+                   FontSize="14"
+                   VerticalOptions="Center"
+                   TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
+            <Picker ItemsSource="{Binding SortOptions}"
+                    SelectedItem="{Binding SelectedSort}"
+                    Title="Sort"
+                    HorizontalOptions="EndAndExpand" />
+        </HorizontalStackLayout>
+
+        <CollectionView Grid.Row="1"
+                        IsVisible="{Binding HasTasks}"
                         ItemsSource="{Binding TaskGroups}"
                         IsGrouped="True"
                         Margin="0"
@@ -206,7 +219,8 @@
                 </DataTemplate>
             </CollectionView.GroupHeaderTemplate>
         </CollectionView>
-        <Grid IsVisible="False">
+        <Grid Grid.Row="1"
+              IsVisible="False">
             <Grid.Triggers>
                 <DataTrigger TargetType="Grid"
                              Binding="{Binding HasTasks}"


### PR DESCRIPTION
### Motivation
- Avoid CollectionView/ObservableCollection re-entrancy and crashes when the user changes the task sort by ensuring grouped sources are stable lists instead of reusing mutable grouped collections.

### Description
- Introduced sort option constants and an observable `SelectedSort` with a `OnSelectedSortChanged` hook to trigger an in-memory re-sort.
- Centralized sorting into `ApplySort(IEnumerable<TaskListItem>)` and updated `LoadAsync` to use the selected sort order on initial load.
- Reworked `ApplySortToCollections` to build local `activeItems` and `doneItems` lists and pass those stable lists to `TaskGroup` instances instead of using the mutable `ActiveTasks`/`DoneTasks` collections directly.
- Updated `TasksPage.xaml` to add a `Picker` bound to `SortOptions`/`SelectedSort` and positioned it above the task list.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984888c9a6c8326bb202edf78913830)