### PR TITLE
Align Android notification delivery with persisted timer completion

### DIFF
--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -9,7 +9,6 @@ using Android.Provider;
 using AndroidX.Core.App;
 using AndroidX.Core.Content;
 using Microsoft.Maui.ApplicationModel;
-using ShuffleTask.Presentation.Utilities;
 
 namespace ShuffleTask.Presentation.Services;
 
@@ -20,6 +19,7 @@ public partial class NotificationService
     private const string AndroidNotificationExtraMessage = "ShuffleTask.Notification.TimeUpMessage";
     private const string AndroidNotificationExtraSound = "ShuffleTask.Notification.Sound";
     private const string AndroidNotificationExtraId = "ShuffleTask.Notification.Id";
+    private const string AndroidNotificationExtraScheduledFireUnixMs = "ShuffleTask.Notification.ScheduledFireUnixMs";
 
     private const string SoundChannelId = "shuffletask.reminders.sound";
     private const string SilentChannelId = "shuffletask.reminders.silent";
@@ -127,12 +127,15 @@ public partial class NotificationService
             return;
         }
 
+        DateTimeOffset scheduledFireAtUtc = DateTimeOffset.UtcNow.AddMilliseconds(delayMs);
+
         var intent = new Intent(context, typeof(ReminderBroadcastReceiver))
             .SetAction(AndroidNotificationAction)
             .PutExtra(AndroidNotificationExtraTitle, title)
             .PutExtra(AndroidNotificationExtraMessage, message)
             .PutExtra(AndroidNotificationExtraSound, playSound)
-            .PutExtra(AndroidNotificationExtraId, notificationId);
+            .PutExtra(AndroidNotificationExtraId, notificationId)
+            .PutExtra(AndroidNotificationExtraScheduledFireUnixMs, scheduledFireAtUtc.ToUnixTimeMilliseconds());
 
         var flags = PendingIntentFlags.UpdateCurrent;
         if (OperatingSystem.IsAndroidVersionAtLeast(23))
@@ -157,7 +160,6 @@ public partial class NotificationService
         if (context.GetSystemService(Context.AlarmService) is AlarmManager)
         {
             long triggerAt = SystemClock.ElapsedRealtime() + delayMs;
-            DateTimeOffset scheduledFireAtUtc = DateTimeOffset.UtcNow.AddMilliseconds(delayMs);
             System.Diagnostics.Debug.WriteLine($"NotificationService(Android): schedule id={notificationId}, delayMs={delayMs}, scheduledFireAtUtc={scheduledFireAtUtc:O}");
             ScheduleExactAlarm(context, AlarmType.ElapsedRealtimeWakeup, pendingIntent, triggerAt);
         }
@@ -297,23 +299,23 @@ public partial class NotificationService
             string message = intent.GetStringExtra(AndroidNotificationExtraMessage) ?? string.Empty;
             bool playSound = intent.GetBooleanExtra(AndroidNotificationExtraSound, true);
             int notificationId = intent.GetIntExtra(AndroidNotificationExtraId, GetNextAndroidNotificationId());
+            long scheduledFireUnixMs = intent.GetLongExtra(AndroidNotificationExtraScheduledFireUnixMs, 0);
+            DateTimeOffset nowUtc = DateTimeOffset.UtcNow;
 
-            if (PersistedTimerState.TryGetActiveTimer(
-                    out _,
-                    out TimeSpan remaining,
-                    out bool expired,
-                    out _,
-                    out DateTimeOffset expiresAt)
-                && !expired
-                && remaining > TimeSpan.Zero)
+            if (scheduledFireUnixMs > 0)
             {
-                System.Diagnostics.Debug.WriteLine(
-                    $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={expiresAt:O}; rescheduling.");
-                ScheduleAndroidNotification(context, title, message, remaining, playSound, notificationId);
-                return;
+                DateTimeOffset scheduledFireAtUtc = DateTimeOffset.FromUnixTimeMilliseconds(scheduledFireUnixMs);
+                TimeSpan remaining = scheduledFireAtUtc - nowUtc;
+                if (remaining > TimeSpan.Zero)
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        $"NotificationService(Android): receive id={notificationId} before scheduled fire time, remaining={remaining.TotalMilliseconds:F0}ms, scheduledFireAtUtc={scheduledFireAtUtc:O}; rescheduling.");
+                    ScheduleAndroidNotification(context, title, message, remaining, playSound, notificationId);
+                    return;
+                }
             }
 
