### PR TITLE
Add Export / Import Functionality for Backup, Restore, and Device Migration

### DIFF
--- a/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
+++ b/ShuffleTask.Application.Tests/TestDoubles/InMemoryStorageService.cs
@@ -150,6 +150,12 @@ internal sealed class InMemoryStorageService : IStorageService
 
     public Task<int> MigrateDeviceTasksToUserAsync(string deviceId, string userId) => Task.FromResult(0);
 
+    public Task<string> ExportBackupAsync(string? sourcePlatform = null) => throw new NotSupportedException();
+
+    public Task<BackupImportPreview> PreviewBackupImportAsync(string backupJson) => throw new NotSupportedException();
+
+    public Task ImportBackupAsync(string backupJson) => throw new NotSupportedException();
+
     private void EnsureInitialized()
     {
         if (!_initialized)

--- a/ShuffleTask.Application/Abstractions/IStorageService.cs
+++ b/ShuffleTask.Application/Abstractions/IStorageService.cs
@@ -22,4 +22,15 @@ public interface IStorageService
     Task<AppSettings> GetSettingsAsync();
     Task SetSettingsAsync(AppSettings settings);
     Task<int> MigrateDeviceTasksToUserAsync(string deviceId, string userId);
+    Task<string> ExportBackupAsync(string? sourcePlatform = null);
+    Task<BackupImportPreview> PreviewBackupImportAsync(string backupJson);
+    Task ImportBackupAsync(string backupJson);
 }
+
+public sealed record BackupImportPreview(
+    DateTime CreatedAtUtc,
+    string SourcePlatform,
+    string AppVersion,
+    int FormatVersion,
+    int SchemaVersion,
+    int TaskCount);

--- a/ShuffleTask.Persistence/StorageService.Backup.cs
+++ b/ShuffleTask.Persistence/StorageService.Backup.cs
@@ -309,7 +309,6 @@ public partial class StorageService
         }
 
         string backupPath = CreateSidecarPath("backup.pre-import");
-        await Db.ExecuteAsync("PRAGMA wal_checkpoint(FULL);").ConfigureAwait(false);
         await Db.CloseAsync().ConfigureAwait(false);
         File.Copy(_dbPath, backupPath, overwrite: false);
         CopySidecarIfExists("-wal", backupPath + "-wal");

