### PR TITLE
Reorganize Settings page into collapsible sections

### DIFF
--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -23,6 +23,7 @@
                            FontSize="16" />
                 </Expander.Header>
                 <Grid ColumnDefinitions="Auto,*"
+                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       RowSpacing="12"
                       ColumnSpacing="12"
                       Padding="0,10,0,0">
@@ -83,6 +84,7 @@
                            FontSize="16" />
                 </Expander.Header>
                 <Grid ColumnDefinitions="Auto,*"
+                      RowDefinitions="Auto,Auto,Auto,Auto,Auto"
                       RowSpacing="12"
                       ColumnSpacing="12"
                       Padding="0,10,0,0">
@@ -134,6 +136,7 @@
                            FontSize="16" />
                 </Expander.Header>
                 <Grid ColumnDefinitions="Auto,*"
+                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       RowSpacing="12"
                       ColumnSpacing="12"
                       Padding="0,10,0,0">
@@ -281,6 +284,7 @@
                            FontSize="16" />
                 </Expander.Header>
                 <Grid ColumnDefinitions="Auto,*"
+                      RowDefinitions="Auto,Auto,Auto,Auto"
                       RowSpacing="12"
                       ColumnSpacing="12"
                       Padding="0,10,0,0">
@@ -339,6 +343,7 @@
                            FontSize="16" />
                 </Expander.Header>
                 <Grid ColumnDefinitions="Auto,*"
+                      RowDefinitions="Auto,Auto"
                       RowSpacing="12"
                       ColumnSpacing="12"
                       Padding="0,10,0,0">
@@ -380,6 +385,7 @@
                            FontSize="16" />
                 </Expander.Header>
                 <Grid ColumnDefinitions="Auto,*"
+                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
                       RowSpacing="12"
                       ColumnSpacing="12"
                       Padding="0,10,0,0">

--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -13,388 +13,423 @@
             <converters:ComplementPercentageConverter x:Key="ComplementPercentageConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
+
     <ScrollView>
-        <Grid Padding="20"
-              ColumnDefinitions="Auto,*"
-              RowSpacing="18">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+        <VerticalStackLayout Padding="20" Spacing="12">
+            <Expander IsExpanded="True">
+                <Expander.Header>
+                    <Label Text="General"
+                           FontAttributes="Bold"
+                           FontSize="16" />
+                </Expander.Header>
+                <Grid ColumnDefinitions="Auto,*"
+                      RowSpacing="12"
+                      ColumnSpacing="12"
+                      Padding="0,10,0,0">
+                    <Label Grid.Row="0"
+                           Text="Auto shuffle"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="0"
+                            Grid.Column="1"
+                            IsToggled="{Binding Settings.AutoShuffleEnabled}" />
 
-            <Label Grid.Row="0"
-                   Text="Auto shuffle"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="0"
-                    Grid.Column="1"
-                    IsToggled="{Binding Settings.AutoShuffleEnabled}" />
+                    <Label Grid.Row="1"
+                           Text="Active"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="1"
+                            Grid.Column="1"
+                            IsToggled="{Binding Settings.Active}" />
 
-            <Label Grid.Row="1"
-                   Text="Work start"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="1"
-                        Grid.Column="1"
-                        Time="{Binding Settings.WorkStart}" />
+                    <Label Grid.Row="2"
+                           Text="Background activity"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="2"
+                            Grid.Column="1"
+                            IsToggled="{Binding Settings.BackgroundActivityEnabled}" />
 
-            <Label Grid.Row="2"
-                   Text="Work end"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="2"
-                        Grid.Column="1"
-                        Time="{Binding Settings.WorkEnd}" />
+                    <Label Grid.Row="3"
+                           Text="Manual shuffle respects allowed hours"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="3"
+                            Grid.Column="1"
+                            IsToggled="{Binding Settings.ManualShuffleRespectsAllowedPeriod}" />
 
-            <Label Grid.Row="3"
-                   Grid.ColumnSpan="2"
-                   Text="Work hours apply to weekdays (Mon–Fri). They power the Workday preset and work/off-work alignment; custom hours use the task's weekdays and time range."
-                   FontSize="12"
-                   TextColor="#6B7280" />
+                    <Label Grid.Row="4"
+                           Text="Work start"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="4"
+                                Grid.Column="1"
+                                Time="{Binding Settings.WorkStart}" />
 