-            System.Diagnostics.Debug.WriteLine($"NotificationService(Android): firing id={notificationId}, nowUtc={DateTimeOffset.UtcNow:O}");
+            System.Diagnostics.Debug.WriteLine($"NotificationService(Android): firing id={notificationId}, nowUtc={nowUtc:O}");
             PostAndroidNotification(context, title, message, playSound, notificationId);
         }
     }

--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Threading;
 using Android.App;
 using Android.Content;
@@ -9,6 +10,7 @@ using Android.Provider;
 using AndroidX.Core.App;
 using AndroidX.Core.Content;
 using Microsoft.Maui.ApplicationModel;
+using ShuffleTask.Presentation.Utilities;
 
 namespace ShuffleTask.Presentation.Services;
 
@@ -19,7 +21,9 @@ public partial class NotificationService
     private const string AndroidNotificationExtraMessage = "ShuffleTask.Notification.TimeUpMessage";
     private const string AndroidNotificationExtraSound = "ShuffleTask.Notification.Sound";
     private const string AndroidNotificationExtraId = "ShuffleTask.Notification.Id";
-    private const string AndroidNotificationExtraScheduledFireUnixMs = "ShuffleTask.Notification.ScheduledFireUnixMs";
+    private const string AndroidNotificationExtraAlignWithActiveTimer = "ShuffleTask.Notification.AlignWithActiveTimer";
+    private const string AndroidNotificationExtraAlignedTimerTaskId = "ShuffleTask.Notification.AlignedTimerTaskId";
+    private const string AndroidNotificationExtraAlignedTimerExpiresAtUtc = "ShuffleTask.Notification.AlignedTimerExpiresAtUtc";
 
     private const string SoundChannelId = "shuffletask.reminders.sound";
     private const string SilentChannelId = "shuffletask.reminders.silent";
@@ -116,7 +120,16 @@ public partial class NotificationService
         NotificationManagerCompat.From(context).Notify(notificationId, builder.Build());
     }
 
-    private static void ScheduleAndroidNotification(Context context, string title, string message, TimeSpan delay, bool playSound, int notificationId)
+    private static void ScheduleAndroidNotification(
+        Context context,
+        string title,
+        string message,
+        TimeSpan delay,
+        bool playSound,
+        int notificationId,
+        bool alignWithActiveTimer,
+        string alignedTimerTaskId,
+        string alignedTimerExpiresAtUtc)
     {
         EnsureChannels(context);
 
@@ -127,15 +140,15 @@ public partial class NotificationService
             return;
         }
 
-        DateTimeOffset scheduledFireAtUtc = DateTimeOffset.UtcNow.AddMilliseconds(delayMs);
-
         var intent = new Intent(context, typeof(ReminderBroadcastReceiver))
             .SetAction(AndroidNotificationAction)
             .PutExtra(AndroidNotificationExtraTitle, title)
             .PutExtra(AndroidNotificationExtraMessage, message)
             .PutExtra(AndroidNotificationExtraSound, playSound)
             .PutExtra(AndroidNotificationExtraId, notificationId)
-            .PutExtra(AndroidNotificationExtraScheduledFireUnixMs, scheduledFireAtUtc.ToUnixTimeMilliseconds());
+            .PutExtra(AndroidNotificationExtraAlignWithActiveTimer, alignWithActiveTimer)
+            .PutExtra(AndroidNotificationExtraAlignedTimerTaskId, alignedTimerTaskId)
+            .PutExtra(AndroidNotificationExtraAlignedTimerExpiresAtUtc, alignedTimerExpiresAtUtc);
 
         var flags = PendingIntentFlags.UpdateCurrent;
         if (OperatingSystem.IsAndroidVersionAtLeast(23))
@@ -160,6 +173,7 @@ public partial class NotificationService
         if (context.GetSystemService(Context.AlarmService) is AlarmManager)
         {
             long triggerAt = SystemClock.ElapsedRealtime() + delayMs;
+            DateTimeOffset scheduledFireAtUtc = DateTimeOffset.UtcNow.AddMilliseconds(delayMs);
             System.Diagnostics.Debug.WriteLine($"NotificationService(Android): schedule id={notificationId}, delayMs={delayMs}, scheduledFireAtUtc={scheduledFireAtUtc:O}");
             ScheduleExactAlarm(context, AlarmType.ElapsedRealtimeWakeup, pendingIntent, triggerAt);
         }