--- a/ShuffleTask.Persistence/StorageService.Backup.cs
+++ b/ShuffleTask.Persistence/StorageService.Backup.cs
@@ -1,0 +1,373 @@
+using System.Globalization;
+using System.Reflection;
+using Newtonsoft.Json;
+using SQLite;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Persistence.Models;
+
+namespace ShuffleTask.Persistence;
+
+public partial class StorageService
+{
+    private const string ExportFormat = "ShuffleTaskExport";
+    private const int CurrentExportFormatVersion = 1;
+
+    public async Task<string> ExportBackupAsync(string? sourcePlatform = null)
+    {
+        await InitializeAsync().ConfigureAwait(false);
+
+        if (_taskSchemaIsFuture || _periodSchemaIsFuture || await HasFutureSettingsSchemaAsync().ConfigureAwait(false))
+        {
+            throw new InvalidDataException("This backup was created by a newer version of ShuffleTask and cannot be exported by this app.");
+        }
+
+        await ValidateAndRecoverTaskTableAsync().ConfigureAwait(false);
+        await ValidateAndRecoverPeriodTableAsync().ConfigureAwait(false);
+
+        var tasks = await Db.Table<TaskItemRecord>()
+            .OrderBy(record => record.Id)
+            .ToListAsync()
+            .ConfigureAwait(false);
+        var periodDefinitions = await Db.Table<PeriodDefinitionRecord>()
+            .OrderBy(record => record.Id)
+            .ToListAsync()
+            .ConfigureAwait(false);
+        var settings = await GetSettingsAsync().ConfigureAwait(false);
+
+        var envelope = new ShuffleTaskExportEnvelope
+        {
+            Format = ExportFormat,
+            FormatVersion = CurrentExportFormatVersion,
+            AppVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown",
+            CreatedAtUtc = _clock.GetUtcNow().UtcDateTime,
+            SourcePlatform = string.IsNullOrWhiteSpace(sourcePlatform) ? "Unknown" : sourcePlatform.Trim(),
+            SchemaVersion = CurrentBackupSchemaVersion,
+            TaskSchemaVersion = CurrentTaskSchemaVersion,
+            SettingsSchemaVersion = CurrentSettingsSchemaVersion,
+            PeriodSchemaVersion = CurrentPeriodSchemaVersion,
+            Data = new ShuffleTaskExportData
+            {
+                Tasks = tasks,
+                Settings = settings,
+                PeriodDefinitions = periodDefinitions,
+                Metadata = new Dictionary<string, string>
+                {
+                    ["exportedAtUtc"] = _clock.GetUtcNow().UtcDateTime.ToString("O", CultureInfo.InvariantCulture)
+                }
+            }
+        };
+
+        return JsonConvert.SerializeObject(envelope, Formatting.Indented);
+    }
+
+    public Task<BackupImportPreview> PreviewBackupImportAsync(string backupJson)
+    {
+        var envelope = ParseAndValidateBackup(backupJson);
+        return Task.FromResult(new BackupImportPreview(
+            EnsureUtc(envelope.CreatedAtUtc),
+            string.IsNullOrWhiteSpace(envelope.SourcePlatform) ? "Unknown" : envelope.SourcePlatform,
+            string.IsNullOrWhiteSpace(envelope.AppVersion) ? "unknown" : envelope.AppVersion,
+            envelope.FormatVersion,
+            envelope.SchemaVersion,
+            envelope.Data!.Tasks.Count));
+    }
+
+    public async Task ImportBackupAsync(string backupJson)
+    {
+        await InitializeAsync().ConfigureAwait(false);
+
+        var envelope = ParseAndValidateBackup(backupJson);
+        var data = envelope.Data!;
+        var settings = NormalizeSettings(data.Settings ?? new AppSettings());
+        string settingsJson = JsonConvert.SerializeObject(CreateSettingsPayload(settings));
+
+        await _settingsLock.WaitAsync().ConfigureAwait(false);
+        await _taskLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await CreateImportSafetyBackupAsync().ConfigureAwait(false);
+
+            await Db.RunInTransactionAsync(conn =>
+            {
+                conn.DeleteAll<TaskItemRecord>();
+                conn.DeleteAll<PeriodDefinitionRecord>();
+                conn.DeleteAll<KeyValueEntity>();
+
+                foreach (var task in data.Tasks)
+                {
+                    conn.Insert(task);
+                }
+
+                foreach (var definition in data.PeriodDefinitions)
+                {
+                    conn.Insert(definition);
+                }
+
+                conn.Insert(new KeyValueEntity { Key = SettingsKey, Value = settingsJson });
+                UpsertSchemaVersion(conn, TaskSchemaVersionKey, CurrentTaskSchemaVersion);
+                UpsertSchemaVersion(conn, PeriodSchemaVersionKey, CurrentPeriodSchemaVersion);
+                _faultInjector?.BeforeCommit("backup.import");
+            }).ConfigureAwait(false);
+
+            _taskSchemaIsFuture = false;
+            _periodSchemaIsFuture = false;
+            await EnsurePresetPeriodDefinitionsAsync().ConfigureAwait(false);
+            _logger?.LogSyncEvent("BackupImportCompleted", $"tasks={data.Tasks.Count}; periods={data.PeriodDefinitions.Count}; schema={envelope.SchemaVersion}");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogSyncEvent("BackupImportFailed", "Import failed. Existing data was not intentionally changed.", ex);
+            throw;
+        }
+        finally
+        {
+            _taskLock.Release();
+            _settingsLock.Release();
+        }
+    }
+
+    private static int CurrentBackupSchemaVersion => Math.Max(CurrentTaskSchemaVersion, Math.Max(CurrentSettingsSchemaVersion, CurrentPeriodSchemaVersion));
+
+    private ShuffleTaskExportEnvelope ParseAndValidateBackup(string backupJson)
+    {
+        if (string.IsNullOrWhiteSpace(backupJson))
+        {
+            throw BackupFormatException();
+        }
+
+        ShuffleTaskExportEnvelope? envelope;
+        try
+        {
+            envelope = JsonConvert.DeserializeObject<ShuffleTaskExportEnvelope>(backupJson);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException("This backup is damaged or incomplete.", ex);
+        }
+
+        if (envelope == null || !string.Equals(envelope.Format, ExportFormat, StringComparison.Ordinal))
+        {
+            throw BackupFormatException();
+        }
+
+        if (envelope.TaskSchemaVersion <= 0)
+        {
+            envelope.TaskSchemaVersion = envelope.SchemaVersion;
+        }
+
+        if (envelope.SettingsSchemaVersion <= 0)
+        {
+            envelope.SettingsSchemaVersion = envelope.SchemaVersion;
+        }
+
+        if (envelope.PeriodSchemaVersion <= 0)
+        {
+            envelope.PeriodSchemaVersion = envelope.SchemaVersion;
+        }
+
+        if (envelope.FormatVersion > CurrentExportFormatVersion
+            || envelope.SchemaVersion > CurrentBackupSchemaVersion
+            || envelope.TaskSchemaVersion > CurrentTaskSchemaVersion
+            || envelope.SettingsSchemaVersion > CurrentSettingsSchemaVersion
+            || envelope.PeriodSchemaVersion > CurrentPeriodSchemaVersion)
+        {
+            throw new InvalidDataException("This backup was created by a newer version of ShuffleTask and cannot be imported.");
+        }
+
+        if (envelope.FormatVersion <= 0
+            || envelope.SchemaVersion <= 0
+            || envelope.Data == null
+            || envelope.Data.Tasks == null
+            || envelope.Data.Settings == null
+            || envelope.Data.PeriodDefinitions == null)
+        {
+            throw new InvalidDataException("This backup is damaged or incomplete.");
+        }
+
+        NormalizeImportedData(envelope);
+        ValidateTasks(envelope.Data.Tasks);
+        ValidatePeriodDefinitions(envelope.Data.PeriodDefinitions);
+        NormalizeSettings(envelope.Data.Settings);
+        return envelope;
+    }
+
+    private void NormalizeImportedData(ShuffleTaskExportEnvelope envelope)
+    {
+        if (envelope.TaskSchemaVersion < CurrentTaskSchemaVersion)
+        {
+            DateTime nowUtc = _clock.GetUtcNow().UtcDateTime;
+
+            foreach (var task in envelope.Data!.Tasks)
+            {
+                task.CreatedAt = task.CreatedAt == default ? nowUtc : EnsureUtc(task.CreatedAt);
+                task.UpdatedAt = task.UpdatedAt == default ? task.CreatedAt : EnsureUtc(task.UpdatedAt);
+                task.EventVersion = Math.Max(1, task.EventVersion);
+
+                if (task.Repeat == RepeatType.Interval && task.IntervalDays < 1)
+                {
+                    task.IntervalDays = 1;
+                }
+
+                if (!string.IsNullOrWhiteSpace(task.UserId))
+                {
+                    task.DeviceId = null;
+                }
+                else if (string.IsNullOrWhiteSpace(task.DeviceId))
+                {
+                    task.DeviceId = Environment.MachineName;
+                }
+            }
+        }
+
+        if (envelope.PeriodSchemaVersion < CurrentPeriodSchemaVersion)
+        {
+            foreach (var definition in envelope.Data!.PeriodDefinitions)
+            {
+                if (definition.Weekdays == Weekdays.None)
+                {
+                    definition.Weekdays = PeriodDefinitionCatalog.AllWeekdays;
+                }
+
+                definition.Weekdays = (Weekdays)((int)definition.Weekdays & ValidWeekdayMask);
+                definition.Mode = (PeriodDefinitionMode)((int)definition.Mode & ValidPeriodModeMask);
+            }
+        }
+    }
+
+    private static void ValidateTasks(IEnumerable<TaskItemRecord> tasks)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var task in tasks)
+        {
+            if (string.IsNullOrWhiteSpace(task.Id) || !ids.Add(task.Id))
+            {
+                throw new InvalidDataException("This backup is damaged or incomplete: task ids must be valid and unique.");
+            }
+
+            if (string.IsNullOrWhiteSpace(task.Title))
+            {
+                throw new InvalidDataException("This backup is damaged or incomplete: each task needs a title.");
+            }
+
+            if (task.CreatedAt == default || task.UpdatedAt == default)
+            {
+                throw new InvalidDataException("This backup is damaged or incomplete: task timestamps are missing.");
+            }
+
+            if (!Enum.IsDefined(task.Repeat)
+                || !Enum.IsDefined(task.AllowedPeriod)
+                || !Enum.IsDefined(task.Status)
+                || !Enum.IsDefined(task.CutInLineMode)
+                || ((int)task.Weekdays & ~ValidWeekdayMask) != 0
+                || (task.CustomWeekdays.HasValue && ((int)task.CustomWeekdays.Value & ~ValidWeekdayMask) != 0)
+                || (task.AdHocWeekdays.HasValue && ((int)task.AdHocWeekdays.Value & ~ValidWeekdayMask) != 0)
+                || ((int)task.AdHocMode & ~ValidPeriodModeMask) != 0)
+            {
+                throw new InvalidDataException("This backup is damaged or incomplete: a task has invalid rules.");
+            }
+
+            if (task.Repeat == RepeatType.Interval && task.IntervalDays < 1)
+            {
+                throw new InvalidDataException("This backup is damaged or incomplete: a repeating task has an invalid interval.");
+            }
+
+            if (task.Status == TaskLifecycleStatus.Snoozed && task.SnoozedUntil == null)
+            {
+                throw new InvalidDataException("This backup is damaged or incomplete: a snoozed task is missing its snooze time.");
+            }
+        }
+    }
+
+    private static void ValidatePeriodDefinitions(IEnumerable<PeriodDefinitionRecord> definitions)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var definition in definitions)
+        {
+            if (string.IsNullOrWhiteSpace(definition.Id) || !ids.Add(definition.Id))
+            {
+                throw new InvalidDataException("This backup is damaged or incomplete: period definition ids must be valid and unique.");
+            }
+
+            if (string.IsNullOrWhiteSpace(definition.Name)
+                || ((int)definition.Weekdays & ~ValidWeekdayMask) != 0
+                || ((int)definition.Mode & ~ValidPeriodModeMask) != 0)
+            {
+                throw new InvalidDataException("This backup is damaged or incomplete: an allowed-time rule is invalid.");
+            }
+        }
+    }
+
+    private async Task<string?> CreateImportSafetyBackupAsync()
+    {
+        if (!File.Exists(_dbPath))
+        {
+            return null;
+        }
+
+        string backupPath = CreateSidecarPath("backup.pre-import");
+        await Db.ExecuteAsync("PRAGMA wal_checkpoint(FULL);").ConfigureAwait(false);
+        await Db.CloseAsync().ConfigureAwait(false);
+        File.Copy(_dbPath, backupPath, overwrite: false);
+        CopySidecarIfExists("-wal", backupPath + "-wal");
+        CopySidecarIfExists("-shm", backupPath + "-shm");
+        _db = new SQLiteAsyncConnection(_dbPath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.FullMutex);
+        await ConfigureSqliteDurabilityAsync().ConfigureAwait(false);
+        _logger?.LogSyncEvent("PersistenceBackupCreated", $"artifact={Path.GetFileName(backupPath)}; reason=pre-import");
+        return backupPath;
+    }
+
+    private static InvalidDataException BackupFormatException()
+        => new("This does not look like a ShuffleTask backup.");
+
+    private sealed class ShuffleTaskExportEnvelope
+    {
+        [JsonProperty("format")]
+        public string? Format { get; set; }
+
+        [JsonProperty("formatVersion")]
+        public int FormatVersion { get; set; }
+
+        [JsonProperty("appVersion")]
+        public string? AppVersion { get; set; }
+
+        [JsonProperty("createdAtUtc")]
+        public DateTime CreatedAtUtc { get; set; }
+
+        [JsonProperty("sourcePlatform")]
+        public string? SourcePlatform { get; set; }
+
+        [JsonProperty("schemaVersion")]
+        public int SchemaVersion { get; set; }
+
+        [JsonProperty("taskSchemaVersion")]
+        public int TaskSchemaVersion { get; set; }
+
+        [JsonProperty("settingsSchemaVersion")]
+        public int SettingsSchemaVersion { get; set; }
+
+        [JsonProperty("periodSchemaVersion")]
+        public int PeriodSchemaVersion { get; set; }
+
+        [JsonProperty("data")]
+        public ShuffleTaskExportData? Data { get; set; }
+    }
+
+    private sealed class ShuffleTaskExportData
+    {
+        [JsonProperty("tasks")]
+        public List<TaskItemRecord> Tasks { get; set; } = new();
+
+        [JsonProperty("settings")]
+        public AppSettings? Settings { get; set; }
+
+        [JsonProperty("periodDefinitions")]
+        public List<PeriodDefinitionRecord> PeriodDefinitions { get; set; } = new();
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; } = new();
+    }
+}

