### PR TITLE
Track task/period schema versions, repair invalid task rows, and make task writes transactional

### DIFF
--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -76,7 +76,8 @@ public class StorageService : IStorageService
             return;
         }
 
-        if (!int.TryParse(row.Value, out int stored) || stored <= 0)
+        bool needsNormalization = !int.TryParse(row.Value, out int stored) || stored <= 0;
+        if (needsNormalization)
         {
             stored = 1;
         }
@@ -91,6 +92,13 @@ public class StorageService : IStorageService
         {
             _logger?.LogSyncEvent("PersistenceMigration", $"{key} migrated {stored}->{currentVersion}");
             row.Value = currentVersion.ToString();
+            await Db.UpdateAsync(row).ConfigureAwait(false);
+            return;
+        }
+
+        if (needsNormalization)
+        {
+            row.Value = stored.ToString();
             await Db.UpdateAsync(row).ConfigureAwait(false);
         }
     }
@@ -332,24 +340,24 @@ public class StorageService : IStorageService
     public async Task UpdateTaskAsync(TaskItem item)
     {
         await _taskLock.WaitAsync().ConfigureAwait(false);
-        _logger?.LogSyncEvent("PersistenceSaveStarted", $"Updating task id={item.Id}");
-        var existing = await Db.FindAsync<TaskItemRecord>(item.Id);
-
-        if (existing != null)
-        {
-            item.CreatedAt = existing.CreatedAt;
-        }
-
-        if (item.UpdatedAt == default)
-        {
-            item.UpdatedAt = _clock.GetUtcNow().UtcDateTime;
-        }
-
-        EnsureMetadata(item, existing, bumpVersion: true);
-
-        var record = BuildTaskRecord(item);
         try
         {
+            _logger?.LogSyncEvent("PersistenceSaveStarted", $"Updating task id={item.Id}");
+            var existing = await Db.FindAsync<TaskItemRecord>(item.Id).ConfigureAwait(false);
+
+            if (existing != null)
+            {
+                item.CreatedAt = existing.CreatedAt;
+            }
+
+            if (item.UpdatedAt == default)
+            {
+                item.UpdatedAt = _clock.GetUtcNow().UtcDateTime;
+            }
+
+            EnsureMetadata(item, existing, bumpVersion: true);
+
+            var record = BuildTaskRecord(item);
             await Db.RunInTransactionAsync(conn =>
             {
                 if (existing == null)

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -13,7 +13,11 @@ namespace ShuffleTask.Persistence;
 public class StorageService : IStorageService
 {
     private const string SettingsKey = "app_settings";
+    private const string TaskSchemaVersionKey = "schema_tasks";
+    private const string PeriodSchemaVersionKey = "schema_periods";
     private const int CurrentSettingsSchemaVersion = 2;
+    private const int CurrentTaskSchemaVersion = 1;
+    private const int CurrentPeriodSchemaVersion = 1;
     private const string IntegerSqlType = "INTEGER";
     private readonly record struct SchemaColumn(string Name, string SqlType, string DefaultSql);
 
@@ -22,6 +26,7 @@ public class StorageService : IStorageService
     private readonly IShuffleLogger? _logger;
     private SQLiteAsyncConnection? _db;
     private readonly SemaphoreSlim _settingsLock = new(1, 1);
+    private readonly SemaphoreSlim _taskLock = new(1, 1);
 
     public StorageService(TimeProvider clock, string databasePath, IShuffleLogger? logger = null)
     {
@@ -52,7 +57,42 @@ public class StorageService : IStorageService
         // Ensure schema has all columns; add columns if missing with sensible defaults.
         await EnsureTaskSchemaAsync();
         await EnsurePeriodDefinitionSchemaAsync();
+        await EnsurePersistenceMetadataAsync();
         await EnsurePresetPeriodDefinitionsAsync();
+    }
+
+    private async Task EnsurePersistenceMetadataAsync()
+    {
+        await UpsertSchemaVersionKeyAsync(TaskSchemaVersionKey, CurrentTaskSchemaVersion).ConfigureAwait(false);
+        await UpsertSchemaVersionKeyAsync(PeriodSchemaVersionKey, CurrentPeriodSchemaVersion).ConfigureAwait(false);
+    }
+
+    private async Task UpsertSchemaVersionKeyAsync(string key, int currentVersion)
+    {
+        var row = await Db.FindAsync<KeyValueEntity>(key).ConfigureAwait(false);
+        if (row == null)
+        {
+            await Db.InsertAsync(new KeyValueEntity { Key = key, Value = currentVersion.ToString() }).ConfigureAwait(false);
+            return;
+        }
+
+        if (!int.TryParse(row.Value, out int stored) || stored <= 0)
+        {
+            stored = 1;
+        }
+
+        if (stored > currentVersion)
+        {
+            _logger?.LogSyncEvent("PersistenceLoadUnsupportedSchema", $"{key}={stored}; supported={currentVersion}");
+            return;
+        }
+
+        if (stored < currentVersion)
+        {
+            _logger?.LogSyncEvent("PersistenceMigration", $"{key} migrated {stored}->{currentVersion}");
+            row.Value = currentVersion.ToString();
+            await Db.UpdateAsync(row).ConfigureAwait(false);
+        }
     }
 
     private async Task EnsureTaskSchemaAsync()
@@ -238,6 +278,7 @@ public class StorageService : IStorageService
         var records = await query
             .OrderByDescending(t => t.CreatedAt)
             .ToListAsync();
+        await ValidateAndRepairTaskRecordsAsync(records).ConfigureAwait(false);
         var tasks = records.Select(r => r.ToDomain()).ToList();
         await ApplyPeriodDefinitionsAsync(tasks);
         return tasks;
@@ -250,6 +291,10 @@ public class StorageService : IStorageService
         var record = await Db.Table<TaskItemRecord>()
                              .Where(t => t.Id == id)
                              .FirstOrDefaultAsync();
+        if (record != null)
+        {
+            await ValidateAndRepairTaskRecordsAsync(new[] { record }).ConfigureAwait(false);
+        }
         var task = record?.ToDomain();
         await ApplyPeriodDefinitionAsync(task);
         return task;
@@ -257,6 +302,8 @@ public class StorageService : IStorageService
 
     public async Task AddTaskAsync(TaskItem item)
     {
+        await _taskLock.WaitAsync().ConfigureAwait(false);
+        _logger?.LogSyncEvent("PersistenceSaveStarted", "Adding task");
         if (string.IsNullOrWhiteSpace(item.Id))
         {
             item.Id = Guid.NewGuid().ToString("n");
@@ -271,11 +318,21 @@ public class StorageService : IStorageService
         EnsureMetadata(item, null, bumpVersion: true);
 
         var record = BuildTaskRecord(item);
-        await Db.InsertAsync(record);
+        try
+        {
+            await Db.RunInTransactionAsync(conn => conn.Insert(record)).ConfigureAwait(false);
+            _logger?.LogSyncEvent("PersistenceSaveCompleted", $"Task added id={record.Id}");
+        }
+        finally
+        {
+            _taskLock.Release();
+        }
     }
 
     public async Task UpdateTaskAsync(TaskItem item)
     {
+        await _taskLock.WaitAsync().ConfigureAwait(false);
+        _logger?.LogSyncEvent("PersistenceSaveStarted", $"Updating task id={item.Id}");
         var existing = await Db.FindAsync<TaskItemRecord>(item.Id);
 
         if (existing != null)
@@ -291,19 +348,39 @@ public class StorageService : IStorageService
         EnsureMetadata(item, existing, bumpVersion: true);
 
         var record = BuildTaskRecord(item);
-        if (existing == null)
+        try
         {
-            await Db.InsertAsync(record);
-            return;
-        }
+            await Db.RunInTransactionAsync(conn =>
+            {
+                if (existing == null)
+                {
+                    conn.Insert(record);
+                    return;
+                }
 
-        await Db.UpdateAsync(record);
+                conn.Update(record);
+            }).ConfigureAwait(false);
+            _logger?.LogSyncEvent("PersistenceSaveCompleted", $"Task updated id={item.Id}");
+        }
+        finally
+        {
+            _taskLock.Release();
+        }
     }
 
     public async Task DeleteTaskAsync(string id)
     {
         await AutoResumeDueTasksAsync();
-        await Db.DeleteAsync<TaskItemRecord>(id);
+        await _taskLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await Db.RunInTransactionAsync(conn => conn.Delete<TaskItemRecord>(id)).ConfigureAwait(false);
+            _logger?.LogSyncEvent("PersistenceSaveCompleted", $"Task deleted id={id}");
+        }
+        finally
+        {
+            _taskLock.Release();
+        }
     }
 
     // Period definitions CRUD
@@ -555,6 +632,53 @@ public class StorageService : IStorageService
         {
             await Db.UpdateAllAsync(toUpdate);
             _logger?.LogSyncEvent("AutoResume", $"Resumed {toUpdate.Count} task(s)");
+        }
+    }
+
+    private async Task ValidateAndRepairTaskRecordsAsync(IEnumerable<TaskItemRecord> records)
+    {
+        foreach (var record in records)
+        {
+            bool dirty = false;
+            if (string.IsNullOrWhiteSpace(record.Id))
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(record.Title))
+            {
+                record.Title = "Untitled";
+                dirty = true;
+            }
+
+            if (record.Status != TaskLifecycleStatus.Active &&
+                record.Status != TaskLifecycleStatus.Snoozed &&
+                record.Status != TaskLifecycleStatus.Completed)
+            {
+                record.Status = TaskLifecycleStatus.Active;
+                record.SnoozedUntil = null;
+                record.NextEligibleAt = null;
+                dirty = true;
+            }
+
+            if (record.Status == TaskLifecycleStatus.Completed && record.CompletedAt == null)
+            {
+                record.CompletedAt = record.UpdatedAt == default ? _clock.GetUtcNow().UtcDateTime : record.UpdatedAt;
+                dirty = true;
+            }
+
+            if (record.Status == TaskLifecycleStatus.Snoozed && record.SnoozedUntil == null)
+            {
+                record.Status = TaskLifecycleStatus.Active;
+                dirty = true;
+            }
+
+            EnsureOwnership(record, null);
+            if (dirty)
+            {
+                _logger?.LogSyncEvent("PersistenceRecovery", $"Repaired invalid task id={record.Id}");
+                await Db.UpdateAsync(record).ConfigureAwait(false);
+            }
         }
     }
 

--- a/ShuffleTask.Tests/StorageServicePersistenceTests.cs
+++ b/ShuffleTask.Tests/StorageServicePersistenceTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using ShuffleTask.Application.Models;
+using ShuffleTask.Domain.Entities;
 using ShuffleTask.Persistence;
 
 namespace ShuffleTask.Tests;
@@ -40,6 +41,72 @@ public class StorageServicePersistenceTests
         finally
         {
         }
+    }
+
+    [Test]
+    public async Task Tasks_Restart_PreservesDoneSnoozePriorityDeadlineImportance()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+
+        var task = new TaskItem
+        {
+            Title = "persist me",
+            Importance = 5,
+            CutInLineMode = CutInLineMode.Now,
+            Deadline = DateTime.UtcNow.AddDays(1)
+        };
+
+        await storage.AddTaskAsync(task);
+        task.Importance = 9;
+        task.Deadline = DateTime.UtcNow.AddDays(2);
+        await storage.UpdateTaskAsync(task);
+        await storage.SnoozeTaskAsync(task.Id, TimeSpan.FromMinutes(30));
+        await storage.MarkTaskDoneAsync(task.Id);
+
+        var reloaded = new StorageService(TimeProvider.System, dbPath);
+        await reloaded.InitializeAsync();
+        var loaded = await reloaded.GetTaskAsync(task.Id);
+
+        Assert.That(loaded, Is.Not.Null);
+        Assert.That(loaded!.Status, Is.EqualTo(TaskLifecycleStatus.Completed));
+        Assert.That(loaded.Importance, Is.EqualTo(9));
+        Assert.That(loaded.Deadline, Is.Not.Null);
+        Assert.That(loaded.CutInLineMode, Is.EqualTo(CutInLineMode.None));
+    }
+
+    [Test]
+    public async Task Tasks_InvalidStatus_IsRecoveredOnLoad()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+        var task = new TaskItem { Title = "invalid status" };
+        await storage.AddTaskAsync(task);
+
+        dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
+        await db.ExecuteAsync($"UPDATE TaskItem SET Status = 999 WHERE Id = '{task.Id}'");
+
+        var loaded = await storage.GetTaskAsync(task.Id);
+        Assert.That(loaded, Is.Not.Null);
+        Assert.That(loaded!.Status, Is.EqualTo(TaskLifecycleStatus.Active));
+    }
+
+    [Test]
+    public async Task TaskSchema_Metadata_UpgradesForward()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+        dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;
+        await db.ExecuteAsync("INSERT OR REPLACE INTO KeyValueEntity(Key, Value) VALUES ('schema_tasks', '0')");
+
+        var reloaded = new StorageService(TimeProvider.System, dbPath);
+        await reloaded.InitializeAsync();
+        dynamic reloadedDb = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(reloaded)!;
+        var schema = await reloadedDb.ExecuteScalarAsync<string>("SELECT Value FROM KeyValueEntity WHERE Key='schema_tasks'");
+        Assert.That(schema, Is.EqualTo("1"));
     }
 
     [Test]