-            <Label Grid.Row="4"
-                   Text="Quiet start"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="4"
-                        Grid.Column="1"
-                        Time="{Binding Settings.QuietHoursStart}" />
+                    <Label Grid.Row="5"
+                           Text="Work end"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="5"
+                                Grid.Column="1"
+                                Time="{Binding Settings.WorkEnd}" />
 
-            <Label Grid.Row="5"
-                   Text="Quiet end"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="5"
-                        Grid.Column="1"
-                        Time="{Binding Settings.QuietHoursEnd}" />
+                    <Label Grid.Row="6"
+                           Grid.ColumnSpan="2"
+                           Text="Work hours apply to weekdays (Mon–Fri). They power the Workday preset and work/off-work alignment; custom hours use the task's weekdays and time range."
+                           FontSize="12"
+                           TextColor="#6B7280" />
+                </Grid>
+            </Expander>
 
-            <Label Grid.Row="6"
-                   Text="Reminder (min)"
-                   VerticalOptions="Center" />
-            <controls:NumericStepper Grid.Row="6"
-                                     Grid.Column="1"
-                                     Minimum="5"
-                                     Maximum="240"
-                                     Increment="5"
-                                     Value="{Binding Settings.ReminderMinutes}"
-                                     HorizontalOptions="Start" />
+            <Expander>
+                <Expander.Header>
+                    <Label Text="Notifications"
+                           FontAttributes="Bold"
+                           FontSize="16" />
+                </Expander.Header>
+                <Grid ColumnDefinitions="Auto,*"
+                      RowSpacing="12"
+                      ColumnSpacing="12"
+                      Padding="0,10,0,0">
+                    <Label Grid.Row="0"
+                           Text="Notifications"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="0"
+                            Grid.Column="1"
+                            IsToggled="{Binding Settings.EnableNotifications}" />
 
-            <Label Grid.Row="7"
-                   Text="Min gap (min)"
-                   VerticalOptions="Center" />
-            <controls:NumericStepper Grid.Row="7"
-                                     Grid.Column="1"
-                                     Minimum="5"
-                                     Maximum="240"
-                                     Increment="5"
-                                     Value="{Binding Settings.MinGapMinutes}"
-                                     HorizontalOptions="Start" />
+                    <Label Grid.Row="1"
+                           Text="Sound"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="1"
+                            Grid.Column="1"
+                            IsToggled="{Binding Settings.SoundOn}" />
 
-            <Label Grid.Row="8"
-                   Text="Max gap (min)"
-                   VerticalOptions="Center" />
-            <controls:NumericStepper Grid.Row="8"
-                                     Grid.Column="1"
-                                     Minimum="5"
-                                     Maximum="480"
-                                     Increment="5"
-                                     Value="{Binding Settings.MaxGapMinutes}"
-                                     HorizontalOptions="Start" />
+                    <Label Grid.Row="2"
+                           Text="Quiet start"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="2"
+                                Grid.Column="1"
+                                Time="{Binding Settings.QuietHoursStart}" />
 
-            <Label Grid.Row="9"
-                   Text="Max daily shuffles"
-                   VerticalOptions="Center" />
-            <controls:NumericStepper Grid.Row="9"
-                                     Grid.Column="1"
-                                     Minimum="0"
-                                     Maximum="24"
-                                     Increment="1"
-                                     Value="{Binding Settings.MaxDailyShuffles}"
-                                     HorizontalOptions="Start" />
+                    <Label Grid.Row="3"
+                           Text="Quiet end"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="3"
+                                Grid.Column="1"
+                                Time="{Binding Settings.QuietHoursEnd}" />
 
-            <Label Grid.Row="10"
-                   Text="Notifications"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="10"
-                    Grid.Column="1"
-                    IsToggled="{Binding Settings.EnableNotifications}" />
+                    <Label Grid.Row="4"
+                           Text="Reminder (min)"
+                           VerticalOptions="Center" />
+                    <controls:NumericStepper Grid.Row="4"
+                                             Grid.Column="1"
+                                             Minimum="5"
+                                             Maximum="240"
+                                             Increment="5"
+                                             Value="{Binding Settings.ReminderMinutes}"
+                                             HorizontalOptions="Start" />
+                </Grid>
+            </Expander>
 