--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -11,6 +11,7 @@ using ShuffleTask.Application.Models;
 using ShuffleTask.Application.Exceptions;
 using ShuffleTask.Domain.Entities;
 using ShuffleTask.Presentation.Services;
+using ShuffleTask.Presentation.Utilities;
 using System;
 using System.ComponentModel;
 using System.IO;
@@ -241,11 +242,18 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             {
                 await _notifications.CancelAllAsync();
                 await _storage.ImportBackupAsync(json);
-                Settings = await _storage.GetSettingsAsync();
+                AppSettings restoredSettings = await _storage.GetSettingsAsync();
+                Settings.CopyFrom(restoredSettings);
                 Settings.NormalizeWeights();
                 Settings.Network?.Normalize();
+                UpdateNetworkSubscription(_networkOptions, Settings.Network);
+                PersistedTimerState.Clear();
+                PersistedSchedulerState.ClearPendingShuffle();
+                PersistedSchedulerState.SaveDailyCount(_clock.GetUtcNow(), 0);
                 await LoadPresetDefinitionsAsync();
                 CacheSessionState();
+                OnPropertyChanged(nameof(Settings));
+                OnPropertyChanged(nameof(UsePomodoro));
                 OnNetworkChanged(this, new PropertyChangedEventArgs(string.Empty));
 
                 var (userScope, deviceScope) = ResolveTaskScopes();

--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -2,7 +2,10 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.ApplicationModel.DataTransfer;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Storage;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
 using ShuffleTask.Application.Exceptions;
@@ -10,6 +13,7 @@ using ShuffleTask.Domain.Entities;
 using ShuffleTask.Presentation.Services;
 using System;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Yaref92.Events.Transport.Grpc;
@@ -155,6 +159,108 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             if (next != null && Settings.EnableNotifications)
             {
                 await _notifications.NotifyTaskAsync(next, Settings.ReminderMinutes, Settings);
+            }
+        });
+    }
+
+    [RelayCommand]
+    private Task ExportBackupAsync()
+    {
+        return ExecuteIfNotBusyAsync(async () =>
+        {
+            bool export = await ShowConfirmAsync(
+                "Export backup",
+                "ShuffleTask backups contain private task and settings data. Keep exported files somewhere you trust.",
+                "Export",
+                "Cancel");
+
+            if (!export)
+            {
+                return;
+            }
+
+            await _storage.InitializeAsync();
+            string json = await _storage.ExportBackupAsync(DeviceInfo.Current.Platform.ToString());
+            string fileName = $"shuffletask-backup-{_clock.GetUtcNow().UtcDateTime:yyyyMMdd-HHmmss}.shuffletask.json";
+            string path = Path.Combine(FileSystem.CacheDirectory, fileName);
+            await File.WriteAllTextAsync(path, json);
+
+            await Share.Default.RequestAsync(new ShareFileRequest
+            {
+                Title = "Export ShuffleTask backup",
+                File = new ShareFile(path)
+            });
+        });
+    }
+
+    [RelayCommand]
+    private Task ImportBackupAsync()
+    {
+        return ExecuteIfNotBusyAsync(async () =>
+        {
+            FileResult? file = await FilePicker.Default.PickAsync(new PickOptions
+            {
+                PickerTitle = "Select ShuffleTask backup"
+            });
+
+            if (file == null)
+            {
+                return;
+            }
+
+            string json;
+            await using (Stream stream = await file.OpenReadAsync())
+            using (var reader = new StreamReader(stream))
+            {
+                json = await reader.ReadToEndAsync();
+            }
+
+            BackupImportPreview preview;
+            try
+            {
+                preview = await _storage.PreviewBackupImportAsync(json);
+            }
+            catch (InvalidDataException ex)
+            {
+                await ShowAlertAsync("Import failed", ex.Message);
+                return;
+            }
+
+            bool replace = await ShowConfirmAsync(
+                "Import Backup?",
+                BuildImportPreviewMessage(preview),
+                "Replace data",
+                "Cancel");
+
+            if (!replace)
+            {
+                return;
+            }
+
+            try
+            {
+                await _notifications.CancelAllAsync();
+                await _storage.ImportBackupAsync(json);
+                Settings = await _storage.GetSettingsAsync();
+                Settings.NormalizeWeights();
+                Settings.Network?.Normalize();
+                await LoadPresetDefinitionsAsync();
+                CacheSessionState();
+                OnNetworkChanged(this, new PropertyChangedEventArgs(string.Empty));
+
+                var (userScope, deviceScope) = ResolveTaskScopes();
+                await _coordinator.RefreshAsync();
+                await RefreshBoundCollectionsAsync(userScope, deviceScope);
+                await ShowAlertAsync("Import complete", "Your ShuffleTask backup was restored.");
+            }
+            catch (InvalidDataException ex)
+            {
+                await ShowAlertAsync("Import failed", ex.Message);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Backup import failed.");
+                await ShowAlertAsync("Import failed", "Import failed. Your existing data was not changed.");
             }
         });
     }
