### PR TITLE
Move release workflow permissions to job level

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,12 @@ on:
         type: string
         required: false
 
-permissions:
-  contents: write
-  actions: read
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
     outputs:
       version: ${{ github.event.inputs.version }}
       release-status: ${{ steps.release-status.outputs.status }}


### PR DESCRIPTION
### Motivation
- Ensure the GitHub Actions token permissions are scoped to the `release` job to follow least-privilege and GitHub requirements for job-level permissions.

### Description
- Moved `permissions: contents: write` and `actions: read` from the top-level workflow to the `release` job in `.github/workflows/release.yml` and made no other changes.

### Testing
- No automated tests were run because this is a configuration-only change; the file modification was validated locally via the repository diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf25d166083269b455719899e1316)

+semver: none