### PR TITLE
Prevent overwriting future settings schema; add transactional DB writes and envelope-based timer persistence

### DIFF
--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SQLite;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
@@ -964,6 +965,11 @@ public class StorageService : IStorageService
 
         try
         {
+            if (TryReadSchemaVersion(kv.Value, out int schemaVersion) && schemaVersion > CurrentSettingsSchemaVersion)
+            {
+                return true;
+            }
+
             var payload = DeserializeSettingsPayload(kv.Value);
             if (payload.SchemaVersion > CurrentSettingsSchemaVersion)
             {
@@ -973,6 +979,44 @@ public class StorageService : IStorageService
         catch (UnsupportedSettingsSchemaException)
         {
             return true;
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadSchemaVersion(string json, out int schemaVersion)
+    {
+        schemaVersion = 0;
+
+        try
+        {
+            var token = JToken.Parse(json);
+            if (token is not JObject obj)
+            {
+                return false;
+            }
+
+            var schemaToken = obj["SchemaVersion"];
+            if (schemaToken == null || schemaToken.Type == JTokenType.Null)
+            {
+                return false;
+            }
+
+            if (schemaToken.Type == JTokenType.Integer)
+            {
+                schemaVersion = schemaToken.Value<int>();
+                return true;
+            }
+
+            if (schemaToken.Type == JTokenType.String && int.TryParse(schemaToken.Value<string>(), out int parsed))
+            {
+                schemaVersion = parsed;
+                return true;
+            }
         }
         catch
         {

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -912,6 +912,13 @@ public class StorageService : IStorageService
     private async Task SetSettingsInternalAsync(AppSettings settings)
     {
         settings = NormalizeSettings(settings);
+
+        if (await HasFutureSettingsSchemaAsync().ConfigureAwait(false))
+        {
+            _logger?.LogSyncEvent("PersistenceSaveSkipped", "Skipped settings save because stored schema version is newer than supported.");
+            return;
+        }
+
         var existingSettings = await GetExistingSettingsAsync().ConfigureAwait(false);
 
         if (IsStale(settings, existingSettings))
@@ -931,17 +938,49 @@ public class StorageService : IStorageService
         };
 
         string json = JsonConvert.SerializeObject(payload);
-        KeyValueEntity existing = await Db.FindAsync<KeyValueEntity>(SettingsKey).ConfigureAwait(false);
-        if (existing == null)
+        await Db.RunInTransactionAsync(conn =>
         {
-            await Db.InsertAsync(new KeyValueEntity { Key = SettingsKey, Value = json }).ConfigureAwait(false);
-            return;
-        }
+            var existing = conn.Find<KeyValueEntity>(SettingsKey);
+            if (existing == null)
+            {
+                conn.Insert(new KeyValueEntity { Key = SettingsKey, Value = json });
+                return;
+            }
 
-        existing.Value = json;
-        await Db.UpdateAsync(existing).ConfigureAwait(false);
+            existing.Value = json;
+            conn.Update(existing);
+        }).ConfigureAwait(false);
     }
 
+
+
+    private async Task<bool> HasFutureSettingsSchemaAsync()
+    {
+        KeyValueEntity kv = await Db.FindAsync<KeyValueEntity>(SettingsKey).ConfigureAwait(false);
+        if (kv == null || string.IsNullOrWhiteSpace(kv.Value))
+        {
+            return false;
+        }
+
+        try
+        {
+            var payload = DeserializeSettingsPayload(kv.Value);
+            if (payload.SchemaVersion > CurrentSettingsSchemaVersion)
+            {
+                return true;
+            }
+        }
+        catch (UnsupportedSettingsSchemaException)
+        {
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
 
     private SettingsPayload DeserializeSettingsPayload(string json)
     {
@@ -991,7 +1030,10 @@ public class StorageService : IStorageService
     {
         string suffix = _clock.GetUtcNow().UtcDateTime.ToString("yyyyMMddHHmmss");
         string key = $"{SettingsKey}_quarantine_{suffix}";
-        await Db.InsertOrReplaceAsync(new KeyValueEntity { Key = key, Value = value }).ConfigureAwait(false);
+        await Db.RunInTransactionAsync(conn =>
+        {
+            conn.InsertOrReplace(new KeyValueEntity { Key = key, Value = value });
+        }).ConfigureAwait(false);
         _logger?.LogSyncEvent("PersistenceQuarantine", $"Stored corrupt settings as {key}; reason={reason}");
     }
 

--- a/ShuffleTask.Presentation/Utilities/PersistedTimerState.cs
+++ b/ShuffleTask.Presentation/Utilities/PersistedTimerState.cs
@@ -5,6 +5,8 @@ namespace ShuffleTask.Presentation.Utilities;
 
 internal static class PersistedTimerState
 {
+    private const string TimerEnvelopeKey = "pref.timerEnvelope";
+    private const int CurrentSchemaVersion = 1;
     public static bool TryGetActiveTimer(
         out string taskId,
         out TimeSpan remaining,
@@ -12,6 +14,22 @@ internal static class PersistedTimerState
         out int durationSeconds,
         out DateTimeOffset expiresAt)
     {
+        if (TryReadEnvelope(out TimerEnvelope? envelope))
+        {
+            taskId = envelope.TaskId;
+            durationSeconds = envelope.DurationSeconds;
+            expiresAt = envelope.ExpiresAt;
+            remaining = expiresAt - DateTimeOffset.UtcNow;
+            expired = remaining <= TimeSpan.Zero;
+            if (expired) remaining = TimeSpan.Zero;
+            if (durationSeconds <= 0)
+            {
+                durationSeconds = Math.Max(1, (int)Math.Ceiling(remaining.TotalSeconds));
+            }
+
+            return !string.IsNullOrWhiteSpace(taskId);
+        }
+
         taskId = Preferences.Default.Get(PreferenceKeys.CurrentTaskId, string.Empty);
         int seconds = Preferences.Default.Get(PreferenceKeys.TimerDurationSeconds, -1);
 
@@ -62,10 +80,72 @@ internal static class PersistedTimerState
         return false;
     }
 
+
+    public static void SaveActiveTimer(string taskId, int durationSeconds, DateTimeOffset expiresAt)
+    {
+        var normalizedTaskId = taskId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalizedTaskId) || durationSeconds <= 0)
+        {
+            Clear();
+            return;
+        }
+
+        var envelope = new TimerEnvelope
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            TaskId = normalizedTaskId,
+            DurationSeconds = durationSeconds,
+            ExpiresAt = expiresAt,
+            SavedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        string json = System.Text.Json.JsonSerializer.Serialize(envelope);
+        Preferences.Default.Set(TimerEnvelopeKey, json);
+        Preferences.Default.Set(PreferenceKeys.CurrentTaskId, normalizedTaskId);
+        Preferences.Default.Set(PreferenceKeys.TimerDurationSeconds, durationSeconds);
+        Preferences.Default.Set(PreferenceKeys.TimerExpiresAt, expiresAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture));
+    }
+
+    private static bool TryReadEnvelope(out TimerEnvelope? envelope)
+    {
+        envelope = null;
+        string json = Preferences.Default.Get(TimerEnvelopeKey, string.Empty);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            var candidate = System.Text.Json.JsonSerializer.Deserialize<TimerEnvelope>(json);
+            if (candidate == null || candidate.SchemaVersion > CurrentSchemaVersion || string.IsNullOrWhiteSpace(candidate.TaskId))
+            {
+                return false;
+            }
+
+            envelope = candidate;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public static void Clear()
     {
         Preferences.Default.Remove(PreferenceKeys.CurrentTaskId);
         Preferences.Default.Remove(PreferenceKeys.TimerDurationSeconds);
         Preferences.Default.Remove(PreferenceKeys.TimerExpiresAt);
+        Preferences.Default.Remove(TimerEnvelopeKey);
+    }
+
+    private sealed class TimerEnvelope
+    {
+        public int SchemaVersion { get; set; }
+        public string TaskId { get; set; } = string.Empty;
+        public int DurationSeconds { get; set; }
+        public DateTimeOffset ExpiresAt { get; set; }
+        public DateTimeOffset SavedAtUtc { get; set; }
     }
 }

--- a/ShuffleTask.Tests/StorageServicePersistenceTests.cs
+++ b/ShuffleTask.Tests/StorageServicePersistenceTests.cs
@@ -179,6 +179,29 @@ public class StorageServicePersistenceTests
         }
     }
 
+
+    [Test]
+    public async Task Settings_FutureSchemaVersion_SetSettings_DoesNotOverwriteStoredValue()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+
+        var futurePayload = JsonConvert.SerializeObject(new
+        {
+            SchemaVersion = 99,
+            AppVersion = "future",
+            LastSuccessfulSaveUtc = DateTime.UtcNow,
+            Data = new AppSettings { FocusMinutes = 88, BreakMinutes = 12 }
+        });
+        await WriteRawSettingsValueAsync(storage, futurePayload);
+
+        await storage.SetSettingsAsync(new AppSettings { FocusMinutes = 25, BreakMinutes = 5 });
+
+        var rawAfterSave = await ReadRawSettingsValueAsync(storage);
+        Assert.That(rawAfterSave, Is.EqualTo(futurePayload));
+    }
+
     private static async Task WriteRawSettingsValueAsync(StorageService storage, string json)
     {
         dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;

--- a/ShuffleTask.Tests/StorageServicePersistenceTests.cs
+++ b/ShuffleTask.Tests/StorageServicePersistenceTests.cs
@@ -202,6 +202,28 @@ public class StorageServicePersistenceTests
         Assert.That(rawAfterSave, Is.EqualTo(futurePayload));
     }
 
+    [Test]
+    public async Task Settings_FutureSchemaVersionWithoutData_SetSettings_DoesNotOverwriteStoredValue()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+
+        var futurePayload = JsonConvert.SerializeObject(new
+        {
+            SchemaVersion = 99,
+            AppVersion = "future",
+            LastSuccessfulSaveUtc = DateTime.UtcNow,
+            Payload = new { FocusMinutes = 88, BreakMinutes = 12 }
+        });
+        await WriteRawSettingsValueAsync(storage, futurePayload);
+
+        await storage.SetSettingsAsync(new AppSettings { FocusMinutes = 25, BreakMinutes = 5 });
+
+        var rawAfterSave = await ReadRawSettingsValueAsync(storage);
+        Assert.That(rawAfterSave, Is.EqualTo(futurePayload));
+    }
+
     private static async Task WriteRawSettingsValueAsync(StorageService storage, string json)
     {
         dynamic db = typeof(StorageService).GetProperty("Db", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(storage)!;


### PR DESCRIPTION
### Motivation
- Avoid corrupting or downgrading stored settings when the on-disk settings schema is newer than the running code.
- Ensure key-value inserts/updates and quarantine writes are performed inside a single DB transaction to reduce race conditions.
- Improve robustness of persisted timer state by introducing a schema'd envelope for saved timer data and centralizing read/write logic.

### Description
- Added `HasFutureSettingsSchemaAsync` and a pre-save check in `SetSettingsInternalAsync` to skip saving when the stored settings schema is newer than `CurrentSettingsSchemaVersion` and log the skip via `PersistenceSaveSkipped`.
- Reworked settings persistence to use `Db.RunInTransactionAsync` with a connection-local `Find/Insert/Update` pattern to perform settings `INSERT` or `UPDATE` atomically.
- Changed `QuarantineSettingsValueAsync` to run `InsertOrReplace` inside `Db.RunInTransactionAsync` for transactional quarantine writes.
- Introduced envelope-based timer persistence in `PersistedTimerState` with `TimerEnvelope` and functions `SaveActiveTimer`, `TryReadEnvelope`, and a schema version constant, while preserving backward compatibility by still updating the legacy preference keys; `TryGetActiveTimer` now prefers the envelope when present.
- Added a unit test `Settings_FutureSchemaVersion_SetSettings_DoesNotOverwriteStoredValue` to verify that `SetSettingsAsync` does not overwrite an existing future-schema settings payload.

### Testing
- Ran the unit test suite for the persistence layer including `StorageServicePersistenceTests`, and the new test `Settings_FutureSchemaVersion_SetSettings_DoesNotOverwriteStoredValue`, which passed.
- Verified existing settings load test that exercises refusing to migrate a future schema still passes and no quarantine entries are created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da751e06883268ad4cc531aa13045)