-            <Label Grid.Row="11"
-                   Text="Sound"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="11"
-                    Grid.Column="1"
-                    IsToggled="{Binding Settings.SoundOn}" />
+            <Expander>
+                <Expander.Header>
+                    <Label Text="Shuffle behavior"
+                           FontAttributes="Bold"
+                           FontSize="16" />
+                </Expander.Header>
+                <Grid ColumnDefinitions="Auto,*"
+                      RowSpacing="12"
+                      ColumnSpacing="12"
+                      Padding="0,10,0,0">
+                    <Label Grid.Row="0"
+                           Text="Min gap (min)"
+                           VerticalOptions="Center" />
+                    <controls:NumericStepper Grid.Row="0"
+                                             Grid.Column="1"
+                                             Minimum="5"
+                                             Maximum="240"
+                                             Increment="5"
+                                             Value="{Binding Settings.MinGapMinutes}"
+                                             HorizontalOptions="Start" />
 
-            <Label Grid.Row="12"
-                   Text="Active"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="12"
-                    Grid.Column="1"
-                    IsToggled="{Binding Settings.Active}" />
+                    <Label Grid.Row="1"
+                           Text="Max gap (min)"
+                           VerticalOptions="Center" />
+                    <controls:NumericStepper Grid.Row="1"
+                                             Grid.Column="1"
+                                             Minimum="5"
+                                             Maximum="480"
+                                             Increment="5"
+                                             Value="{Binding Settings.MaxGapMinutes}"
+                                             HorizontalOptions="Start" />
 
-            <Label Grid.Row="13"
-                   Text="Background activity"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="13"
-                    Grid.Column="1"
-                    IsToggled="{Binding Settings.BackgroundActivityEnabled}" />
+                    <Label Grid.Row="2"
+                           Text="Max daily shuffles"
+                           VerticalOptions="Center" />
+                    <controls:NumericStepper Grid.Row="2"
+                                             Grid.Column="1"
+                                             Minimum="0"
+                                             Maximum="24"
+                                             Increment="1"
+                                             Value="{Binding Settings.MaxDailyShuffles}"
+                                             HorizontalOptions="Start" />
 
-            <Label Grid.Row="14"
-                   Text="Manual shuffle respects allowed hours"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="14"
-                    Grid.Column="1"
-                    IsToggled="{Binding Settings.ManualShuffleRespectsAllowedPeriod}" />
+                    <Label Grid.Row="3"
+                           Text="Streak bias"
+                           VerticalOptions="Center" />
+                    <Grid Grid.Row="3"
+                          Grid.Column="1"
+                          ColumnDefinitions="*,Auto"
+                          ColumnSpacing="8">
+                        <Slider Minimum="0"
+                                Maximum="1"
+                                Value="{Binding Settings.StreakBias}" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Settings.StreakBias, StringFormat='{0:F2}'}"
+                               VerticalOptions="Center" />
+                    </Grid>
 
-            <Label Grid.Row="15"
-                   Text="Streak bias"
-                   VerticalOptions="Center" />
-            <Grid Grid.Row="15"
-                  Grid.Column="1"
-                  ColumnDefinitions="*,Auto"
-                  ColumnSpacing="8">
-                <Slider Minimum="0"
-                        Maximum="1"
-                        Value="{Binding Settings.StreakBias}" />
-                <Label Grid.Column="1"
-                       Text="{Binding Settings.StreakBias, StringFormat='{0:F2}'}"
-                       VerticalOptions="Center" />
-            </Grid>
+                    <Label Grid.Row="4"
+                           Text="Stable randomness"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="4"
+                            Grid.Column="1"
+                            IsToggled="{Binding Settings.StableRandomnessPerDay}" />
 
-            <Label Grid.Row="16"
-                   Text="Stable randomness"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="16"
-                    Grid.Column="1"
-                    IsToggled="{Binding Settings.StableRandomnessPerDay}" />
+                    <Label Grid.Row="5"
+                           Text="Importance vs urgency"
+                           VerticalOptions="Center" />
+                    <Grid Grid.Row="5"
+                          Grid.Column="1"
+                          RowDefinitions="Auto,Auto"
+                          ColumnDefinitions="*,Auto"
+                          RowSpacing="4"
+                          ColumnSpacing="8">
+                        <Slider Grid.Row="0"
+                                Grid.ColumnSpan="2"
+                                Minimum="0"
+                                Maximum="100"
+                                Value="{Binding Settings.ImportanceWeight}" />
+                        <Label Grid.Row="1"
+                               Grid.Column="0"
+                               Text="{Binding Settings.ImportanceWeight, StringFormat='Importance: {0:0}%'}"
+                               VerticalOptions="Center" />
+                        <Label Grid.Row="1"
+                               Grid.Column="1"
+                               Text="{Binding Settings.ImportanceWeight, Converter={StaticResource ComplementPercentageConverter}, StringFormat='Urgency: {0:0}%'}"
+                               HorizontalTextAlignment="End"
+                               VerticalOptions="Center" />
+                    </Grid>
 
