### PR TITLE
Show migration result and surface failures for device→user task migration

### DIFF
--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -475,6 +475,18 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             Microsoft.Maui.Controls.Application.Current?.MainPage?.DisplayAlert(title, message, "Yes", "No") ?? Task.FromResult(false));
     }
 
+    private static Task ShowMigrationResultAsync(bool success)
+    {
+        string title = success ? "Tasks synced" : "Task sync failed";
+        string message = success
+            ? "Device tasks are now attached to your account."
+            : "Could not move device tasks to your account. Please try again.";
+
+        return MainThread.InvokeOnMainThreadAsync(() =>
+            Microsoft.Maui.Controls.Application.Current?.MainPage?.DisplayAlert(title, message, "OK")
+            ?? Task.CompletedTask);
+    }
+
     private async Task<string?> GetUsernameAsync(string? username)
     {
         string? candidate = username;
@@ -514,7 +526,24 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             bool migrate = await SettingsViewModel.PromptMigrateDeviceTasksAsync();
             if (migrate)
             {
-                await _storage.MigrateDeviceTasksToUserAsync(Settings.Network.DeviceId, Settings.Network.UserId);
+                try
+                {
+                    int migrated = await _storage.MigrateDeviceTasksToUserAsync(Settings.Network.DeviceId, Settings.Network.UserId);
+                    if (migrated <= 0)
+                    {
+                        _logger?.LogWarning("No device tasks migrated for device '{DeviceId}' and user '{UserId}'.", Settings.Network.DeviceId, Settings.Network.UserId);
+                        await ShowMigrationResultAsync(success: false);
+                    }
+                    else
+                    {
+                        await ShowMigrationResultAsync(success: true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError(ex, "Failed migrating device tasks for device '{DeviceId}' and user '{UserId}'.", Settings.Network.DeviceId, Settings.Network.UserId);
+                    await ShowMigrationResultAsync(success: false);
+                }
             }
         }
 

--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -528,10 +528,13 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             {
                 try
                 {
-                    int migrated = await _storage.MigrateDeviceTasksToUserAsync(Settings.Network.DeviceId, Settings.Network.UserId);
+                    string deviceId = string.IsNullOrWhiteSpace(Settings.Network.DeviceId)
+                        ? _networkSync.DeviceId
+                        : Settings.Network.DeviceId;
+                    int migrated = await _storage.MigrateDeviceTasksToUserAsync(deviceId, Settings.Network.UserId);
                     if (migrated <= 0)
                     {
-                        _logger?.LogWarning("No device tasks migrated for device '{DeviceId}' and user '{UserId}'.", Settings.Network.DeviceId, Settings.Network.UserId);
+                        _logger?.LogWarning("No device tasks migrated for device '{DeviceId}' and user '{UserId}'.", deviceId, Settings.Network.UserId);
                         await ShowMigrationResultAsync(success: false);
                     }
                     else


### PR DESCRIPTION
### Motivation
- Fix a bug where confirming the device→user migration prompt did not reliably migrate tasks and produced no user-visible feedback or logs.

### Description
- Add `ShowMigrationResultAsync` and wrap the `MigrateDeviceTasksToUserAsync` call with a try/catch and a migrated-row check to log warnings/errors and show a success/failure alert to the user.

### Testing
- No automated tests were executed for this fast-patch; change is limited to `ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs` and preserves the existing refresh flow after migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f99c79ba348326a61eeac0ca34f1e7)