### PR TITLE
Fix Android notification firing before timer reaches zero

### DIFF
--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -31,6 +31,7 @@ public partial class NotificationService
     private const string SilentChannelName = "ShuffleTask silent reminders";
     private const string ChannelDescription = "Task reminders and timer alerts.";
     private const int NotificationPermissionRequestCode = 0x42;
+    private const int TimerAlignmentToleranceSeconds = 5;
 
     private static int _nextAndroidNotificationId = 2000;
     private static readonly ConcurrentDictionary<int, byte> ScheduledNotificationIds = new();
@@ -357,7 +358,10 @@ public partial class NotificationService
                     out DateTimeOffset activeExpiresAt)
                 && !expired
                 && remaining > TimeSpan.Zero
-                && string.Equals(activeTaskId, alignedTimerTaskId, StringComparison.Ordinal))
+                && string.Equals(activeTaskId, alignedTimerTaskId, StringComparison.Ordinal)
+                // Persisted expiry can drift by a few seconds as the UI updates timer state once per tick.
+                // Keep early-fire protection active when both expirations are still effectively the same timer.
+                && Math.Abs((activeExpiresAt - alignedTimerExpiresAt).TotalSeconds) <= TimerAlignmentToleranceSeconds)
             {
                 System.Diagnostics.Debug.WriteLine(
                     $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={activeExpiresAt:O}; rescheduling.");

--- a/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs
@@ -357,8 +357,7 @@ public partial class NotificationService
                     out DateTimeOffset activeExpiresAt)
                 && !expired
                 && remaining > TimeSpan.Zero
-                && string.Equals(activeTaskId, alignedTimerTaskId, StringComparison.Ordinal)
-                && activeExpiresAt.Equals(alignedTimerExpiresAt))
+                && string.Equals(activeTaskId, alignedTimerTaskId, StringComparison.Ordinal))
             {
                 System.Diagnostics.Debug.WriteLine(
                     $"NotificationService(Android): receive id={notificationId} before timer completion, remaining={remaining.TotalMilliseconds:F0}ms, expiresAtUtc={activeExpiresAt:O}; rescheduling.");


### PR DESCRIPTION
### Motivation
- Prevent Android alarm early-fires from posting the "time up" notification prematurely when persisted expiration timestamps drift, ensuring the receiver reschedules if the same active timer still has remaining time.

### Description
- Relaxed the receiver guard in `ShuffleTask.Presentation/Platforms/Android/Services/NotificationService.android.cs` by removing the strict `activeExpiresAt.Equals(alignedTimerExpiresAt)` comparison so the receiver will reschedule when the persisted active task ID matches and `remaining > TimeSpan.Zero`.

### Testing
- Attempted to run `dotnet test ShuffleTask.Presentation.Tests/ShuffleTask.Presentation.Tests.csproj`, but tests could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08b943d288326a8fd2904daf5d331)