### PR TITLE
Harden local settings persistence with schema envelope, migration, and recovery

### DIFF
--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
 using Newtonsoft.Json;
 using SQLite;
 using ShuffleTask.Application.Abstractions;
@@ -10,6 +13,7 @@ namespace ShuffleTask.Persistence;
 public class StorageService : IStorageService
 {
     private const string SettingsKey = "app_settings";
+    private const int CurrentSettingsSchemaVersion = 2;
     private const string IntegerSqlType = "INTEGER";
     private readonly record struct SchemaColumn(string Name, string SqlType, string DefaultSql);
 
@@ -17,6 +21,7 @@ public class StorageService : IStorageService
     private readonly string _dbPath;
     private readonly IShuffleLogger? _logger;
     private SQLiteAsyncConnection? _db;
+    private readonly SemaphoreSlim _settingsLock = new(1, 1);
 
     public StorageService(TimeProvider clock, string databasePath, IShuffleLogger? logger = null)
     {
@@ -711,27 +716,63 @@ public class StorageService : IStorageService
     // Settings
     public async Task<AppSettings> GetSettingsAsync()
     {
-        KeyValueEntity kv = await Db.FindAsync<KeyValueEntity>(SettingsKey);
-        if (kv == null || string.IsNullOrWhiteSpace(kv.Value))
-        {
-            var defaults = new AppSettings();
-            await SetSettingsAsync(defaults); // persist defaults once
-            return defaults;
-        }
+        await _settingsLock.WaitAsync().ConfigureAwait(false);
+        var stopwatch = Stopwatch.StartNew();
+        _logger?.LogSyncEvent("PersistenceLoadStarted", "Loading settings state");
 
         try
         {
-            AppSettings? settings = JsonConvert.DeserializeObject<AppSettings>(kv.Value!);
-            return NormalizeSettings(settings ?? new AppSettings());
+            KeyValueEntity kv = await Db.FindAsync<KeyValueEntity>(SettingsKey).ConfigureAwait(false);
+            if (kv == null || string.IsNullOrWhiteSpace(kv.Value))
+            {
+                var defaults = new AppSettings();
+                await SetSettingsInternalAsync(defaults).ConfigureAwait(false);
+                _logger?.LogSyncEvent("PersistenceRecovery", "Settings missing. Persisted defaults.");
+                return defaults;
+            }
+
+            try
+            {
+                var payload = DeserializeSettingsPayload(kv.Value!);
+                var migrated = MigrateSettingsPayload(payload);
+                var normalized = NormalizeSettings(migrated.Data ?? new AppSettings());
+
+                _logger?.LogSyncEvent("PersistenceLoadCompleted", $"schema={migrated.SchemaVersion}; durationMs={stopwatch.ElapsedMilliseconds}");
+                return normalized;
+            }
+            catch (Exception ex)
+            {
+                await QuarantineSettingsValueAsync(kv.Value!, ex.Message).ConfigureAwait(false);
+                var defaults = new AppSettings();
+                await SetSettingsInternalAsync(defaults).ConfigureAwait(false);
+                _logger?.LogSyncEvent("PersistenceRecovery", $"Corrupted settings recovered with defaults; durationMs={stopwatch.ElapsedMilliseconds}");
+                return defaults;
+            }
         }
-        catch
+        finally
         {
-            // If parsing fails, return defaults
-            return new AppSettings();
+            _settingsLock.Release();
         }
     }
 
     public async Task SetSettingsAsync(AppSettings settings)
+    {
+        await _settingsLock.WaitAsync().ConfigureAwait(false);
+        _logger?.LogSyncEvent("PersistenceSaveStarted", "Saving settings state");
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await SetSettingsInternalAsync(settings).ConfigureAwait(false);
+            _logger?.LogSyncEvent("PersistenceSaveCompleted", $"durationMs={stopwatch.ElapsedMilliseconds}");
+        }
+        finally
+        {
+            _settingsLock.Release();
+        }
+    }
+
+    private async Task SetSettingsInternalAsync(AppSettings settings)
     {
         settings = NormalizeSettings(settings);
         var existingSettings = await GetExistingSettingsAsync().ConfigureAwait(false);
@@ -743,23 +784,78 @@ public class StorageService : IStorageService
 
         settings.EventVersion = NormalizeVersion(settings.EventVersion, existingSettings?.EventVersion);
         settings.UpdatedAt = NormalizeUpdatedAt(settings.UpdatedAt, existingSettings?.UpdatedAt);
-        string json = JsonConvert.SerializeObject(settings);
-        // Upsert
-        KeyValueEntity existing = await Db.FindAsync<KeyValueEntity>(SettingsKey);
+
+        var payload = new SettingsPayload
+        {
+            SchemaVersion = CurrentSettingsSchemaVersion,
+            AppVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown",
+            LastSuccessfulSaveUtc = _clock.GetUtcNow().UtcDateTime,
+            Data = settings
+        };
+
+        string json = JsonConvert.SerializeObject(payload);
+        KeyValueEntity existing = await Db.FindAsync<KeyValueEntity>(SettingsKey).ConfigureAwait(false);
         if (existing == null)
         {
-            var kv = new KeyValueEntity
-            {
-                Key = SettingsKey,
-                Value = json
-            };
-            await Db.InsertAsync(kv);
+            await Db.InsertAsync(new KeyValueEntity { Key = SettingsKey, Value = json }).ConfigureAwait(false);
+            return;
         }
-        else
+
+        existing.Value = json;
+        await Db.UpdateAsync(existing).ConfigureAwait(false);
+    }
+
+
+    private SettingsPayload DeserializeSettingsPayload(string json)
+    {
+        var envelope = JsonConvert.DeserializeObject<SettingsPayload>(json);
+        if (envelope?.Data != null)
         {
-            existing.Value = json;
-            await Db.UpdateAsync(existing);
+            return envelope;
         }
+
+        var legacy = JsonConvert.DeserializeObject<AppSettings>(json);
+        if (legacy == null)
+        {
+            throw new InvalidOperationException("Settings payload is invalid.");
+        }
+
+        return new SettingsPayload
+        {
+            SchemaVersion = 1,
+            AppVersion = "legacy",
+            LastSuccessfulSaveUtc = _clock.GetUtcNow().UtcDateTime,
+            Data = legacy
+        };
+    }
+
+    private SettingsPayload MigrateSettingsPayload(SettingsPayload payload)
+    {
+        if (payload.SchemaVersion > CurrentSettingsSchemaVersion)
+        {
+            throw new InvalidOperationException($"Unsupported future settings schema version: {payload.SchemaVersion}");
+        }
+
+        if (payload.SchemaVersion <= 0)
+        {
+            payload.SchemaVersion = 1;
+        }
+
+        if (payload.SchemaVersion < CurrentSettingsSchemaVersion)
+        {
+            _logger?.LogSyncEvent("PersistenceMigration", $"Migrated settings schema {payload.SchemaVersion} -> {CurrentSettingsSchemaVersion}");
+            payload.SchemaVersion = CurrentSettingsSchemaVersion;
+        }
+
+        return payload;
+    }
+
+    private async Task QuarantineSettingsValueAsync(string value, string reason)
+    {
+        string suffix = _clock.GetUtcNow().UtcDateTime.ToString("yyyyMMddHHmmss");
+        string key = $"{SettingsKey}_quarantine_{suffix}";
+        await Db.InsertOrReplaceAsync(new KeyValueEntity { Key = key, Value = value }).ConfigureAwait(false);
+        _logger?.LogSyncEvent("PersistenceQuarantine", $"Stored corrupt settings as {key}; reason={reason}");
     }
 
     private static AppSettings NormalizeSettings(AppSettings settings)
@@ -794,8 +890,9 @@ public class StorageService : IStorageService
                 return null;
             }
 
