### PR TITLE
Android: align scheduled notifications with active timer and reschedule on receive

### DIFF
--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -9,6 +9,7 @@ using Android.Provider;
 using AndroidX.Core.App;
 using AndroidX.Core.Content;
 using Microsoft.Maui.ApplicationModel;
+using ShuffleTask.Presentation.Utilities;
 
 namespace ShuffleTask.Presentation.Services;
 
@@ -19,6 +20,7 @@ public partial class NotificationService
     private const string AndroidNotificationExtraMessage = "ShuffleTask.Notification.TimeUpMessage";
     private const string AndroidNotificationExtraSound = "ShuffleTask.Notification.Sound";
     private const string AndroidNotificationExtraId = "ShuffleTask.Notification.Id";
+    private const string AndroidNotificationExtraAlignWithActiveTimer = "ShuffleTask.Notification.AlignWithActiveTimer";
 
     private const string SoundChannelId = "shuffletask.reminders.sound";
     private const string SilentChannelId = "shuffletask.reminders.silent";
@@ -115,7 +117,7 @@ public partial class NotificationService
         NotificationManagerCompat.From(context).Notify(notificationId, builder.Build());
     }
 
-    private static void ScheduleAndroidNotification(Context context, string title, string message, TimeSpan delay, bool playSound, int notificationId)
+    private static void ScheduleAndroidNotification(Context context, string title, string message, TimeSpan delay, bool playSound, int notificationId, bool alignWithActiveTimer)
     {
         EnsureChannels(context);
 
@@ -131,7 +133,8 @@ public partial class NotificationService
             .PutExtra(AndroidNotificationExtraTitle, title)
             .PutExtra(AndroidNotificationExtraMessage, message)
             .PutExtra(AndroidNotificationExtraSound, playSound)
-            .PutExtra(AndroidNotificationExtraId, notificationId);
+            .PutExtra(AndroidNotificationExtraId, notificationId)
+            .PutExtra(AndroidNotificationExtraAlignWithActiveTimer, alignWithActiveTimer);
 
         var flags = PendingIntentFlags.UpdateCurrent;
         if (OperatingSystem.IsAndroidVersionAtLeast(23))
@@ -156,6 +159,8 @@ public partial class NotificationService
         if (context.GetSystemService(Context.AlarmService) is AlarmManager)
         {
             long triggerAt = SystemClock.ElapsedRealtime() + delayMs;
+            DateTimeOffset scheduledFireAtUtc = DateTimeOffset.UtcNow.AddMilliseconds(delayMs);
+            System.Diagnostics.Debug.WriteLine($"NotificationService(Android): schedule id={notificationId}, delayMs={delayMs}, scheduledFireAtUtc={scheduledFireAtUtc:O}");
             ScheduleExactAlarm(context, AlarmType.ElapsedRealtimeWakeup, pendingIntent, triggerAt);
         }
         else
@@ -253,6 +258,15 @@ public partial class NotificationService
             var context = Android.App.Application.Context;
             int notificationId = GetNextAndroidNotificationId();
             ScheduledNotificationIds[notificationId] = 0;
+            bool alignWithActiveTimer = false;
+
+            if (delay > TimeSpan.Zero
+                && PersistedTimerState.TryGetActiveTimer(out _, out TimeSpan remaining, out bool expired, out _, out _)
+                && !expired
+                && remaining > TimeSpan.Zero)
+            {
+                alignWithActiveTimer = Math.Abs((remaining - delay).TotalSeconds) <= 1;
+            }
 
             if (delay <= TimeSpan.Zero)
             {
@@ -260,7 +274,7 @@ public partial class NotificationService
             }
             else
             {
-                ScheduleAndroidNotification(context, title, message, delay, playSound, notificationId);
+                ScheduleAndroidNotification(context, title, message, delay, playSound, notificationId, alignWithActiveTimer);
             }
 
             return Task.CompletedTask;
@@ -294,7 +308,25 @@ public partial class NotificationService
             string message = intent.GetStringExtra(AndroidNotificationExtraMessage) ?? string.Empty;
             bool playSound = intent.GetBooleanExtra(AndroidNotificationExtraSound, true);
             int notificationId = intent.GetIntExtra(AndroidNotificationExtraId, GetNextAndroidNotificationId());
+            bool alignWithActiveTimer = intent.GetBooleanExtra(AndroidNotificationExtraAlignWithActiveTimer, false);
 
+            if (alignWithActiveTimer
+                && PersistedTimerState.TryGetActiveTimer(
+                    out _,
+                    out TimeSpan remaining,
+                    out bool expired,
+                    out _,
+                    out DateTimeOffset expiresAt)
+                && !expired
+                && remaining > TimeSpan.Zero)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={expiresAt:O}; rescheduling.");
+                ScheduleAndroidNotification(context, title, message, remaining, playSound, notificationId, alignWithActiveTimer: true);
+                return;
+            }
+
+            System.Diagnostics.Debug.WriteLine($"NotificationService(Android): firing id={notificationId}, nowUtc={DateTimeOffset.UtcNow:O}");
             PostAndroidNotification(context, title, message, playSound, notificationId);
         }
     }

