### PR TITLE
#219: Add compact filters for allowed time and repeating tasks on Tasks pag…

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -17,12 +17,18 @@ public partial class TasksViewModel : ObservableObject
     private const string SortScore = "Score";
     private const string SortImportance = "Importance";
     private const string SortDeadline = "Deadline";
+    private const string RepeatFilterAll = "All";
+    private const string RepeatFilterRepeating = "Repeating";
+    private const string RepeatFilterNonRepeating = "One-off";
 
     private readonly IStorageService _storage;
     private readonly INetworkSyncService _networkSyncService;
     private readonly TimeProvider _clock;
     private readonly AppSettings _settings;
     private bool _pendingSort;
+    private bool _pendingRefresh;
+    private bool _suppressRefresh;
+    private List<TaskListItem> _allTasks = [];
 
     public TasksViewModel(IStorageService storage, TimeProvider clock, INetworkSyncService networkSyncService, AppSettings settings)
     {
@@ -38,6 +44,7 @@ public partial class TasksViewModel : ObservableObject
     public ObservableCollection<TaskListItem> DoneTasks { get; } = [];
     public ObservableCollection<TaskGroup> TaskGroups { get; private set; } = [];
     public IReadOnlyList<string> SortOptions { get; } = new[] { SortScore, SortImportance, SortDeadline };
+    public IReadOnlyList<string> RepeatFilterOptions { get; } = new[] { RepeatFilterAll, RepeatFilterRepeating, RepeatFilterNonRepeating };
 
     public bool HasActiveTasks => ActiveTasks.Count > 0;
     public bool HasDoneTasks => DoneTasks.Count > 0;
@@ -48,6 +55,21 @@ public partial class TasksViewModel : ObservableObject
 
     [ObservableProperty]
     private string selectedSort = SortScore;
+
+    [ObservableProperty]
+    private bool filterAllowedNow;
+
+    [ObservableProperty]
+    private bool filterAllowedMorning;
+
+    [ObservableProperty]
+    private bool filterAllowedAfternoon;
+
+    [ObservableProperty]
+    private bool filterAllowedEvening;
+
+    [ObservableProperty]
+    private string selectedRepeatFilter = RepeatFilterAll;
 
     public async Task LoadAsync(string? userId = null, string? deviceId = null)
     {
@@ -66,25 +88,22 @@ public partial class TasksViewModel : ObservableObject
             AppSettings settings = _settings;
             DateTimeOffset now = _clock.GetUtcNow();
 
-            IEnumerable<TaskListItem> sortedItems = ApplySort(items
-                .Select(task => TaskListItem.From(task, settings, now)));
+            _allTasks = items
+                .Select(task => TaskListItem.From(task, settings, now))
+                .ToList();
             await MainThread.InvokeOnMainThreadAsync(() =>
             {
-                Tasks.Clear();
-                ActiveTasks.Clear();
-                DoneTasks.Clear();
-                SeparateTasksToActiveAndDone(sortedItems);
-                AddAppropriateTaskGroups();
-                OnTaskBooleansChanged();
+                ApplySortToCollections();
                 return Task.CompletedTask;
             });
         }
         finally
         {
             IsBusy = false;
-            if (_pendingSort)
+            if (_pendingSort || _pendingRefresh)
             {
                 _pendingSort = false;
+                _pendingRefresh = false;
                 ApplySortToCollections();
             }
         }
@@ -92,9 +111,61 @@ public partial class TasksViewModel : ObservableObject
 
     partial void OnSelectedSortChanged(string value)
     {
+        RequestRefresh(true);
+    }
+
+    partial void OnFilterAllowedNowChanged(bool value)
+    {
+        RequestRefresh();
+    }
+
+    partial void OnFilterAllowedMorningChanged(bool value)
+    {
+        RequestRefresh();
+    }
+
+    partial void OnFilterAllowedAfternoonChanged(bool value)
+    {
+        RequestRefresh();
+    }
+
+    partial void OnFilterAllowedEveningChanged(bool value)
+    {
+        RequestRefresh();
+    }
+
+    partial void OnSelectedRepeatFilterChanged(string value)
+    {
+        RequestRefresh();
+    }
+
+    public void ResetFilters()
+    {
+        _suppressRefresh = true;
+        FilterAllowedNow = false;
+        FilterAllowedMorning = false;
+        FilterAllowedAfternoon = false;
+        FilterAllowedEvening = false;
+        SelectedRepeatFilter = RepeatFilterAll;
+        _suppressRefresh = false;
+        ApplySortToCollections();
+    }
+
+    private void RequestRefresh(bool isSortChange = false)
+    {
+        if (_suppressRefresh)
+        {
+            return;
+        }
+
         if (IsBusy)
         {
-            _pendingSort = true;
+            if (isSortChange)
+            {
+                _pendingSort = true;
+            }
+
+            _pendingRefresh = true;
             return;
         }
 
@@ -127,14 +198,83 @@ public partial class TasksViewModel : ObservableObject
         }
 #endif
 
-        List<TaskListItem> items = Tasks.ToList();
+        List<TaskListItem> items = _allTasks.ToList();
         Tasks.Clear();
         ActiveTasks.Clear();
         DoneTasks.Clear();
 
-        SeparateTasksToActiveAndDone(ApplySort(items));
+        IEnumerable<TaskListItem> filteredItems = ApplyFilters(items);
+        SeparateTasksToActiveAndDone(ApplySort(filteredItems));
         AddAppropriateTaskGroups();
         OnTaskBooleansChanged();
+    }
+
+    private IEnumerable<TaskListItem> ApplyFilters(IEnumerable<TaskListItem> items)
+    {
+        IEnumerable<TaskListItem> filteredItems = items;
+
+        if (FilterAllowedNow || FilterAllowedMorning || FilterAllowedAfternoon || FilterAllowedEvening)
+        {
+            DateTimeOffset now = _clock.GetUtcNow();
+            filteredItems = filteredItems.Where(item => MatchesAllowedTimeFilter(item.Task, now));
+        }
+
+        filteredItems = SelectedRepeatFilter switch
+        {
+            RepeatFilterRepeating => filteredItems.Where(item => item.Task.Repeat != RepeatType.None),
+            RepeatFilterNonRepeating => filteredItems.Where(item => item.Task.Repeat == RepeatType.None),
+            _ => filteredItems
+        };
+
+        return filteredItems;
+    }
+
+    private bool MatchesAllowedTimeFilter(TaskItem task, DateTimeOffset now)
+    {
+        if (FilterAllowedNow && TimeWindowService.AllowedNow(task, now, _settings))
+        {
+            return true;
+        }
+
+        DateTimeOffset localNow = TimeZoneInfo.ConvertTime(now, TimeZoneInfo.Local);
+
+        if (FilterAllowedMorning && IsAllowedDuringWindow(task, localNow, _settings.MorningStart, _settings.MorningEnd))
+        {
+            return true;
+        }
+
+        if (FilterAllowedAfternoon && IsAllowedDuringWindow(task, localNow, _settings.LunchEnd, _settings.EveningStart))
+        {
+            return true;
+        }
+
+        if (FilterAllowedEvening && IsAllowedDuringWindow(task, localNow, _settings.EveningStart, _settings.EveningEnd))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsAllowedDuringWindow(TaskItem task, DateTimeOffset localNow, TimeSpan start, TimeSpan end)
+    {
+        DateTimeOffset windowStartLocal = new(localNow.Date + start, localNow.Offset);
+        DateTimeOffset windowEndLocal = start == end
+            ? windowStartLocal.AddDays(1)
+            : (start < end
+                ? new DateTimeOffset(localNow.Date + end, localNow.Offset)
+                : new DateTimeOffset(localNow.Date + end, localNow.Offset).AddDays(1));
+
+        for (DateTimeOffset cursorLocal = windowStartLocal; cursorLocal < windowEndLocal; cursorLocal = cursorLocal.AddMinutes(1))
+        {
+            if (TimeWindowService.AllowedNow(task, cursorLocal.ToOffset(TimeSpan.Zero), _settings))
+            {
+                return true;
+            }
+        }
+
+        // AllowedNow treats the end as exclusive, so explicitly probe just before the window end.
+        return TimeWindowService.AllowedNow(task, windowEndLocal.AddTicks(-1).ToOffset(TimeSpan.Zero), _settings);
     }
 
     private void SeparateTasksToActiveAndDone(IEnumerable<TaskListItem> sortedItems)

--- a/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/TasksViewModel.cs
@@ -265,16 +265,142 @@ public partial class TasksViewModel : ObservableObject
                 ? new DateTimeOffset(localNow.Date + end, localNow.Offset)
                 : new DateTimeOffset(localNow.Date + end, localNow.Offset).AddDays(1));
 