@@ -258,6 +272,22 @@ public partial class NotificationService
             var context = Android.App.Application.Context;
             int notificationId = GetNextAndroidNotificationId();
             ScheduledNotificationIds[notificationId] = 0;
+            bool alignWithActiveTimer = false;
+            string alignedTimerTaskId = string.Empty;
+            string alignedTimerExpiresAtUtc = string.Empty;
+
+            if (delay > TimeSpan.Zero
+                && PersistedTimerState.TryGetActiveTimer(out string taskId, out TimeSpan remaining, out bool expired, out _, out DateTimeOffset expiresAt)
+                && !expired
+                && remaining > TimeSpan.Zero)
+            {
+                alignWithActiveTimer = Math.Abs((remaining - delay).TotalSeconds) <= 1;
+                if (alignWithActiveTimer)
+                {
+                    alignedTimerTaskId = taskId;
+                    alignedTimerExpiresAtUtc = expiresAt.ToString("O", CultureInfo.InvariantCulture);
+                }
+            }
 
             if (delay <= TimeSpan.Zero)
             {
@@ -265,7 +295,16 @@ public partial class NotificationService
             }
             else
             {
-                ScheduleAndroidNotification(context, title, message, delay, playSound, notificationId);
+                ScheduleAndroidNotification(
+                    context,
+                    title,
+                    message,
+                    delay,
+                    playSound,
+                    notificationId,
+                    alignWithActiveTimer,
+                    alignedTimerTaskId,
+                    alignedTimerExpiresAtUtc);
             }
 
             return Task.CompletedTask;
@@ -299,23 +338,44 @@ public partial class NotificationService
             string message = intent.GetStringExtra(AndroidNotificationExtraMessage) ?? string.Empty;
             bool playSound = intent.GetBooleanExtra(AndroidNotificationExtraSound, true);
             int notificationId = intent.GetIntExtra(AndroidNotificationExtraId, GetNextAndroidNotificationId());
-            long scheduledFireUnixMs = intent.GetLongExtra(AndroidNotificationExtraScheduledFireUnixMs, 0);
-            DateTimeOffset nowUtc = DateTimeOffset.UtcNow;
+            bool alignWithActiveTimer = intent.GetBooleanExtra(AndroidNotificationExtraAlignWithActiveTimer, false);
+            string alignedTimerTaskId = intent.GetStringExtra(AndroidNotificationExtraAlignedTimerTaskId) ?? string.Empty;
+            string alignedTimerExpiresAtUtc = intent.GetStringExtra(AndroidNotificationExtraAlignedTimerExpiresAtUtc) ?? string.Empty;
 
-            if (scheduledFireUnixMs > 0)
+            if (alignWithActiveTimer
+                && !string.IsNullOrWhiteSpace(alignedTimerTaskId)
+                && DateTimeOffset.TryParse(
+                    alignedTimerExpiresAtUtc,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out DateTimeOffset alignedTimerExpiresAt)
+                && PersistedTimerState.TryGetActiveTimer(
+                    out string activeTaskId,
+                    out TimeSpan remaining,
+                    out bool expired,
+                    out _,
+                    out DateTimeOffset activeExpiresAt)
+                && !expired
+                && remaining > TimeSpan.Zero
+                && string.Equals(activeTaskId, alignedTimerTaskId, StringComparison.Ordinal)
+                && activeExpiresAt.Equals(alignedTimerExpiresAt))
             {
-                DateTimeOffset scheduledFireAtUtc = DateTimeOffset.FromUnixTimeMilliseconds(scheduledFireUnixMs);
-                TimeSpan remaining = scheduledFireAtUtc - nowUtc;
-                if (remaining > TimeSpan.Zero)
-                {
-                    System.Diagnostics.Debug.WriteLine(
-                        $"NotificationService(Android): receive id={notificationId} before scheduled fire time, remaining={remaining.TotalMilliseconds:F0}ms, scheduledFireAtUtc={scheduledFireAtUtc:O}; rescheduling.");
-                    ScheduleAndroidNotification(context, title, message, remaining, playSound, notificationId);
-                    return;
-                }
+                System.Diagnostics.Debug.WriteLine(
+                    $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={activeExpiresAt:O}; rescheduling.");
+                ScheduleAndroidNotification(
+                    context,
+                    title,
+                    message,
+                    remaining,
+                    playSound,
+                    notificationId,
+                    alignWithActiveTimer: true,
+                    alignedTimerTaskId,
+                    alignedTimerExpiresAtUtc);
+                return;
             }
 
-            System.Diagnostics.Debug.WriteLine($"NotificationService(Android): firing id={notificationId}, nowUtc={nowUtc:O}");
+            System.Diagnostics.Debug.WriteLine($"NotificationService(Android): firing id={notificationId}, nowUtc={DateTimeOffset.UtcNow:O}");
             PostAndroidNotification(context, title, message, playSound, notificationId);
         }
     }