@@ -485,6 +591,26 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         return MainThread.InvokeOnMainThreadAsync(() =>
             Microsoft.Maui.Controls.Application.Current?.MainPage?.DisplayAlert(title, message, "OK")
             ?? Task.CompletedTask);
+    }
+
+    private static string BuildImportPreviewMessage(BackupImportPreview preview)
+        => $"Backup created: {preview.CreatedAtUtc:u}{Environment.NewLine}"
+           + $"Tasks: {preview.TaskCount}{Environment.NewLine}"
+           + $"Source: {preview.SourcePlatform}{Environment.NewLine}"
+           + $"App version: {preview.AppVersion}{Environment.NewLine}"
+           + $"Schema version: {preview.SchemaVersion}{Environment.NewLine}{Environment.NewLine}"
+           + "This will replace your current ShuffleTask data. A safety backup of your current data will be created first.";
+
+    private static Task<bool> ShowConfirmAsync(string title, string message, string accept, string cancel)
+    {
+        return MainThread.InvokeOnMainThreadAsync(() =>
+            Microsoft.Maui.Controls.Application.Current?.MainPage?.DisplayAlert(title, message, accept, cancel) ?? Task.FromResult(false));
+    }
+
+    private static Task ShowAlertAsync(string title, string message)
+    {
+        return MainThread.InvokeOnMainThreadAsync(() =>
+            Microsoft.Maui.Controls.Application.Current?.MainPage?.DisplayAlert(title, message, "OK") ?? Task.CompletedTask);
     }
 
     private async Task<string?> GetUsernameAsync(string? username)

