### PR TITLE
Fix StorageServicePersistenceTests SQLite query usage for quarantine checks

### DIFF
--- a/ShuffleTask.Tests/StorageServicePersistenceTests.cs
+++ b/ShuffleTask.Tests/StorageServicePersistenceTests.cs
@@ -122,14 +122,13 @@ public class StorageServicePersistenceTests
     private static async Task<bool> HasQuarantineAsync(StorageService storage)
     {
         dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
-        var rows = await db.QueryAsync<dynamic>("SELECT Key FROM KeyValueEntity WHERE Key LIKE 'app_settings_quarantine_%'");
-        return rows.Count > 0;
+        var count = await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM KeyValueEntity WHERE Key LIKE 'app_settings_quarantine_%'");
+        return count > 0;
     }
 
     private static async Task<string?> ReadRawSettingsValueAsync(StorageService storage)
     {
         dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
-        var rows = await db.QueryAsync<dynamic>("SELECT Value FROM KeyValueEntity WHERE Key = 'app_settings'");
-        return rows.Count > 0 ? (string?)rows[0].Value : null;
+        return await db.ExecuteScalarAsync<string?>("SELECT Value FROM KeyValueEntity WHERE Key = 'app_settings' LIMIT 1");
     }
 }


### PR DESCRIPTION
### Motivation
- Tests were failing due to use of `db.QueryAsync<dynamic>(...)` against the `SQLiteAsyncConnection` internals which triggers reflection-based mapping for a null/unsupported runtime type and throws `ArgumentNullException`.

### Description
- Replaced the dynamic query in `HasQuarantineAsync` with a scalar `COUNT(1)` using `ExecuteScalarAsync<int>` to avoid row-mapping and correctly detect quarantine rows.
- Replaced the dynamic query in `ReadRawSettingsValueAsync` with `ExecuteScalarAsync<string?>` and `LIMIT 1` to retrieve the stored `Value` without invoking dynamic mapping, in `ShuffleTask.Tests/StorageServicePersistenceTests.cs`.

### Testing
- Ran the `NUnit` test suite for `ShuffleTask.Tests`; the two previous failures related to settings persistence are resolved and the full test run passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c6a3b712083269ee30b1b4664e626)