-            AppSettings? parsed = JsonConvert.DeserializeObject<AppSettings>(kv.Value);
-            return parsed is null ? null : NormalizeSettings(parsed);
+            var payload = DeserializeSettingsPayload(kv.Value);
+            var migrated = MigrateSettingsPayload(payload);
+            return migrated.Data is null ? null : NormalizeSettings(migrated.Data);
         }
         catch
         {
@@ -846,6 +943,17 @@ public class StorageService : IStorageService
         }
 
         return DateTime.UtcNow;
+    }
+
+    private sealed class SettingsPayload
+    {
+        public int SchemaVersion { get; set; }
+
+        public string AppVersion { get; set; } = string.Empty;
+
+        public DateTime LastSuccessfulSaveUtc { get; set; }
+
+        public AppSettings? Data { get; set; }
     }
 
     private sealed class KeyValueEntity

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -740,6 +740,11 @@ public class StorageService : IStorageService
                 _logger?.LogSyncEvent("PersistenceLoadCompleted", $"schema={migrated.SchemaVersion}; durationMs={stopwatch.ElapsedMilliseconds}");
                 return normalized;
             }
+            catch (UnsupportedSettingsSchemaException ex)
+            {
+                _logger?.LogSyncEvent("PersistenceLoadUnsupportedSchema", $"schemaVersion={ex.SchemaVersion}; returning defaults read-only; durationMs={stopwatch.ElapsedMilliseconds}");
+                return new AppSettings();
+            }
             catch (Exception ex)
             {
                 await QuarantineSettingsValueAsync(kv.Value!, ex.Message).ConfigureAwait(false);
@@ -833,7 +838,7 @@ public class StorageService : IStorageService
     {
         if (payload.SchemaVersion > CurrentSettingsSchemaVersion)
         {
-            throw new InvalidOperationException($"Unsupported future settings schema version: {payload.SchemaVersion}");
+            throw new UnsupportedSettingsSchemaException(payload.SchemaVersion);
         }
 
         if (payload.SchemaVersion <= 0)
@@ -954,6 +959,17 @@ public class StorageService : IStorageService
         public DateTime LastSuccessfulSaveUtc { get; set; }
 
         public AppSettings? Data { get; set; }
+    }
+
+    private sealed class UnsupportedSettingsSchemaException : InvalidOperationException
+    {
+        public UnsupportedSettingsSchemaException(int schemaVersion)
+            : base($"Unsupported future settings schema version: {schemaVersion}")
+        {
+            SchemaVersion = schemaVersion;
+        }
+
+        public int SchemaVersion { get; }
     }
 
     private sealed class KeyValueEntity

--- a/ShuffleTask.Tests/ShuffleTask.Tests.csproj
+++ b/ShuffleTask.Tests/ShuffleTask.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ShuffleTask.Application\ShuffleTask.Application.csproj" />
     <ProjectReference Include="..\ShuffleTask.Domain\ShuffleTask.Domain.csproj" />
+    <ProjectReference Include="..\ShuffleTask.Persistence\ShuffleTask.Persistence.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ShuffleTask.Tests/StorageServicePersistenceTests.cs
+++ b/ShuffleTask.Tests/StorageServicePersistenceTests.cs
@@ -1,0 +1,100 @@
+using System.Reflection;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Persistence;
+
+namespace ShuffleTask.Tests;
+
+[TestFixture]
+public class StorageServicePersistenceTests
+{
+    private static string CreateDbPath() => Path.Combine(Path.GetTempPath(), $"shuffletask-test-{Guid.NewGuid():N}.db3");
+
+    [Test]
+    public async Task Settings_SaveAndReload_PersistsEnvelopeAndData()
+    {
+        var dbPath = CreateDbPath();
+        try
+        {
+            var storage = new StorageService(TimeProvider.System, dbPath);
+            await storage.InitializeAsync();
+
+            await storage.SetSettingsAsync(new AppSettings
+            {
+                FocusMinutes = 42,
+                BreakMinutes = 7,
+                PomodoroCycles = 5,
+                ImportanceWeight = 33
+            });
+
+            var reloaded = new StorageService(TimeProvider.System, dbPath);
+            await reloaded.InitializeAsync();
+
+            var loaded = await reloaded.GetSettingsAsync();
+            Assert.That(loaded.FocusMinutes, Is.EqualTo(42));
+            Assert.That(loaded.BreakMinutes, Is.EqualTo(7));
+            Assert.That(loaded.PomodoroCycles, Is.EqualTo(5));
+            Assert.That(loaded.ImportanceWeight, Is.EqualTo(33));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Test]
+    public async Task Settings_LoadsLegacyPayload_AndMigrates()
+    {
+        var dbPath = CreateDbPath();
+        try
+        {
+            var storage = new StorageService(TimeProvider.System, dbPath);
+            await storage.InitializeAsync();
+            await WriteRawSettingsValueAsync(storage, JsonConvert.SerializeObject(new AppSettings { FocusMinutes = 55 }));
+
+            var loaded = await storage.GetSettingsAsync();
+            Assert.That(loaded.FocusMinutes, Is.EqualTo(55));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Test]
+    public async Task Settings_Corruption_RecoversToDefaults_AndQuarantines()
+    {
+        var dbPath = CreateDbPath();
+        try
+        {
+            var storage = new StorageService(TimeProvider.System, dbPath);
+            await storage.InitializeAsync();
+            await WriteRawSettingsValueAsync(storage, "{bad json");
+
+            var loaded = await storage.GetSettingsAsync();
+            Assert.That(loaded.FocusMinutes, Is.EqualTo(new AppSettings().FocusMinutes));
+
+            var hasQuarantine = await HasQuarantineAsync(storage);
+            Assert.That(hasQuarantine, Is.True);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    private static async Task WriteRawSettingsValueAsync(StorageService storage, string json)
+    {
+        dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
+        string escaped = json.Replace("'", "''");
+        await db.ExecuteAsync($"INSERT OR REPLACE INTO KeyValueEntity(Key, Value) VALUES ('app_settings', '{escaped}')");
+    }
+
+    private static async Task<bool> HasQuarantineAsync(StorageService storage)
+    {
+        dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
+        var rows = await db.QueryAsync<dynamic>("SELECT Key FROM KeyValueEntity WHERE Key LIKE 'app_settings_quarantine_%'");
+        return rows.Count > 0;
+    }
+}

--- a/ShuffleTask.Tests/StorageServicePersistenceTests.cs
+++ b/ShuffleTask.Tests/StorageServicePersistenceTests.cs
@@ -84,6 +84,38 @@ public class StorageServicePersistenceTests
         }
     }
 
+    [Test]
+    public async Task Settings_FutureSchemaVersion_ReturnsDefaults_WithoutMutatingStoredValue()
+    {
+        var dbPath = CreateDbPath();
+        try
+        {
+            var storage = new StorageService(TimeProvider.System, dbPath);
+            await storage.InitializeAsync();
+            var futurePayload = JsonConvert.SerializeObject(new
+            {
+                SchemaVersion = 99,
+                AppVersion = "future",
+                LastSuccessfulSaveUtc = DateTime.UtcNow,
+                Data = new AppSettings { FocusMinutes = 88 }
+            });
+            await WriteRawSettingsValueAsync(storage, futurePayload);
+
+            var loaded = await storage.GetSettingsAsync();
+            Assert.That(loaded.FocusMinutes, Is.EqualTo(new AppSettings().FocusMinutes));
+
+            var hasQuarantine = await HasQuarantineAsync(storage);
+            Assert.That(hasQuarantine, Is.False);
+
+            var rawAfterLoad = await ReadRawSettingsValueAsync(storage);
+            Assert.That(rawAfterLoad, Is.EqualTo(futurePayload));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
     private static async Task WriteRawSettingsValueAsync(StorageService storage, string json)
     {
         dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
@@ -96,5 +128,12 @@ public class StorageServicePersistenceTests
         dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
         var rows = await db.QueryAsync<dynamic>("SELECT Key FROM KeyValueEntity WHERE Key LIKE 'app_settings_quarantine_%'");
         return rows.Count > 0;
+    }
+
+    private static async Task<string?> ReadRawSettingsValueAsync(StorageService storage)
+    {
+        dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
+        var rows = await db.QueryAsync<dynamic>("SELECT Value FROM KeyValueEntity WHERE Key = 'app_settings'");
+        return rows.Count > 0 ? (string?)rows[0].Value : null;
     }
 }


### PR DESCRIPTION
### Motivation

- Improve durability and observability of local settings persistence so settings survive crashes, partial writes, and schema evolution.
- Add a minimal migration and recovery path to avoid crashes or silent data loss when encountering legacy or corrupted settings payloads.

### Description

- Added a schema envelope type `SettingsPayload` and a centralized `CurrentSettingsSchemaVersion` constant, and now persist settings as an envelope with `schemaVersion`, `appVersion`, `lastSuccessfulSaveUtc`, and `data` via `KeyValueEntity` in `StorageService` (file `ShuffleTask.Persistence/StorageService.cs`).
- Serialized settings access is protected with a `SemaphoreSlim` (`_settingsLock`) and operations emit structured lifecycle logs via `IShuffleLogger` for load/save/migration/quarantine events and durations in `GetSettingsAsync` / `SetSettingsAsync` paths.
- Implemented `DeserializeSettingsPayload`, `MigrateSettingsPayload`, `QuarantineSettingsValueAsync`, and `SetSettingsInternalAsync` to support legacy (plain `AppSettings`) payloads, reject unsupported future schemas safely, and quarantine corrupted payloads while restoring defaults.
- Added focused unit tests `ShuffleTask.Tests/StorageServicePersistenceTests.cs` covering save+reload round-trip, legacy payload migration, and corruption recovery+quarantine, and added a project reference from the test project to `ShuffleTask.Persistence` (`ShuffleTask.Tests/ShuffleTask.Tests.csproj`).

### Testing

- New automated tests added: `StorageServicePersistenceTests.Settings_SaveAndReload_PersistsEnvelopeAndData`, `StorageServicePersistenceTests.Settings_LoadsLegacyPayload_AndMigrates`, and `StorageServicePersistenceTests.Settings_Corruption_RecoversToDefaults_AndQuarantines` in `ShuffleTask.Tests/StorageServicePersistenceTests.cs` (not executed in this rollout).
- The test project was updated to reference `ShuffleTask.Persistence` so the new tests can be executed by CI or locally via `dotnet test` (tests were not run here per the instruction to avoid running builds/tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c45815d9c8326b16a3fa936c68fad)