--- a/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
+++ b/ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs
@@ -243,7 +243,16 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
                 await _notifications.CancelAllAsync();
                 await _storage.ImportBackupAsync(json);
                 AppSettings restoredSettings = await _storage.GetSettingsAsync();
-                Settings.CopyFrom(restoredSettings);
+                UnsubscribeSettings(Settings);
+                try
+                {
+                    Settings.CopyFrom(restoredSettings);
+                }
+                finally
+                {
+                    SubscribeSettings(Settings);
+                }
+
                 Settings.NormalizeWeights();
                 Settings.Network?.Normalize();
                 UpdateNetworkSubscription(_networkOptions, Settings.Network);

--- a/ShuffleTask.Presentation/Views/SettingsPage.xaml
+++ b/ShuffleTask.Presentation/Views/SettingsPage.xaml
@@ -339,6 +339,29 @@
 
             <toolkit:Expander>
                 <toolkit:Expander.Header>
+                    <Label Text="Backup &amp; restore"
+                           FontAttributes="Bold"
+                           FontSize="16" />
+                </toolkit:Expander.Header>
+                <VerticalStackLayout Spacing="10"
+                                     Padding="0,10,0,0">
+                    <Label Text="Backup files include private task and settings data."
+                           FontSize="12"
+                           TextColor="#6B7280" />
+                    <Grid ColumnDefinitions="*,*"
+                          ColumnSpacing="12">
+                        <Button Grid.Column="0"
+                                Text="Export backup"
+                                Command="{Binding ExportBackupCommand}" />
+                        <Button Grid.Column="1"
+                                Text="Import backup"
+                                Command="{Binding ImportBackupCommand}" />
+                    </Grid>
+                </VerticalStackLayout>
+            </toolkit:Expander>
+
+            <toolkit:Expander>
+                <toolkit:Expander.Header>
                     <Label Text="Sync &amp; account"
                            FontAttributes="Bold"
                            FontSize="16" />

--- a/ShuffleTask.Tests/StorageServicePersistenceTests.cs
+++ b/ShuffleTask.Tests/StorageServicePersistenceTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
@@ -476,6 +477,172 @@ public class StorageServicePersistenceTests
 
         var rawAfterSave = await ReadRawSettingsValueAsync(storage);
         Assert.That(rawAfterSave, Is.EqualTo(futurePayload));
