### PR TITLE
Prevent duplicate launches from notification taps on Windows and Android

### DIFF
--- a/ShuffleTask.Presentation/Platforms/Android/MainActivity.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/MainActivity.cs
@@ -1,17 +1,32 @@
 ﻿using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.OS;
 using Microsoft.Extensions.DependencyInjection;
 using ShuffleTask.Presentation.Services;
+using System.Diagnostics;
 
 namespace ShuffleTask.Presentation;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        LogActivationIntent("OnCreate", Intent);
+    }
+
+    protected override void OnNewIntent(Intent? intent)
+    {
+        base.OnNewIntent(intent);
+        LogActivationIntent("OnNewIntent", intent);
+    }
+
     protected override void OnResume()
     {
         base.OnResume();
+        LogActivationIntent("OnResume", Intent);
 
         var coordinator = MauiProgram.TryGetServiceProvider()?.GetService<ShuffleCoordinatorService>();
         if (coordinator != null)
@@ -24,4 +39,9 @@ public class MainActivity : MauiAppCompatActivity
     // The ShuffleCoordinatorService schedules notifications via AlarmManager,
     // which delivers notifications even when the app is backgrounded.
     // This ensures auto-shuffle notifications fire reliably in the background.
+
+    private static void LogActivationIntent(string source, Intent? intent)
+    {
+        Debug.WriteLine($"MainActivity(Android): {source}, action={intent?.Action}, flags={intent?.Flags}");
+    }
 }

--- a/ShuffleTask.Presentation/Platforms/Windows/App.xaml.cs
+++ b/ShuffleTask.Presentation/Platforms/Windows/App.xaml.cs
@@ -1,7 +1,11 @@
 using ShuffleTask.Presentation;
 using ShuffleTask.Presentation.Services;
+using System.Diagnostics;
+using System.Linq;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.AppLifecycle;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -13,12 +17,27 @@ namespace ShuffleTask.WinUI;
 /// </summary>
 public partial class App : MauiWinUIApplication
 {
+    private const string MainInstanceKey = "main";
+
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
     public App()
     {
+        var currentInstance = AppInstance.GetCurrent();
+        var mainInstance = AppInstance.FindOrRegisterForKey(MainInstanceKey);
+
+        if (!mainInstance.IsCurrent)
+        {
+            Debug.WriteLine("App(Windows): redirecting activation to existing instance.");
+            _ = mainInstance.RedirectActivationToAsync(currentInstance.GetActivatedEventArgs());
+            Environment.Exit(0);
+            return;
+        }
+
+        mainInstance.Activated += OnAppInstanceActivated;
+
         InitializeComponent();
         CoreApplication.Suspending += OnSuspendingAsync;
         CoreApplication.Resuming += OnResumingAsync;
@@ -38,5 +57,23 @@ public partial class App : MauiWinUIApplication
     private static void OnSuspendingAsync(object? sender, SuspendingEventArgs e)
     {
         e.SuspendingOperation.GetDeferral().Complete();
+    }
+
+    private static void OnAppInstanceActivated(object? sender, AppActivationArguments args)
+    {
+        Debug.WriteLine($"App(Windows): activated via {args.Kind}.");
+        (Microsoft.UI.Xaml.Application.Current as Application)?.DispatcherQueue.TryEnqueue(() =>
+        {
+            if (Microsoft.Maui.Controls.Application.Current?.Windows.FirstOrDefault()?.Handler?.PlatformView is Window window)
+            {
+                if (window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+                {
+                    presenter.Restore();
+                }
+
+                window.Activate();
+                Debug.WriteLine("App(Windows): existing window activated.");
+            }
+        });
     }
 }


### PR DESCRIPTION
### Motivation
- Tapping notifications was launching duplicate app instances on Windows and sometimes Android instead of focusing the running instance.  
- Ensure notification taps redirect to the existing instance and bring its window/activity to the foreground without changing notification payload routing or domain logic.

### Description
- On Windows, register a primary `AppInstance` key `"main"`, redirect secondary instances via `RedirectActivationToAsync`, and exit duplicate processes.  
- Added an `Activated` handler to restore and activate the existing window on redirected activations via the application's `DispatcherQueue`.  
- On Android, changed `MainActivity` launch mode from `SingleTop` to `SingleTask` and added `OnCreate`, `OnNewIntent`, and `OnResume` logging to observe activation intents.  
- All changes are presentation/platform-only and do not modify domain, persistence, or notification payload routing logic.

### Testing
- No automated tests were executed as part of this fast patch; the changes are limited to platform activation behavior.  
- Please run the repository test suite with `dotnet test` and perform manual verification of notification tap behavior on Windows and Android devices/emulators to confirm the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ec2ac4d88326b8d683c4162d9e76)