### PR DESCRIPTION
### Motivation
- Persist schema metadata so forward migrations and compatibility checks are possible for tasks and periods.
- Detect and recover invalid task records on load to avoid corrupted state and ensure reasonable defaults.
- Make task create/update/delete operations atomic and serialized to avoid partial writes and race conditions.

### Description
- Add schema keys and current version constants (`TaskSchemaVersionKey`, `PeriodSchemaVersionKey`, `CurrentTaskSchemaVersion`, `CurrentPeriodSchemaVersion`) and implement `EnsurePersistenceMetadataAsync` with `UpsertSchemaVersionKeyAsync` to record/upgrade schema versions.
- Add `_taskLock` and switch task write operations to transactional `Db.RunInTransactionAsync(...)` guarded by the lock, and emit sync/log events during save operations.
- Introduce `ValidateAndRepairTaskRecordsAsync` to detect/repair invalid task fields (blank title, invalid status, missing timestamps/ownership) and call it from `GetTasksAsync` and `GetTaskAsync` so records are repaired on load.
- Minor related changes: ensure metadata handling remains in place and add logging for persistence recovery and migration events.
- Add unit tests in `StorageServicePersistenceTests` to cover persistence across restart, invalid-status recovery, and schema metadata upgrade behavior.

### Testing
- Ran the `ShuffleTask.Tests` NUnit suite covering `StorageServicePersistenceTests`.
- New tests `Tasks_Restart_PreservesDoneSnoozePriorityDeadlineImportance`, `Tasks_InvalidStatus_IsRecoveredOnLoad`, and `TaskSchema_Metadata_UpgradesForward` were executed and passed.  All storage-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c740c20dc83268adcc33bc39fe4a2)