--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -9,6 +9,7 @@ using Android.Provider;
 using AndroidX.Core.App;
 using AndroidX.Core.Content;
 using Microsoft.Maui.ApplicationModel;
+using ShuffleTask.Presentation.Utilities;
 
 namespace ShuffleTask.Presentation.Services;
 
@@ -156,6 +157,8 @@ public partial class NotificationService
         if (context.GetSystemService(Context.AlarmService) is AlarmManager)
         {
             long triggerAt = SystemClock.ElapsedRealtime() + delayMs;
+            DateTimeOffset scheduledFireAtUtc = DateTimeOffset.UtcNow.AddMilliseconds(delayMs);
+            System.Diagnostics.Debug.WriteLine($"NotificationService(Android): schedule id={notificationId}, delayMs={delayMs}, scheduledFireAtUtc={scheduledFireAtUtc:O}");
             ScheduleExactAlarm(context, AlarmType.ElapsedRealtimeWakeup, pendingIntent, triggerAt);
         }
         else
@@ -295,6 +298,22 @@ public partial class NotificationService
             bool playSound = intent.GetBooleanExtra(AndroidNotificationExtraSound, true);
             int notificationId = intent.GetIntExtra(AndroidNotificationExtraId, GetNextAndroidNotificationId());
 
+            if (PersistedTimerState.TryGetActiveTimer(
+                    out _,
+                    out TimeSpan remaining,
+                    out bool expired,
+                    out _,
+                    out DateTimeOffset expiresAt)
+                && !expired
+                && remaining > TimeSpan.Zero)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={expiresAt:O}; rescheduling.");
+                ScheduleAndroidNotification(context, title, message, remaining, playSound, notificationId);
+                return;
+            }
+
+            System.Diagnostics.Debug.WriteLine($"NotificationService(Android): firing id={notificationId}, nowUtc={DateTimeOffset.UtcNow:O}");
             PostAndroidNotification(context, title, message, playSound, notificationId);
         }
     }

--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -31,6 +31,7 @@ public partial class NotificationService
     private const string SilentChannelName = "ShuffleTask silent reminders";
     private const string ChannelDescription = "Task reminders and timer alerts.";
     private const int NotificationPermissionRequestCode = 0x42;
+    private const int TimerAlignmentToleranceSeconds = 5;
 
     private static int _nextAndroidNotificationId = 2000;
     private static readonly ConcurrentDictionary<int, byte> ScheduledNotificationIds = new();
@@ -358,7 +359,9 @@ public partial class NotificationService
                 && !expired
                 && remaining > TimeSpan.Zero
                 && string.Equals(activeTaskId, alignedTimerTaskId, StringComparison.Ordinal)
-                && activeExpiresAt.Equals(alignedTimerExpiresAt))
+                // Persisted expiry can drift by a few seconds as the UI updates timer state once per tick.
+                // Keep early-fire protection active when both expirations are still effectively the same timer.
+                && Math.Abs((activeExpiresAt - alignedTimerExpiresAt).TotalSeconds) <= TimerAlignmentToleranceSeconds)
             {
                 System.Diagnostics.Debug.WriteLine(
                     $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={activeExpiresAt:O}; rescheduling.");


### PR DESCRIPTION
### Motivation

- Prevent OS-level Android notifications from firing earlier than the in-app countdown by making Android scheduling respect the persisted timer expiry used by the app.
- Add lightweight debug traces to compare scheduled fire time and actual firing to aid drift troubleshooting.

### Description

- Import `PersistedTimerState` and write a debug line when scheduling an Android alarm that records the scheduled fire timestamp and delay.
- In `ReminderBroadcastReceiver.OnReceive`, check `PersistedTimerState.TryGetActiveTimer` and, if the persisted timer is still active and not expired, reschedule the Android notification for the remaining duration instead of firing immediately.
- Add debug logging for early-receive reschedules and for actual notification firing timestamps.

### Testing

- No automated tests were run for this change (per FAST PATCH MODE instructions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb355444648326ab29fd686666cc5a)