-        for (DateTimeOffset cursorLocal = windowStartLocal; cursorLocal < windowEndLocal; cursorLocal = cursorLocal.AddMinutes(1))
+        if (windowEndLocal <= windowStartLocal)
         {
-            if (TimeWindowService.AllowedNow(task, cursorLocal.ToOffset(TimeSpan.Zero), _settings))
+            return false;
+        }
+
+        HashSet<DateTimeOffset> probes = BuildAllowedWindowProbes(task, windowStartLocal, windowEndLocal);
+        foreach (DateTimeOffset probe in probes.OrderBy(value => value))
+        {
+            if (TimeWindowService.AllowedNow(task, probe.ToOffset(TimeSpan.Zero), _settings))
             {
                 return true;
             }
         }
 
-        // AllowedNow treats the end as exclusive, so explicitly probe just before the window end.
-        return TimeWindowService.AllowedNow(task, windowEndLocal.AddTicks(-1).ToOffset(TimeSpan.Zero), _settings);
+        return false;
+    }
+
+    private HashSet<DateTimeOffset> BuildAllowedWindowProbes(TaskItem task, DateTimeOffset windowStartLocal, DateTimeOffset windowEndLocal)
+    {
+        HashSet<DateTimeOffset> probes = [];
+
+        void AddProbe(DateTimeOffset localProbe)
+        {
+            if (localProbe >= windowStartLocal && localProbe < windowEndLocal)
+            {
+                probes.Add(localProbe);
+            }
+        }
+
+        AddProbe(windowStartLocal);
+        AddProbe(windowStartLocal.AddTicks(1));
+        AddProbe(windowEndLocal.AddTicks(-1));
+
+        foreach (TimeSpan boundary in GetTransitionBoundaries(task))
+        {
+            DateTime startDate = windowStartLocal.Date.AddDays(-1);
+            DateTime endDate = windowEndLocal.Date.AddDays(1);
+
+            for (DateTime day = startDate; day <= endDate; day = day.AddDays(1))
+            {
+                DateTimeOffset boundaryLocal = new(day + boundary, windowStartLocal.Offset);
+                AddProbe(boundaryLocal.AddTicks(-1));
+                AddProbe(boundaryLocal);
+                AddProbe(boundaryLocal.AddTicks(1));
+            }
+        }
+
+        for (DateTime day = windowStartLocal.Date.AddDays(-1); day <= windowEndLocal.Date.AddDays(1); day = day.AddDays(1))
+        {
+            DateTimeOffset midnight = new(day, windowStartLocal.Offset);
+            AddProbe(midnight.AddTicks(-1));
+            AddProbe(midnight);
+            AddProbe(midnight.AddTicks(1));
+        }
+
+        return probes;
+    }
+
+    private IReadOnlyCollection<TimeSpan> GetTransitionBoundaries(TaskItem task)
+    {
+        HashSet<TimeSpan> boundaries =
+        [
+            _settings.WorkStart,
+            _settings.WorkEnd,
+            _settings.MorningStart,
+            _settings.MorningEnd,
+            _settings.LunchStart,
+            _settings.LunchEnd,
+            _settings.EveningStart,
+            _settings.EveningEnd
+        ];
+
+        PeriodDefinition definition = ResolvePeriodDefinition(task);
+        (TimeSpan definitionStart, TimeSpan definitionEnd) = ResolveTimeWindow(definition);
+        boundaries.Add(definitionStart);
+        boundaries.Add(definitionEnd);
+
+        return boundaries;
+    }
+
+    private PeriodDefinition ResolvePeriodDefinition(TaskItem task)
+    {
+        if (PeriodDefinitionCatalog.TryGet(task.PeriodDefinitionId, out PeriodDefinition catalogDefinition))
+        {
+            return catalogDefinition;
+        }
+
+        if (TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
+        {
+            return adHocDefinition;
+        }
+
+        return task.AllowedPeriod switch
+        {
+            AllowedPeriod.Work => PeriodDefinitionCatalog.Work,
+            AllowedPeriod.OffWork => PeriodDefinitionCatalog.OffWork,
+            AllowedPeriod.Custom => new PeriodDefinition
+            {
+                Id = string.Empty,
+                Name = "Legacy custom",
+                StartTime = task.CustomStartTime,
+                EndTime = task.CustomEndTime,
+                Weekdays = task.CustomWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
+                IsAllDay = !task.CustomStartTime.HasValue || !task.CustomEndTime.HasValue,
+                Mode = PeriodDefinitionMode.None
+            },
+            _ => PeriodDefinitionCatalog.Any
+        };
+    }
+
+    private (TimeSpan Start, TimeSpan End) ResolveTimeWindow(PeriodDefinition definition)
+    {
+        bool alignsWithWorkHours = definition.Mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours)
+            || definition.Mode.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours);
+
+        if (alignsWithWorkHours)
+        {
+            return (_settings.WorkStart, _settings.WorkEnd);
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Morning))
+        {
+            return (_settings.MorningStart, _settings.MorningEnd);
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Lunch))
+        {
+            return (_settings.LunchStart, _settings.LunchEnd);
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Evening))
+        {
+            return (_settings.EveningStart, _settings.EveningEnd);
+        }
+
+        return (definition.StartTime ?? TimeSpan.Zero, definition.EndTime ?? TimeSpan.Zero);
     }
 
     private void SeparateTasksToActiveAndDone(IEnumerable<TaskListItem> sortedItems)

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml
@@ -185,17 +185,69 @@
     </ContentPage.ToolbarItems>
 
     <Grid RowDefinitions="Auto,*">