-            <Label Grid.Row="17"
-                   Text="Importance vs urgency"
-                   VerticalOptions="Center" />
-            <Grid Grid.Row="17"
-                  Grid.Column="1"
-                  RowDefinitions="Auto,Auto"
-                  ColumnDefinitions="*,Auto"
-                  RowSpacing="4"
-                  ColumnSpacing="8">
-                <Slider Grid.Row="0"
-                        Grid.ColumnSpan="2"
-                        Minimum="0"
-                        Maximum="100"
-                        Value="{Binding Settings.ImportanceWeight}" />
-                <Label Grid.Row="1"
-                       Grid.Column="0"
-                       Text="{Binding Settings.ImportanceWeight, StringFormat='Importance: {0:0}%'}"
-                       VerticalOptions="Center" />
-                <Label Grid.Row="1"
-                       Grid.Column="1"
-                       Text="{Binding Settings.ImportanceWeight, Converter={StaticResource ComplementPercentageConverter}, StringFormat='Urgency: {0:0}%'}"
-                       HorizontalTextAlignment="End"
-                       VerticalOptions="Center" />
-            </Grid>
+                    <Label Grid.Row="6"
+                           Text="Deadline share"
+                           VerticalOptions="Center" />
+                    <Grid Grid.Row="6"
+                          Grid.Column="1"
+                          RowDefinitions="Auto,Auto"
+                          ColumnDefinitions="*,Auto"
+                          RowSpacing="4"
+                          ColumnSpacing="8">
+                        <Slider Grid.Row="0"
+                                Grid.ColumnSpan="2"
+                                Minimum="0"
+                                Maximum="100"
+                                Value="{Binding Settings.UrgencyDeadlineShare}" />
+                        <Label Grid.Row="1"
+                               Grid.Column="0"
+                               Text="{Binding Settings.UrgencyDeadlineShare, StringFormat='Deadlines: {0:0}%'}"
+                               VerticalOptions="Center" />
+                        <Label Grid.Row="1"
+                               Grid.Column="1"
+                               Text="{Binding Settings.UrgencyDeadlineShare, Converter={StaticResource ComplementPercentageConverter}, StringFormat='Repeats: {0:0}%'}"
+                               HorizontalTextAlignment="End"
+                               VerticalOptions="Center" />
+                    </Grid>
 
-            <Label Grid.Row="18"
-                   Text="Deadline share"
-                   VerticalOptions="Center" />
-            <Grid Grid.Row="18"
-                  Grid.Column="1"
-                  RowDefinitions="Auto,Auto"
-                  ColumnDefinitions="*,Auto"
-                  RowSpacing="4"
-                  ColumnSpacing="8">
-                <Slider Grid.Row="0"
-                        Grid.ColumnSpan="2"
-                        Minimum="0"
-                        Maximum="100"
-                        Value="{Binding Settings.UrgencyDeadlineShare}" />
-                <Label Grid.Row="1"
-                       Grid.Column="0"
-                       Text="{Binding Settings.UrgencyDeadlineShare, StringFormat='Deadlines: {0:0}%'}"
-                       VerticalOptions="Center" />
-                <Label Grid.Row="1"
-                       Grid.Column="1"
-                       Text="{Binding Settings.UrgencyDeadlineShare, Converter={StaticResource ComplementPercentageConverter}, StringFormat='Repeats: {0:0}%'}"
-                       HorizontalTextAlignment="End"
-                       VerticalOptions="Center" />
-            </Grid>
+                    <Label Grid.Row="7"
+                           Text="Repeat penalty"
+                           VerticalOptions="Center" />
+                    <Grid Grid.Row="7"
+                          Grid.Column="1"
+                          ColumnDefinitions="*,Auto"
+                          ColumnSpacing="8">
+                        <Slider Minimum="0"
+                                Maximum="1"
+                                Value="{Binding Settings.RepeatUrgencyPenalty}" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Settings.RepeatUrgencyPenalty, StringFormat='{0:F2}'}"
+                               VerticalOptions="Center" />
+                    </Grid>
 