+    }
+
+    [Test]
+    public async Task Backup_ExportImport_RestoresTasksSettingsAndPeriodDefinitions()
+    {
+        var sourcePath = CreateDbPath();
+        var targetPath = CreateDbPath();
+
+        var source = new StorageService(TimeProvider.System, sourcePath);
+        await source.InitializeAsync();
+        await source.SetSettingsAsync(new AppSettings
+        {
+            FocusMinutes = 42,
+            BreakMinutes = 7,
+            PomodoroCycles = 5,
+            ImportanceWeight = 33
+        });
+        await source.UpdatePeriodDefinitionAsync(new PeriodDefinition
+        {
+            Id = "deep-work",
+            Name = "Deep work",
+            Weekdays = Weekdays.Mon | Weekdays.Wed,
+            StartTime = new TimeSpan(8, 30, 0),
+            EndTime = new TimeSpan(10, 0, 0),
+            Mode = PeriodDefinitionMode.None
+        });
+        await source.AddTaskAsync(new TaskItem
+        {
+            Id = "active-task",
+            Title = "Active task",
+            Description = "keep notes",
+            Importance = 5,
+            Deadline = DateTime.UtcNow.AddDays(2),
+            Repeat = RepeatType.Weekly,
+            Weekdays = Weekdays.Mon | Weekdays.Wed,
+            PeriodDefinitionId = "deep-work",
+            CutInLineMode = CutInLineMode.Once,
+            CustomReminderMinutes = 20
+        });
+        await source.AddTaskAsync(new TaskItem { Id = "snoozed-task", Title = "Snoozed task", Importance = 3 });
+        await source.SnoozeTaskAsync("snoozed-task", TimeSpan.FromDays(2));
+
+        string backup = await source.ExportBackupAsync("Android");
+        var preview = await source.PreviewBackupImportAsync(backup);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(backup, Does.Contain("\"format\": \"ShuffleTaskExport\""));
+            Assert.That(backup, Does.Contain("\"formatVersion\": 1"));
+            Assert.That(preview.SourcePlatform, Is.EqualTo("Android"));
+            Assert.That(preview.TaskCount, Is.EqualTo(2));
+        });
+
+        var target = new StorageService(TimeProvider.System, targetPath);
+        await target.InitializeAsync();
+        await target.AddTaskAsync(new TaskItem { Id = "old-task", Title = "Old task" });
+        await target.SetSettingsAsync(new AppSettings { FocusMinutes = 11 });
+
+        await target.ImportBackupAsync(backup);
+
+        var tasks = await target.GetTasksAsync();
+        var restoredSettings = await target.GetSettingsAsync();
+        var restoredPeriod = await target.GetPeriodDefinitionAsync("deep-work");
+        bool safetyBackupExists = Directory.GetFiles(Path.GetDirectoryName(targetPath)!, $"{Path.GetFileName(targetPath)}.backup.pre-import.*.db3").Length > 0;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tasks.Select(t => t.Id), Does.Contain("active-task"));
+            Assert.That(tasks.Select(t => t.Id), Does.Contain("snoozed-task"));
+            Assert.That(tasks.Select(t => t.Id), Does.Not.Contain("old-task"));
+            Assert.That(tasks.Single(t => t.Id == "snoozed-task").Status, Is.EqualTo(TaskLifecycleStatus.Snoozed));
+            Assert.That(restoredSettings.FocusMinutes, Is.EqualTo(42));
+            Assert.That(restoredSettings.BreakMinutes, Is.EqualTo(7));
+            Assert.That(restoredPeriod, Is.Not.Null);
+            Assert.That(restoredPeriod!.StartTime, Is.EqualTo(new TimeSpan(8, 30, 0)));
+            Assert.That(safetyBackupExists, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task Backup_ImportInvalidJson_DoesNotModifyExistingData()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+        await storage.AddTaskAsync(new TaskItem { Id = "existing-task", Title = "Existing" });
+        await storage.SetSettingsAsync(new AppSettings { FocusMinutes = 31 });
+
+        Assert.ThrowsAsync<InvalidDataException>(() => storage.ImportBackupAsync("{bad json"));
+
+        var task = await storage.GetTaskAsync("existing-task");
+        var settings = await storage.GetSettingsAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(task, Is.Not.Null);
+            Assert.That(task!.Title, Is.EqualTo("Existing"));
+            Assert.That(settings.FocusMinutes, Is.EqualTo(31));
+        });
+    }
+
+    [Test]
+    public async Task Backup_ImportFutureVersion_DoesNotModifyExistingData()
+    {
+        var source = new StorageService(TimeProvider.System, CreateDbPath());
+        await source.InitializeAsync();
+        await source.AddTaskAsync(new TaskItem { Id = "source-task", Title = "Source" });
+        var json = JObject.Parse(await source.ExportBackupAsync("Android"));
+        json["formatVersion"] = 99;
+
+        var target = new StorageService(TimeProvider.System, CreateDbPath());
+        await target.InitializeAsync();
+        await target.AddTaskAsync(new TaskItem { Id = "existing-task", Title = "Existing" });
+
+        Assert.ThrowsAsync<InvalidDataException>(() => target.ImportBackupAsync(json.ToString(Formatting.None)));
+
+        var tasks = await target.GetTasksAsync();
+        Assert.That(tasks.Select(t => t.Id), Is.EquivalentTo(new[] { "existing-task" }));
+    }
+
+    [Test]
+    public async Task Backup_ImportDuplicateTaskIds_DoesNotModifyExistingData()
+    {
+        var source = new StorageService(TimeProvider.System, CreateDbPath());
+        await source.InitializeAsync();
+        await source.AddTaskAsync(new TaskItem { Id = "duplicate-task", Title = "Original" });
+        var json = JObject.Parse(await source.ExportBackupAsync("Android"));
+        var tasks = (JArray)json["data"]!["tasks"]!;
+        tasks.Add(tasks[0]!.DeepClone());
+
+        var target = new StorageService(TimeProvider.System, CreateDbPath());
+        await target.InitializeAsync();
+        await target.AddTaskAsync(new TaskItem { Id = "existing-task", Title = "Existing" });
+
+        Assert.ThrowsAsync<InvalidDataException>(() => target.ImportBackupAsync(json.ToString(Formatting.None)));
+
+        var existing = await target.GetTaskAsync("existing-task");
+        Assert.That(existing, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task Backup_ImportOlderSchemaVersion_IsAcceptedWhenCurrentModelsCanReadIt()
+    {
+        var source = new StorageService(TimeProvider.System, CreateDbPath());
+        await source.InitializeAsync();
+        await source.SetSettingsAsync(new AppSettings { FocusMinutes = 27 });
+        await source.AddTaskAsync(new TaskItem { Id = "portable-task", Title = "Portable" });
+
+        var json = JObject.Parse(await source.ExportBackupAsync("Android"));
+        json["schemaVersion"] = 1;
+        json["taskSchemaVersion"] = 1;
+        json["settingsSchemaVersion"] = 1;
+        json["periodSchemaVersion"] = 1;
+
+        var target = new StorageService(TimeProvider.System, CreateDbPath());
+        await target.InitializeAsync();
+        await target.ImportBackupAsync(json.ToString(Formatting.None));
+
+        var task = await target.GetTaskAsync("portable-task");
+        var settings = await target.GetSettingsAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(task, Is.Not.Null);
+            Assert.That(settings.FocusMinutes, Is.EqualTo(27));
+        });
     }
 
     private static async Task WriteRawSettingsValueAsync(StorageService storage, string json)

--- a/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
+++ b/ShuffleTask.Tests/TestDoubles/StorageServiceStub.cs
@@ -263,6 +263,12 @@ public class StorageServiceStub : IStorageService
         return Task.CompletedTask;
     }
 
