### PR TITLE
Support single-instance activation on Windows and add Android intent logging

### DIFF
--- a/ShuffleTask.Presentation/Platforms/Android/MainActivity.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/MainActivity.cs
@@ -1,17 +1,32 @@
 ﻿using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.OS;
 using Microsoft.Extensions.DependencyInjection;
 using ShuffleTask.Presentation.Services;
+using System.Diagnostics;
 
 namespace ShuffleTask.Presentation;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        LogActivationIntent("OnCreate", Intent);
+    }
+
+    protected override void OnNewIntent(Intent? intent)
+    {
+        base.OnNewIntent(intent);
+        LogActivationIntent("OnNewIntent", intent);
+    }
+
     protected override void OnResume()
     {
         base.OnResume();
+        LogActivationIntent("OnResume", Intent);
 
         var coordinator = MauiProgram.TryGetServiceProvider()?.GetService<ShuffleCoordinatorService>();
         if (coordinator != null)
@@ -24,4 +39,9 @@ public class MainActivity : MauiAppCompatActivity
     // The ShuffleCoordinatorService schedules notifications via AlarmManager,
     // which delivers notifications even when the app is backgrounded.
     // This ensures auto-shuffle notifications fire reliably in the background.
+
+    private static void LogActivationIntent(string source, Intent? intent)
+    {
+        Debug.WriteLine($"MainActivity(Android): {source}, action={intent?.Action}, flags={intent?.Flags}");
+    }
 }

--- a/ShuffleTask.Presentation/Platforms/Windows/App.xaml.cs
+++ b/ShuffleTask.Presentation/Platforms/Windows/App.xaml.cs
@@ -1,7 +1,11 @@
 using ShuffleTask.Presentation;
 using ShuffleTask.Presentation.Services;
+using System.Diagnostics;
+using System.Linq;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.AppLifecycle;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -13,12 +17,27 @@ namespace ShuffleTask.WinUI;
 /// </summary>
 public partial class App : MauiWinUIApplication
 {
+    private const string MainInstanceKey = "main";
+
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
     public App()
     {
+        var currentInstance = AppInstance.GetCurrent();
+        var mainInstance = AppInstance.FindOrRegisterForKey(MainInstanceKey);
+
+        if (!mainInstance.IsCurrent)
+        {
+            Debug.WriteLine("App(Windows): redirecting activation to existing instance.");
+            _ = mainInstance.RedirectActivationToAsync(currentInstance.GetActivatedEventArgs());
+            Environment.Exit(0);
+            return;
+        }
+
+        mainInstance.Activated += OnAppInstanceActivated;
+
         InitializeComponent();
         CoreApplication.Suspending += OnSuspendingAsync;
         CoreApplication.Resuming += OnResumingAsync;
@@ -38,5 +57,23 @@ public partial class App : MauiWinUIApplication
     private static void OnSuspendingAsync(object? sender, SuspendingEventArgs e)
     {
         e.SuspendingOperation.GetDeferral().Complete();
+    }
+
+    private static void OnAppInstanceActivated(object? sender, AppActivationArguments args)
+    {
+        Debug.WriteLine($"App(Windows): activated via {args.Kind}.");
+        (Microsoft.UI.Xaml.Application.Current as Microsoft.UI.Xaml.Application)?.DispatcherQueue.TryEnqueue(() =>
+        {
+            if (Microsoft.Maui.Controls.Application.Current?.Windows.FirstOrDefault()?.Handler?.PlatformView is Window window)
+            {
+                if (window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+                {
+                    presenter.Restore();
+                }
+
+                window.Activate();
+                Debug.WriteLine("App(Windows): existing window activated.");
+            }
+        });
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure the Windows app runs as a single main instance and redirects additional activations to the main instance to avoid multiple app windows and to properly surface activations. 
- Restore and activate the existing WinUI window when the app receives a new activation so the user is returned to the running UI. 
- Improve handling of Android re-activation by switching the activity launch mode to `SingleTask` and logging incoming intents for easier diagnosis. 
- Keep the `ShuffleCoordinatorService` active/resumed when the app regains focus so scheduled notifications and auto-shuffle behavior remain reliable.

### Description

- Implement single-instance behavior on Windows using `AppInstance.FindOrRegisterForKey("main")`, redirecting activation to the main instance and exiting non-main instances. 
- Add `OnAppInstanceActivated` which restores an `OverlappedPresenter` if present, activates the existing `Window`, and logs activation events. 
- Change Android `MainActivity` `LaunchMode` from `SingleTop` to `SingleTask`, and add overrides for `OnCreate`, `OnNewIntent`, and `OnResume` to log incoming intents via `LogActivationIntent`. 
- Add `Debug.WriteLine` logging on both platforms to help trace activation source and intent metadata, and ensure `ShuffleCoordinatorService.ResumeAsync()` is invoked on resume.

### Testing

- Ran `dotnet build` for the solution and the build completed successfully. 
- Ran `dotnet test` for the solution test projects and all automated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ec2ac4d88326b8d683c4162d9e76)