### PR TITLE
Fix Android notification cancellation iteration

### DIFF
--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -202,7 +202,7 @@ public partial class NotificationService
             var context = Android.App.Application.Context;
             if (context.GetSystemService(Context.AlarmService) is AlarmManager alarmManager)
             {
-                foreach ((int notificationId, _) in ScheduledNotificationIds)
+                foreach (int notificationId in ScheduledNotificationIds.Keys)
                 {
                     var intent = new Intent(context, typeof(ReminderBroadcastReceiver))
                         .SetAction(AndroidNotificationAction);


### PR DESCRIPTION
### Motivation
- Prevent a deconstruction-related iteration issue when canceling scheduled Android notifications by iterating the dictionary keys directly instead of deconstructing entries.

### Description
- Replaced `foreach ((int notificationId, _) in ScheduledNotificationIds)` with `foreach (int notificationId in ScheduledNotificationIds.Keys)` in `ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs` to iterate the scheduled IDs and preserve existing cancellation behavior.

### Testing
- Attempted to run `dotnet build /workspace/ShuffleTask/ShuffleTask.sln`, but the environment reported `dotnet` is not available so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdd802f0083269e151e49d1b9e65d)