+    public Task<string> ExportBackupAsync(string? sourcePlatform = null) => throw new NotSupportedException();
+
+    public Task<BackupImportPreview> PreviewBackupImportAsync(string backupJson) => throw new NotSupportedException();
+
+    public Task ImportBackupAsync(string backupJson) => throw new NotSupportedException();
+
     private void AutoResumeDueTasks()
     {
         DateTime nowUtc = _clock.GetUtcNow().UtcDateTime;


### PR DESCRIPTION
Implements:

# GitHub Issue #281: Add Export / Import Functionality for Backup, Restore, and Device Migration

URL: https://github.com/com-mit-group/ShuffleTask/issues/281

## Problem

Users need a reliable way to manually back up, restore, and move their ShuffleTask data.

ShuffleTask contains important personal productivity state:

- active tasks
- completed tasks
- priorities
- deadlines
- repeating tasks
- allowed-time rules
- snoozes
- settings
- Pomodoro/timer preferences

Without export/import, users are vulnerable to:

- device loss
- app reinstall
- platform migration
- failed sync experiments
- corrupted local data
- accidental data deletion

## Goal

Add manual export/import functionality that allows users to safely back up and restore ShuffleTask data.

The feature should support:

- full export
- full import/restore
- schema versioning
- validation before import
- safe replace behavior
- user-friendly error messages
- platform-native file picker/share behavior

## Scope

This issue covers **manual export/import**.

It does not replace robust local persistence.
It should rely on the persistence layer being reliable and versioned.

## User Stories

### Backup

As a user, I want to export my ShuffleTask data so that I can keep a backup outside the app.

### Restore

As a user, I want to import a previous backup so that I can restore my tasks after reinstalling the app or changing devices.

### Device Migration

As a user, I want to move my ShuffleTask data from one device/platform to another.

### Debug / Support

As a developer, I want users to be able to export app data so persistence issues can be diagnosed more easily.

## Export Format

Use a structured, versioned format.

Recommended initial format:

- JSON file
- extension: `.shuffletask.json`

Example:

```json
{
  "format": "ShuffleTaskExport",
  "formatVersion": 1,
  "appVersion": "1.0.0",
  "createdAtUtc": "2026-01-01T12:00:00Z",
  "sourcePlatform": "Android",
  "schemaVersion": 3,
  "data": {
    "tasks": [],
    "settings": {},
    "timerState": {},
    "metadata": {}
  }
}
```

If binary assets/attachments are added later, a zipped package format can be introduced:

```text
backup.shuffletask
├── manifest.json
├── tasks.json
├── settings.json
├── metadata.json
└── attachments/
```

For the first version, plain JSON is likely enough.

## Data to Include

At minimum, export/import should include:

### Tasks

- task id
- title
- description / notes
- status
- done state
- snoozed state
- score
- importance
- deadline
- allowed time rules
- repeating task rules
- cut-in-line priority
- created/updated timestamps
- device/user ownership metadata, if relevant

### Settings

- notification settings
- Pomodoro settings
- shuffle settings
- sort/filter preferences
- UI preferences where useful

### Optional / Handle Carefully

- active timer state
- pending notification references
- device-specific identifiers
- sync metadata

Device-specific and notification-specific fields should not be blindly restored.
They should either be excluded, regenerated, or clearly marked as non-portable.

## Import Mode

Implement **Replace Existing Data** first.

Import should replace all local data with the imported backup.

Pros:

- simple
- predictable
- safer for true restore
- avoids premature conflict-resolution complexity

Cons:

- can overwrite newer local changes

Merge import should be a future enhancement only after data model and conflict rules are mature.

The import UX should clearly say:

> This will replace your current ShuffleTask data with the imported backup.

## Import Validation

Before applying an import, validate the file.

Checks:

- valid JSON
- correct `format`
- supported `formatVersion`
- supported or migratable `schemaVersion`
- required fields exist
- task ids are valid and unique
- dates parse correctly
- repeating rules are valid
- allowed time rules are valid
- no obviously impossible state

Acceptance:

- invalid imports do not modify existing data
- user gets a clear error message
- detailed reason is logged for debugging

## Migration During Import

If an export file uses an older schema, import should reuse the same migration system as local persistence.

Import flow:

1. Pick file
2. Parse export
3. Validate export envelope
4. Migrate data to current schema if needed
5. Validate migrated data
6. Ask user to confirm restore
7. Backup current local state internally
8. Replace local data
9. Reload app state cleanly
10. Reschedule notifications if needed

## Safety Backup Before Import

Before replacing local data, create an internal safety backup of the current app state.

This protects users from:

- choosing the wrong file
- importing an old backup accidentally
- import bugs
- partial import failure

Acceptance:

- current local state is saved before replacement
- if import fails midway, old state can be restored
- user data is not lost due to partial import failure

## Notification and Timer Handling

Imported data should not blindly restore stale OS notification IDs.

Recommended behavior:

- cancel all currently scheduled app notifications before import restore
- import task/timer preferences
- regenerate/reschedule notifications from imported state only where appropriate
- do not preserve platform-specific notification identifiers from export

Acceptance:

- no ghost notifications after import
- no notifications for done/snoozed tasks unless explicitly intended
- Android notification state is consistent after import

## Privacy and Security

Exported files may contain private personal task data.

The UX should warn users that exported backups may contain private information.

Initial version can use plain JSON if clearly labeled.

Future enhancements:

- encrypted export
- password-protected export
- sanitized diagnostic export

## Platform UX

### Android

- export through native share sheet or file saver
- import through native file picker
- handle file permissions/URI access correctly
- use clear `.json` or `.shuffletask.json` extension

### iOS

- export through share sheet / Files
- import through document picker
- respect iOS file access lifecycle

### Desktop

- export via save file dialog
- import via open file dialog
- allow user to choose backup location

## UI Proposal

Location:

Settings > Backup & Restore

Actions:

- Export backup
- Import backup
- Show last export date, if tracked
- Optional: Include diagnostic metadata toggle

Import confirmation should show:

- backup creation date
- source platform
- task count
- app version
- schema version
- clear warning that current data will be replaced

Example:

```text
Import Backup?

Backup created: 2026-01-01 12:00 UTC
Tasks: 184
Source: Android
Schema version: 3

This will replace your current ShuffleTask data.
A safety backup of your current data will be created first.
```

## Error Handling

User-facing errors should be clear:

- "This does not look like a ShuffleTask backup."
- "This backup was created by a newer version of ShuffleTask and cannot be imported."
- "This backup is damaged or incomplete."
- "Import failed. Your existing data was not changed."
- "Import succeeded, but some invalid entries were skipped."

Developer logs should include more detail.

## Acceptance Criteria

- [ ] User can export a complete backup file
- [ ] Export file includes explicit format version and schema version
- [ ] User can import a backup file
- [ ] Import validates file before modifying local data
- [ ] Import supports migration from older schema versions where available
- [ ] Import uses replace mode for the initial implementation
- [ ] Current local data is safety-backed-up before import replace
- [ ] Invalid import does not modify existing data
- [ ] OS notification state is cleaned up/regenerated after import
- [ ] Platform-native file picker/share/save UX is used
- [ ] User is warned that exports may contain private data
- [ ] Export/import works at least on Android
- [ ] Export/import has automated tests for valid, invalid, old-version, and corrupted files

## Suggested Tests

### Export Tests

- export empty app state
- export app state with active tasks
- export app state with done tasks
- export app state with snoozed tasks
- export repeating tasks
- export tasks with deadlines/importance/cut-in-line priority
- export settings

### Import Tests

- import valid backup
- import backup with older schema
- import invalid JSON
- import wrong file type
- import missing required fields
- import duplicate task ids
- import backup created by newer unsupported version
- import backup with stale notification metadata
- import while existing data exists

### Manual Platform Tests

- Android export to Files
- Android export via share sheet
- Android import from Files
- app restart after import
- verify done/snoozed/repeating/deadline/priority state after import

## Non-Goals

- cloud backup
- cross-device sync
- merge/conflict resolution
- encrypted backups
- automatic scheduled backups
- multi-user backup merging

These can become future issues.

## Notes

This feature is both practical and trust-building.

Users forgive missing features. They do not forgive losing their tasks.

Codex plan:

1) Where to look
   - `IStorageService`, `StorageService.*`, `TaskItemRecord`, `PeriodDefinitionRecord`, `SettingsPayload`
   - `CurrentSettingsSchemaVersion`, `CurrentTaskSchemaVersion`, `CurrentPeriodSchemaVersion`
   - `SettingsViewModel`, `SettingsPage.xaml`, MAUI `FilePicker` / `Share`
   - Existing persistence tests around settings/task schema migration and rollback
   - Search terms: `GetTasksAsync`, `SetSettingsAsync`, `RunInTransactionAsync`, `PersistenceBackupCreated`