-        <HorizontalStackLayout Padding="12,8"
-                               Spacing="12">
-            <Label Text="Sort by"
-                   FontSize="14"
-                   VerticalOptions="Center"
-                   TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
-            <Picker ItemsSource="{Binding SortOptions}"
-                    SelectedItem="{Binding SelectedSort}"
-                    Title="Sort"
-                    HorizontalOptions="EndAndExpand" />
-        </HorizontalStackLayout>
+        <VerticalStackLayout Padding="12,8"
+                             Spacing="8">
+            <HorizontalStackLayout Spacing="12">
+                <Label Text="Sort by"
+                       FontSize="14"
+                       VerticalOptions="Center"
+                       TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
+                <Picker ItemsSource="{Binding SortOptions}"
+                        SelectedItem="{Binding SelectedSort}"
+                        Title="Sort"
+                        HorizontalOptions="EndAndExpand" />
+            </HorizontalStackLayout>
+
+            <VerticalStackLayout Spacing="6">
+                <HorizontalStackLayout Spacing="8">
+                    <Label Text="Allowed time"
+                           FontSize="13"
+                           VerticalOptions="Center"
+                           TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
+                    <HorizontalStackLayout Spacing="6">
+                        <CheckBox IsChecked="{Binding FilterAllowedNow}" />
+                        <Label Text="Now"
+                               FontSize="13"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                    <HorizontalStackLayout Spacing="6">
+                        <CheckBox IsChecked="{Binding FilterAllowedMorning}" />
+                        <Label Text="Morning"
+                               FontSize="13"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                    <HorizontalStackLayout Spacing="6">
+                        <CheckBox IsChecked="{Binding FilterAllowedAfternoon}" />
+                        <Label Text="Afternoon"
+                               FontSize="13"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                    <HorizontalStackLayout Spacing="6">
+                        <CheckBox IsChecked="{Binding FilterAllowedEvening}" />
+                        <Label Text="Evening"
+                               FontSize="13"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                </HorizontalStackLayout>
+
+                <HorizontalStackLayout Spacing="12">
+                    <Label Text="Repeating"
+                           FontSize="13"
+                           VerticalOptions="Center"
+                           TextColor="{AppThemeBinding Light=#4a5568, Dark=#cbd5f5}" />
+                    <Picker ItemsSource="{Binding RepeatFilterOptions}"
+                            SelectedItem="{Binding SelectedRepeatFilter}"
+                            Title="Repeat"
+                            HorizontalOptions="StartAndExpand" />
+                    <Button Text="Reset filters"
+                            FontSize="12"
+                            Padding="12,6"
+                            BackgroundColor="Transparent"
+                            TextColor="{AppThemeBinding Light=#2d9cdb, Dark=#90cdf4}"
+                            Clicked="OnResetFiltersClicked" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
+        </VerticalStackLayout>
 
         <CollectionView Grid.Row="1"
                         IsVisible="{Binding HasTasks}"

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml.cs
@@ -115,6 +115,11 @@ public partial class TasksPage : ContentPage
         await _vm.DeleteAsync(task);
     }
 