-            <Label Grid.Row="19"
-                   Text="Repeat penalty"
-                   VerticalOptions="Center" />
-            <Grid Grid.Row="19"
-                  Grid.Column="1"
-                  ColumnDefinitions="*,Auto"
-                  ColumnSpacing="8">
-                <Slider Minimum="0"
-                        Maximum="1"
-                        Value="{Binding Settings.RepeatUrgencyPenalty}" />
-                <Label Grid.Column="1"
-                       Text="{Binding Settings.RepeatUrgencyPenalty, StringFormat='{0:F2}'}"
-                       VerticalOptions="Center" />
-            </Grid>
+                    <Label Grid.Row="8"
+                           Text="Size bias strength"
+                           VerticalOptions="Center" />
+                    <Grid Grid.Row="8"
+                          Grid.Column="1"
+                          ColumnDefinitions="*,Auto"
+                          ColumnSpacing="8">
+                        <Slider Minimum="0"
+                                Maximum="1"
+                                Value="{Binding Settings.SizeBiasStrength}" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Settings.SizeBiasStrength, StringFormat='{0:F2}'}"
+                               VerticalOptions="Center" />
+                    </Grid>
+                </Grid>
+            </Expander>
 
-            <Label Grid.Row="20"
-                   Text="Size bias strength"
-                   VerticalOptions="Center" />
-            <Grid Grid.Row="20"
-                  Grid.Column="1"
-                  ColumnDefinitions="*,Auto"
-                  ColumnSpacing="8">
-                <Slider Minimum="0"
-                        Maximum="1"
-                        Value="{Binding Settings.SizeBiasStrength}" />
-                <Label Grid.Column="1"
-                       Text="{Binding Settings.SizeBiasStrength, StringFormat='{0:F2}'}"
-                       VerticalOptions="Center" />
-            </Grid>
+            <Expander>
+                <Expander.Header>
+                    <Label Text="Pomodoro"
+                           FontAttributes="Bold"
+                           FontSize="16" />
+                </Expander.Header>
+                <Grid ColumnDefinitions="Auto,*"
+                      RowSpacing="12"
+                      ColumnSpacing="12"
+                      Padding="0,10,0,0">
+                    <Label Grid.Row="0"
+                           Text="Pomodoro mode"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="0"
+                            Grid.Column="1"
+                            IsToggled="{Binding UsePomodoro}" />
 
-            <Label Grid.Row="21"
-                   Text="Pomodoro mode"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="21"
-                    Grid.Column="1"
-                    IsToggled="{Binding UsePomodoro}" />
+                    <Label Grid.Row="1"
+                           Text="Focus length (min)"
+                           VerticalOptions="Center"
+                           IsVisible="{Binding UsePomodoro}" />
+                    <controls:NumericStepper Grid.Row="1"
+                                             Grid.Column="1"
+                                             Minimum="1"
+                                             Maximum="240"
+                                             Increment="1"
+                                             Value="{Binding Settings.FocusMinutes}"
+                                             HorizontalOptions="Start"
+                                             IsVisible="{Binding UsePomodoro}" />
 
-            <Label Grid.Row="22"
-                   Text="Focus length (min)"
-                   VerticalOptions="Center"
-                   IsVisible="{Binding UsePomodoro}" />
-            <controls:NumericStepper Grid.Row="22"
-                                     Grid.Column="1"
-                                     Minimum="1"
-                                     Maximum="240"
-                                     Increment="1"
-                                     Value="{Binding Settings.FocusMinutes}"
-                                     HorizontalOptions="Start"
-                                     IsVisible="{Binding UsePomodoro}" />
+                    <Label Grid.Row="2"
+                           Text="Break length (min)"
+                           VerticalOptions="Center"
+                           IsVisible="{Binding UsePomodoro}" />
+                    <controls:NumericStepper Grid.Row="2"
+                                             Grid.Column="1"
+                                             Minimum="1"
+                                             Maximum="120"
+                                             Increment="1"
+                                             Value="{Binding Settings.BreakMinutes}"
+                                             HorizontalOptions="Start"
+                                             IsVisible="{Binding UsePomodoro}" />
 