2) Files / areas likely to touch
   - `ShuffleTask.Application/Abstractions/IStorageService.cs`
   - New or existing `ShuffleTask.Persistence/StorageService.*.cs` partial for export/import envelope, validation, and replace transaction
   - `ShuffleTask.Presentation/ViewModels/SettingsViewModel.cs`
   - `ShuffleTask.Presentation/Views/SettingsPage.xaml`
   - `ShuffleTask.Tests/StorageServicePersistenceTests.cs`

3) Assumptions
   - This issue is too broad for every future UX/platform detail; implement the first usable manual JSON backup/restore path.
   - Export/import should include persisted tasks, period definitions/allowed-time rules, and app settings.
   - Replace mode should restore the whole local store and should not merge with current state.
   - Export can use MAUI share sheet for Android first; import can use MAUI file picker.
   - Existing storage migrations/normalization can be reused by writing through current persistence models and settings payload handling.

4) Plan
   - Add storage-level export/import methods with a versioned `ShuffleTaskExport` JSON envelope, schema fields, validation, and duplicate task id checks.
   - Implement import as an atomic replace transaction after creating a sidecar safety backup of the current database file; do not mutate existing data if parse/validation fails.
   - Wire Settings commands/buttons for export and import, including privacy warning, replace confirmation, clear alerts, file picker import, and share-sheet export.
   - Add focused persistence tests for valid export/import, invalid/corrupt JSON preserving current data, future unsupported export version, and duplicate ids.

5) Risks / gotchas
   - SQLite WAL sidecars need to be checkpointed or copied alongside the main database before safety backup.
   - `SetSettingsAsync` stale-write protection can block restored settings if imported event metadata is older; replace import should write the payload directly in the transaction.
   - `GetTasksAsync` auto-resumes due snoozes, so export tests should use future snooze values when preserving snoozed state.
   - MAUI file APIs are hard to unit-test here; keep platform glue thin and put behavior tests at persistence level.
   - Notification cleanup/regeneration may only be best-effort through existing services unless the notification abstraction already exposes cancel-all/reschedule APIs.

6) Recommended implementation approach
   - Option A: fastest / lowest-risk: put export/import in a `StorageService` partial using existing record models and settings payload logic, expose it through `IStorageService`, and add Settings UI commands that call storage plus existing notification/task refresh services.
   - Option B: slightly cleaner, only if Option A is blocked or too messy: add a small application-level backup service that composes `IStorageService`, leaving `StorageService` with only low-level snapshot/replace helpers.


Local verification:

~~~
pwsh -File "C:\Users\yaref92\codex-tools\codex-verify.ps1" -Profiles "backend,maui"
~~~
