### PR TITLE
Handle single-instance activation on Windows and Android intent handling with lifecycle logging

### DIFF
--- a/ShuffleTask.Presentation/Platforms/Android/MainActivity.cs
+++ b/ShuffleTask.Presentation/Platforms/Android/MainActivity.cs
@@ -1,17 +1,32 @@
 ﻿using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.OS;
 using Microsoft.Extensions.DependencyInjection;
 using ShuffleTask.Presentation.Services;
+using System.Diagnostics;
 
 namespace ShuffleTask.Presentation;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        LogActivationIntent("OnCreate", Intent);
+    }
+
+    protected override void OnNewIntent(Intent? intent)
+    {
+        base.OnNewIntent(intent);
+        LogActivationIntent("OnNewIntent", intent);
+    }
+
     protected override void OnResume()
     {
         base.OnResume();
+        LogActivationIntent("OnResume", Intent);
 
         var coordinator = MauiProgram.TryGetServiceProvider()?.GetService<ShuffleCoordinatorService>();
         if (coordinator != null)
@@ -24,4 +39,9 @@ public class MainActivity : MauiAppCompatActivity
     // The ShuffleCoordinatorService schedules notifications via AlarmManager,
     // which delivers notifications even when the app is backgrounded.
     // This ensures auto-shuffle notifications fire reliably in the background.
+
+    private static void LogActivationIntent(string source, Intent? intent)
+    {
+        Debug.WriteLine($"MainActivity(Android): {source}, action={intent?.Action}, flags={intent?.Flags}");
+    }
 }

--- a/ShuffleTask.Presentation/Platforms/Windows/App.xaml.cs
+++ b/ShuffleTask.Presentation/Platforms/Windows/App.xaml.cs
@@ -1,7 +1,11 @@
 using ShuffleTask.Presentation;
 using ShuffleTask.Presentation.Services;
+using System.Diagnostics;
+using System.Linq;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.AppLifecycle;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -13,12 +17,27 @@ namespace ShuffleTask.WinUI;
 /// </summary>
 public partial class App : MauiWinUIApplication
 {
+    private const string MainInstanceKey = "main";
+
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
     public App()
     {
+        var currentInstance = AppInstance.GetCurrent();
+        var mainInstance = AppInstance.FindOrRegisterForKey(MainInstanceKey);
+
+        if (!mainInstance.IsCurrent)
+        {
+            Debug.WriteLine("App(Windows): redirecting activation to existing instance.");
+            _ = mainInstance.RedirectActivationToAsync(currentInstance.GetActivatedEventArgs());
+            Environment.Exit(0);
+            return;
+        }
+
+        mainInstance.Activated += OnAppInstanceActivated;
+
         InitializeComponent();
         CoreApplication.Suspending += OnSuspendingAsync;
         CoreApplication.Resuming += OnResumingAsync;
@@ -38,5 +57,23 @@ public partial class App : MauiWinUIApplication
     private static void OnSuspendingAsync(object? sender, SuspendingEventArgs e)
     {
         e.SuspendingOperation.GetDeferral().Complete();
+    }
+
+    private static void OnAppInstanceActivated(object? sender, AppActivationArguments args)
+    {
+        Debug.WriteLine($"App(Windows): activated via {args.Kind}.");
+        Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
+        {
+            if (Microsoft.Maui.Controls.Application.Current?.Windows.FirstOrDefault()?.Handler?.PlatformView is Window window)
+            {
+                if (window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+                {
+                    presenter.Restore();
+                }
+
+                window.Activate();
+                Debug.WriteLine("App(Windows): existing window activated.");
+            }
+        });
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure the app behaves as a single instance on Windows so subsequent activations are redirected to the primary window instead of launching a new instance.
- Make the Android activity handle and log activation intents reliably (including new intents) and resume the shuffle coordinator when the activity becomes foregrounded.
- Keep background auto-shuffle notifications reliable by not pausing the coordinator on activity pause and by using lifecycle hooks to resume it.

### Description

- Changed Android `MainActivity` `LaunchMode` from `SingleTop` to `SingleTask` and added `OnCreate`, `OnNewIntent`, and `OnResume` overrides to log activation intents and call `ShuffleCoordinatorService.ResumeAsync` when resuming.
- Added a private `LogActivationIntent` helper in `MainActivity` and included required `using` directives for `Android.Content` and `System.Diagnostics`.
- Implemented single-instance activation for Windows by registering/finding an `AppInstance` key (`main`), redirecting activation to the existing instance when appropriate, and exiting the secondary instance immediately.
- Added an `Activated` handler (`OnAppInstanceActivated`) on the main `AppInstance` that restores and activates the existing WinUI window on new activations, and added debug logging and necessary `using` directives for `Microsoft.Windows.AppLifecycle` and dispatcher APIs.

### Testing

- Built the solution with `dotnet build` and the build completed successfully.
- Ran the automated test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ec2ac4d88326b8d683c4162d9e76)