### PR TITLE
Hotfix: Fix build artifacts Windows runtime restore

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -181,6 +181,14 @@ jobs:
             -p $env:NUGET_TOKEN `
             --store-password-in-clear-text
 
+      - name: Restore Windows runtime packs
+        if: steps.check-artifacts.outputs.exists == 'false'
+        run: >-
+          dotnet restore ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
+          -r win-x64
+          /p:TargetFrameworks=net10.0-windows10.0.19041.0
+          /p:SelfContained=true
+
       - name: Restore dependencies
         if: steps.check-artifacts.outputs.exists == 'false'
         run: dotnet restore ShuffleTask.sln


### PR DESCRIPTION
## Summary
- Add a dedicated Windows runtime-pack restore step before the existing solution restore in the Build Artifacts workflow.
- Keep the existing `--no-restore` Windows publish while ensuring `win-x64` runtime packs are present.

## Root Cause
The workflow restored `ShuffleTask.sln` without a runtime identifier, then published the Windows self-contained executable with `--no-restore -r win-x64`. The publish reused restore assets that did not include `Microsoft.NETCore.App.Runtime.win-x64` or `Microsoft.AspNetCore.App.Runtime.win-x64`, causing `NETSDK1112`.

## Validation
- `git diff --check`
- `dotnet restore ShuffleTask.Presentation\ShuffleTask.Presentation.csproj -r win-x64 /p:TargetFrameworks=net10.0-windows10.0.19041.0 /p:SelfContained=true`
- `dotnet restore ShuffleTask.sln`
- `dotnet publish ShuffleTask.Presentation\ShuffleTask.Presentation.csproj --no-restore -c Release -r win-x64 --self-contained true -f net10.0-windows10.0.19041.0 -o .\artifacts\win /p:AssemblyVersion=0.10.11`

Existing compiler/MSBuild warnings remain, but the runtime-pack publish failure is no longer reproduced locally.