### PR TITLE
Clamp MaxDailyShuffles to MinGapMinutes-based upper bound and update UI max

### DIFF
--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -771,7 +771,8 @@ public class StorageService : IStorageService
         settings.MinGapMinutes = Math.Clamp(settings.MinGapMinutes, 1, 24 * 60);
         settings.MaxGapMinutes = Math.Max(settings.MinGapMinutes, settings.MaxGapMinutes);
         settings.ReminderMinutes = Math.Clamp(settings.ReminderMinutes, 1, 6 * 60);
-        settings.MaxDailyShuffles = Math.Clamp(settings.MaxDailyShuffles, 1, 24);
+        int maxDailyShufflesUpperBound = (24 * 60) / settings.MinGapMinutes;
+        settings.MaxDailyShuffles = Math.Clamp(settings.MaxDailyShuffles, 0, maxDailyShufflesUpperBound);
         settings.FocusMinutes = Math.Clamp(settings.FocusMinutes, 5, 120);
         settings.BreakMinutes = Math.Clamp(settings.BreakMinutes, 1, 60);
         settings.PomodoroCycles = Math.Clamp(settings.PomodoroCycles, 1, 8);

--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -169,7 +169,7 @@
                     <controls:NumericStepper Grid.Row="2"
                                              Grid.Column="1"
                                              Minimum="0"
-                                             Maximum="24"
+                                             Maximum="288"
                                              Increment="1"
                                              Value="{Binding Settings.MaxDailyShuffles}"
                                              HorizontalOptions="Start" />


### PR DESCRIPTION
### Motivation

- Ensure `MaxDailyShuffles` is consistent with `MinGapMinutes` so the configured daily shuffles are physically possible given the minimum gap constraint.

### Description

- Change `NormalizeSettings` in `StorageService` to compute an upper bound `maxDailyShufflesUpperBound = (24 * 60) / settings.MinGapMinutes` and clamp `MaxDailyShuffles` to the range `0..maxDailyShufflesUpperBound` instead of the fixed `1..24` range. 
- Allow `0` as a valid `MaxDailyShuffles` value to represent "unlimited" scheduling. 
- Increase the `NumericStepper` `Maximum` in `SettingsPage.xaml` from `24` to `288` to match the maximum possible when the minimum gap is `5` minutes (`24*60/5 = 288`).

### Testing

- Ran unit tests for the project, and they completed successfully. 
- Built the presentation project (`SettingsPage.xaml`) and UI compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c8c7f1e8832690db841e1e1477e7)