--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Threading;
 using Android.App;
 using Android.Content;
@@ -21,6 +22,8 @@ public partial class NotificationService
     private const string AndroidNotificationExtraSound = "ShuffleTask.Notification.Sound";
     private const string AndroidNotificationExtraId = "ShuffleTask.Notification.Id";
     private const string AndroidNotificationExtraAlignWithActiveTimer = "ShuffleTask.Notification.AlignWithActiveTimer";
+    private const string AndroidNotificationExtraAlignedTimerTaskId = "ShuffleTask.Notification.AlignedTimerTaskId";
+    private const string AndroidNotificationExtraAlignedTimerExpiresAtUtc = "ShuffleTask.Notification.AlignedTimerExpiresAtUtc";
 
     private const string SoundChannelId = "shuffletask.reminders.sound";
     private const string SilentChannelId = "shuffletask.reminders.silent";
@@ -117,7 +120,16 @@ public partial class NotificationService
         NotificationManagerCompat.From(context).Notify(notificationId, builder.Build());
     }
 
-    private static void ScheduleAndroidNotification(Context context, string title, string message, TimeSpan delay, bool playSound, int notificationId, bool alignWithActiveTimer)
+    private static void ScheduleAndroidNotification(
+        Context context,
+        string title,
+        string message,
+        TimeSpan delay,
+        bool playSound,
+        int notificationId,
+        bool alignWithActiveTimer,
+        string alignedTimerTaskId,
+        string alignedTimerExpiresAtUtc)
     {
         EnsureChannels(context);
 
@@ -128,15 +140,15 @@ public partial class NotificationService
             return;
         }
 
-        DateTimeOffset scheduledFireAtUtc = DateTimeOffset.UtcNow.AddMilliseconds(delayMs);
-
         var intent = new Intent(context, typeof(ReminderBroadcastReceiver))
             .SetAction(AndroidNotificationAction)
             .PutExtra(AndroidNotificationExtraTitle, title)
             .PutExtra(AndroidNotificationExtraMessage, message)
             .PutExtra(AndroidNotificationExtraSound, playSound)
             .PutExtra(AndroidNotificationExtraId, notificationId)
-            .PutExtra(AndroidNotificationExtraAlignWithActiveTimer, alignWithActiveTimer);
+            .PutExtra(AndroidNotificationExtraAlignWithActiveTimer, alignWithActiveTimer)
+            .PutExtra(AndroidNotificationExtraAlignedTimerTaskId, alignedTimerTaskId)
+            .PutExtra(AndroidNotificationExtraAlignedTimerExpiresAtUtc, alignedTimerExpiresAtUtc);
 
         var flags = PendingIntentFlags.UpdateCurrent;
         if (OperatingSystem.IsAndroidVersionAtLeast(23))
@@ -261,13 +273,20 @@ public partial class NotificationService
             int notificationId = GetNextAndroidNotificationId();
             ScheduledNotificationIds[notificationId] = 0;
             bool alignWithActiveTimer = false;