+    private void OnResetFiltersClicked(object sender, EventArgs e)
+    {
+        _vm.ResetFilters();
+    }
+
     private async Task OpenEditorAsync(TaskItem? task)
     {
         var page = _services.GetRequiredService<EditTaskPage>();


### PR DESCRIPTION
### Motivation
- Provide a compact, immediate filtering UI for the Tasks page so users can focus on tasks allowed at particular times
(Now/Morning/Afternoon/Evening) and quickly filter repeating vs one-off tasks.

### Description
- Added a compact filter bar to `TasksPage.xaml` containing allowed-time checkboxes (`Now`, `Morning`, `Afternoon`, `Evening`), a repeating `Picker`, and a `Reset filters` `Button` wired to
`OnResetFiltersClicked` in `TasksPage.xaml.cs`.
- Wired the reset action in `TasksPage.xaml.cs` to call a new `ResetFilters()` method on the view model.
- Extended `TasksViewModel` with filter state properties (`FilterAllowedNow`, `FilterAllowedMorning`, `FilterAllowedAfternoon`, `FilterAllowedEvening`, `SelectedRepeatFilter`, and `RepeatFilterOptions`) and kept a backing `_allTasks` list to preserve the unfiltered dataset.
- Implemented `ApplyFilters()` which is run before sorting in `ApplySortToCollections()`, and added `MatchesAllowedTimeFilter()` and `IsAllowedDuringWindow()` that reuse `TimeWindowService` and `AppSettings` to align allowed-period semantics; added `RequestRefresh()` and pending-refresh logic to ensure UI updates are immediate and safe while loading.

### Testing
- No automated tests were executed for this patch (per instructions).

------
[Codex
Task](https://chatgpt.com/codex/tasks/task_e_6989c8bc8cac8326b47b9f0c08154e3a)

+semver: minor