-            <Label Grid.Row="23"
-                   Text="Break length (min)"
-                   VerticalOptions="Center"
-                   IsVisible="{Binding UsePomodoro}" />
-            <controls:NumericStepper Grid.Row="23"
-                                     Grid.Column="1"
-                                     Minimum="1"
-                                     Maximum="120"
-                                     Increment="1"
-                                     Value="{Binding Settings.BreakMinutes}"
-                                     HorizontalOptions="Start"
-                                     IsVisible="{Binding UsePomodoro}" />
+                    <Label Grid.Row="3"
+                           Text="Cycles"
+                           VerticalOptions="Center"
+                           IsVisible="{Binding UsePomodoro}" />
+                    <controls:NumericStepper Grid.Row="3"
+                                             Grid.Column="1"
+                                             Minimum="1"
+                                             Maximum="12"
+                                             Increment="1"
+                                             Value="{Binding Settings.PomodoroCycles}"
+                                             HorizontalOptions="Start"
+                                             IsVisible="{Binding UsePomodoro}" />
+                </Grid>
+            </Expander>
 
-            <Label Grid.Row="24"
-                   Text="Cycles"
-                   VerticalOptions="Center"
-                   IsVisible="{Binding UsePomodoro}" />
-            <controls:NumericStepper Grid.Row="24"
-                                     Grid.Column="1"
-                                     Minimum="1"
-                                     Maximum="12"
-                                     Increment="1"
-                                     Value="{Binding Settings.PomodoroCycles}"
-                                     HorizontalOptions="Start"
-                                     IsVisible="{Binding UsePomodoro}" />
+            <Expander>
+                <Expander.Header>
+                    <Label Text="Sync &amp; account"
+                           FontAttributes="Bold"
+                           FontSize="16" />
+                </Expander.Header>
+                <Grid ColumnDefinitions="Auto,*"
+                      RowSpacing="12"
+                      ColumnSpacing="12"
+                      Padding="0,10,0,0">
+                    <Label Grid.Row="0"
+                           Text="Anonymous session"
+                           VerticalOptions="Center" />
+                    <Switch Grid.Row="0"
+                            Grid.Column="1"
+                            IsToggled="{Binding IsAnonymousSession}"
+                            IsEnabled="False" />
 
-            <Label Grid.Row="25"
-                   Text="Anonymous session"
-                   VerticalOptions="Center" />
-            <Switch Grid.Row="25"
-                    Grid.Column="1"
-                    IsToggled="{Binding IsAnonymousSession}"
-                    IsEnabled="False" />
+                    <Label Grid.Row="1"
+                           Text="User id"
+                           VerticalOptions="Center" />
+                    <Grid Grid.Row="1"
+                          Grid.Column="1"
+                          ColumnDefinitions="*,Auto"
+                          ColumnSpacing="8">
+                        <Label Grid.Column="0"
+                               Text="{Binding UserDisplayLabel}" />
+                        <Button Grid.Column="1"
+                                Text="Login"
+                                Command="{Binding LoginCommand}"
+                                IsEnabled="{Binding IsAnonymousSession}"
+                                IsVisible="{Binding IsAnonymousSession}" />
+                        <Button Grid.Column="1"
+                                Text="Logout"
+                                Command="{Binding LogoutCommand}"
+                                IsEnabled="{Binding IsLoggedIn}"
+                                IsVisible="{Binding IsLoggedIn}" />
+                    </Grid>
+                </Grid>
+            </Expander>
 
-            <Label Grid.Row="26"
-                   Text="User id"
-                   VerticalOptions="Center" />
-            <Grid Grid.Row="26" Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <Label Grid.Column="0"
-                       Text="{Binding UserDisplayLabel}" />
-                <Button Grid.Column="1"
-                        Text="Login"
-                        Command="{Binding LoginCommand}"
-                        IsEnabled="{Binding IsAnonymousSession}"
-                        IsVisible="{Binding IsAnonymousSession}" />
-                <Button Grid.Column="1"
-                        Text="Logout"
-                        Command="{Binding LogoutCommand}"
-                        IsEnabled="{Binding IsLoggedIn}"
-                        IsVisible="{Binding IsLoggedIn}" />
-            </Grid>
+            <Expander>
+                <Expander.Header>
+                    <Label Text="Day slots"
+                           FontAttributes="Bold"
+                           FontSize="16" />
+                </Expander.Header>
+                <Grid ColumnDefinitions="Auto,*"
+                      RowSpacing="12"
+                      ColumnSpacing="12"
+                      Padding="0,10,0,0">
+                    <Label Grid.Row="0"
+                           Text="Morning start"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="0"
+                                Grid.Column="1"
+                                Time="{Binding MorningStart}" />
 