+            string alignedTimerTaskId = string.Empty;
+            string alignedTimerExpiresAtUtc = string.Empty;
 
             if (delay > TimeSpan.Zero
-                && PersistedTimerState.TryGetActiveTimer(out _, out TimeSpan remaining, out bool expired, out _, out _)
+                && PersistedTimerState.TryGetActiveTimer(out string taskId, out TimeSpan remaining, out bool expired, out _, out DateTimeOffset expiresAt)
                 && !expired
                 && remaining > TimeSpan.Zero)
             {
                 alignWithActiveTimer = Math.Abs((remaining - delay).TotalSeconds) <= 1;
+                if (alignWithActiveTimer)
+                {
+                    alignedTimerTaskId = taskId;
+                    alignedTimerExpiresAtUtc = expiresAt.ToString("O", CultureInfo.InvariantCulture);
+                }
             }
 
             if (delay <= TimeSpan.Zero)
@@ -276,7 +295,16 @@ public partial class NotificationService
             }
             else
             {
-                ScheduleAndroidNotification(context, title, message, delay, playSound, notificationId, alignWithActiveTimer);
+                ScheduleAndroidNotification(
+                    context,
+                    title,
+                    message,
+                    delay,
+                    playSound,
+                    notificationId,
+                    alignWithActiveTimer,
+                    alignedTimerTaskId,
+                    alignedTimerExpiresAtUtc);
             }
 
             return Task.CompletedTask;
@@ -311,20 +339,39 @@ public partial class NotificationService
             bool playSound = intent.GetBooleanExtra(AndroidNotificationExtraSound, true);
             int notificationId = intent.GetIntExtra(AndroidNotificationExtraId, GetNextAndroidNotificationId());
             bool alignWithActiveTimer = intent.GetBooleanExtra(AndroidNotificationExtraAlignWithActiveTimer, false);
+            string alignedTimerTaskId = intent.GetStringExtra(AndroidNotificationExtraAlignedTimerTaskId) ?? string.Empty;
+            string alignedTimerExpiresAtUtc = intent.GetStringExtra(AndroidNotificationExtraAlignedTimerExpiresAtUtc) ?? string.Empty;
 
             if (alignWithActiveTimer
+                && !string.IsNullOrWhiteSpace(alignedTimerTaskId)
+                && DateTimeOffset.TryParse(
+                    alignedTimerExpiresAtUtc,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out DateTimeOffset alignedTimerExpiresAt)
                 && PersistedTimerState.TryGetActiveTimer(
-                    out _,
+                    out string activeTaskId,
                     out TimeSpan remaining,
                     out bool expired,
                     out _,
-                    out DateTimeOffset expiresAt)
+                    out DateTimeOffset activeExpiresAt)
                 && !expired
-                && remaining > TimeSpan.Zero)
+                && remaining > TimeSpan.Zero
+                && string.Equals(activeTaskId, alignedTimerTaskId, StringComparison.Ordinal)
+                && activeExpiresAt.Equals(alignedTimerExpiresAt))
             {
                 System.Diagnostics.Debug.WriteLine(
-                    $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={expiresAt:O}; rescheduling.");
-                ScheduleAndroidNotification(context, title, message, remaining, playSound, notificationId, alignWithActiveTimer: true);
+                    $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={activeExpiresAt:O}; rescheduling.");
+                ScheduleAndroidNotification(
+                    context,
+                    title,
+                    message,
+                    remaining,
+                    playSound,
+                    notificationId,
+                    alignWithActiveTimer: true,
+                    alignedTimerTaskId,
+                    alignedTimerExpiresAtUtc);
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Ensure scheduled Android notifications that were intended to match a running timer are aligned with the active timer end to avoid duplicate or out-of-sync alerts. 
- Add resilience so notifications scheduled to align with a timer are deferred if the timer is still running when the broadcast is received.

### Description
- Added `AndroidNotificationExtraAlignWithActiveTimer` intent extra and a corresponding `bool alignWithActiveTimer` parameter to `ScheduleAndroidNotification` to carry alignment intent through the alarm flow. 
- Compute `alignWithActiveTimer` in `NotifyAsync` by consulting `PersistedTimerState` and pass it when scheduling notifications. 
- On receipt in `ReminderBroadcastReceiver`, if `alignWithActiveTimer` is true and the timer is still active, reschedule the notification for the timer `remaining` duration instead of firing immediately. 
- Added debug logging for scheduled and firing notifications and imported `ShuffleTask.Presentation.Utilities` to access `PersistedTimerState`.

### Testing
- Ran existing automated unit/integration tests (`dotnet test`) against the solution and they completed successfully. 
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb355444648326ab29fd686666cc5a)