-            <Label Grid.Row="27"
-                   Text="Morning start"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="27"
-                        Grid.Column="1"
-                        Time="{Binding MorningStart}" />
+                    <Label Grid.Row="1"
+                           Text="Morning end"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="1"
+                                Grid.Column="1"
+                                Time="{Binding MorningEnd}" />
 
-            <Label Grid.Row="28"
-                   Text="Morning end"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="28"
-                        Grid.Column="1"
-                        Time="{Binding MorningEnd}" />
+                    <Label Grid.Row="2"
+                           Text="Evening start"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="2"
+                                Grid.Column="1"
+                                Time="{Binding EveningStart}" />
 
-            <Label Grid.Row="29"
-                   Text="Evening start"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="29"
-                        Grid.Column="1"
-                        Time="{Binding EveningStart}" />
+                    <Label Grid.Row="3"
+                           Text="Evening end"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="3"
+                                Grid.Column="1"
+                                Time="{Binding EveningEnd}" />
 
-            <Label Grid.Row="30"
-                   Text="Evening end"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="30"
-                        Grid.Column="1"
-                        Time="{Binding EveningEnd}" />
+                    <Label Grid.Row="4"
+                           Text="Lunch start"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="4"
+                                Grid.Column="1"
+                                Time="{Binding LunchStart}" />
 
-            <Label Grid.Row="31"
-                   Text="Lunch start"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="31"
-                        Grid.Column="1"
-                        Time="{Binding LunchStart}" />
+                    <Label Grid.Row="5"
+                           Text="Lunch end"
+                           VerticalOptions="Center" />
+                    <TimePicker Grid.Row="5"
+                                Grid.Column="1"
+                                Time="{Binding LunchEnd}" />
+                </Grid>
+            </Expander>
 
-            <Label Grid.Row="32"
-                   Text="Lunch end"
-                   VerticalOptions="Center" />
-            <TimePicker Grid.Row="32"
-                        Grid.Column="1"
-                        Time="{Binding LunchEnd}" />
-
-            <Grid Grid.Row="33"
-                  Grid.ColumnSpan="2"
-                  ColumnDefinitions="*,*"
-                  ColumnSpacing="16">
+            <Grid ColumnDefinitions="*,*"
+                  ColumnSpacing="16"
+                  Margin="0,8,0,0">
                 <Button Grid.Column="0"
                         Text="Save"
                         Command="{Binding SaveCommand}" />
@@ -403,11 +438,9 @@
                         Command="{Binding ShufflePreviewCommand}" />
             </Grid>
 
-            <ActivityIndicator Grid.Row="34"
-                               Grid.ColumnSpan="2"
-                               HorizontalOptions="Center"
+            <ActivityIndicator HorizontalOptions="Center"
                                IsVisible="{Binding IsBusy}"
                                IsRunning="{Binding IsBusy}" />
-        </Grid>
+        </VerticalStackLayout>
     </ScrollView>
 </ContentPage>


### PR DESCRIPTION
### Motivation
- The Settings page had grown into a long flat list that required heavy scrolling and hurt discoverability. 
- Grouping related controls into labeled, collapsible sections improves scanability and surfaces high-frequency toggles quickly. 
- This is a presentation-only change implementing the low-risk Option A (accordion/expanders) to reduce scope and risk.

### Description
- Replaced the large row-indexed `Grid` in `ShuffleTask.Presentation/Views/SettingsPage.xaml` with a `ScrollView` + `VerticalStackLayout` containing multiple `Expander` sections. 
- Introduced labeled sections: `General` (expanded by default), `Notifications`, `Shuffle behavior`, `Pomodoro`, `Sync & account`, and `Day slots`. 
- Kept all existing bindings and commands intact (e.g., `Settings.*`, `UsePomodoro`, `SaveCommand`, `ShufflePreviewCommand`) and preserved the footer buttons and `ActivityIndicator`. 
- No ViewModel, domain, persistence, or scoring logic was changed.

### Testing
- No automated tests or build/run were executed for this patch; `build/run/tests` were intentionally skipped per FAST PATCH MODE constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccf2300c88326bf7397062e2465ca)