### PR TITLE
After closing from the tray app still sends notifications and can be "revived" through them

### DIFF
--- a/ShuffleTask.Presentation.Tests/ShuffleCoordinatorServiceTests.cs
+++ b/ShuffleTask.Presentation.Tests/ShuffleCoordinatorServiceTests.cs
@@ -130,6 +130,19 @@ public class ShuffleCoordinatorServiceTests
         Assert.That(_background.LastScheduledAt, Is.Not.Null);
     }
 
+    [Test]
+    public async Task ApplyBackgroundActivityChangeAsync_WhenDisabled_CancelsBackgroundAndNotifications()
+    {
+        using var service = CreateService();
+        await service.StartAsync();
+
+        await service.ApplyBackgroundActivityChangeAsync(false);
+
+        Assert.That(_background.CancelCount, Is.GreaterThan(0));
+        Assert.That(_background.StopCount, Is.EqualTo(1));
+        Assert.That(_notifications.CancelAllCount, Is.EqualTo(1));
+    }
+
     private ShuffleCoordinatorService CreateService()
     {
         var network = Substitute.For<INetworkSyncService>();
@@ -161,8 +174,15 @@ public class ShuffleCoordinatorServiceTests
 
     private sealed class NotificationStub : INotificationService
     {
+        public int CancelAllCount { get; private set; }
+
         public Task InitializeAsync() => Task.CompletedTask;
-        public Task CancelAllAsync() => Task.CompletedTask;
+
+        public Task CancelAllAsync()
+        {
+            CancelAllCount++;
+            return Task.CompletedTask;
+        }
 
         public Task NotifyPhaseAsync(string title, string message, TimeSpan delay, AppSettings settings)
         {
@@ -183,6 +203,8 @@ public class ShuffleCoordinatorServiceTests
     {
         public int ScheduleCount { get; private set; }
         public int AsyncScheduleCount { get; private set; }
+        public int CancelCount { get; private set; }
+        public int StopCount { get; private set; }
         public DateTimeOffset? LastScheduledAt { get; private set; }
         public string? LastScheduledTaskId { get; private set; }
         private Func<Task>? _callback;
@@ -205,10 +227,12 @@ public class ShuffleCoordinatorServiceTests
 
         public void Cancel()
         {
+            CancelCount++;
         }
 
         public void Stop()
         {
+            StopCount++;
         }
 
         public Task TriggerAsyncCallbackAsync()

--- a/ShuffleTask.Presentation/Platforms/Windows/Services/WindowsTrayIconManager.windows.cs
+++ b/ShuffleTask.Presentation/Platforms/Windows/Services/WindowsTrayIconManager.windows.cs
@@ -139,6 +139,7 @@ internal sealed class WindowsTrayIconManager : IDisposable
         {
             RemoveTrayIcon();
             _window?.Close();
+            MauiApplication.Current?.Quit();
         });
 
         if (!queued)

--- a/ShuffleTask.Presentation/Platforms/Windows/Services/WindowsTrayIconManager.windows.cs
+++ b/ShuffleTask.Presentation/Platforms/Windows/Services/WindowsTrayIconManager.windows.cs
@@ -2,14 +2,23 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Windowing;
 using WinRT.Interop;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Presentation.Services;
 using MauiApplication = Microsoft.Maui.Controls.Application;
 
 namespace ShuffleTask.Presentation.Platforms.Windows.Services;
 
 internal sealed class WindowsTrayIconManager : IDisposable
 {
+    private readonly IStorageService _storage;
+    private readonly AppSettings _settings;
+    private readonly ShuffleCoordinatorService _coordinator;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<WindowsTrayIconManager>? _logger;
     private readonly Icon _icon;
     private readonly bool _ownsIcon;
     private readonly uint _trayCallbackMessage;
@@ -22,9 +31,20 @@ internal sealed class WindowsTrayIconManager : IDisposable
     private bool _initialized;
     private bool _allowClose;
     private bool _hasShownBackgroundTip;
+    private bool _exitRequested;
 
-    public WindowsTrayIconManager()
+    public WindowsTrayIconManager(
+        IStorageService storage,
+        AppSettings settings,
+        ShuffleCoordinatorService coordinator,
+        TimeProvider clock,
+        ILogger<WindowsTrayIconManager>? logger = null)
     {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger;
         (_icon, _ownsIcon) = LoadIcon();
         _trayCallbackMessage = WM_APP + 1000;
         _wndProcDelegate = WindowProcedure;
@@ -97,8 +117,17 @@ internal sealed class WindowsTrayIconManager : IDisposable
         });
     }
 
-    private void ExitApplication()
+    private async void ExitApplication()
     {
+        if (_exitRequested)
+        {
+            return;
+        }
+
+        _exitRequested = true;
+        _allowClose = true;
+        await StopBackgroundActivityAsync().ConfigureAwait(false);
+
         if (_window == null)
         {
             MauiApplication.Current?.Quit();
@@ -106,12 +135,42 @@ internal sealed class WindowsTrayIconManager : IDisposable
             return;
         }
 
-        _allowClose = true;
-        _ = _window.DispatcherQueue.TryEnqueue(() =>
+        bool queued = _window.DispatcherQueue.TryEnqueue(() =>
         {
             RemoveTrayIcon();
             _window?.Close();
         });
+
+        if (!queued)
+        {
+            RemoveTrayIcon();
+            MauiApplication.Current?.Quit();
+            Dispose();
+        }
+    }
+
+    private async Task StopBackgroundActivityAsync()
+    {
+        _settings.BackgroundActivityEnabled = false;
+        _settings.Touch(_clock);
+
+        try
+        {
+            await _storage.SetSettingsAsync(_settings).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to persist disabled background activity before tray exit.");
+        }
+
+        try
+        {
+            await _coordinator.ApplyBackgroundActivityChangeAsync(false).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to stop background activity before tray exit.");
+        }
     }
 
     private void ShowBackgroundTip()

--- a/ShuffleTask.Presentation/Properties/launchSettings.json
+++ b/ShuffleTask.Presentation/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
     "Windows Machine": {
-      "commandName": "MsixPackage",
+      "commandName": "Project",
       "nativeDebugging": false
     }
   }

--- a/ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs
+++ b/ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs
@@ -87,6 +87,14 @@ public class ShuffleCoordinatorService : IDisposable
 
         await PauseAsync().ConfigureAwait(false);
         _backgroundService.Stop();
+        try
+        {
+            await _notifications.CancelAllAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"ShuffleCoordinatorService notification cancel error: {ex}");
+        }
     }
 
     private async Task ResumeInternalAsync()

--- a/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
+++ b/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <!-- Build Windows by default to unblock, other targets can be re-enabled later -->
-        <TargetFrameworks Condition="'$(TargetFramework)' == ''">net10.0-android</TargetFrameworks>
-      <TargetFrameworks Condition="'$(TargetFramework)' == '' and $([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net10.0-android</TargetFrameworks>
+      <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
         <!--<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('android'))">$(TargetFrameworks);net10.0-android</TargetFrameworks>-->
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('ios'))">$(TargetFrameworks);net10.0-ios</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('maccatalyst'))">$(TargetFrameworks);net10.0-maccatalyst</TargetFrameworks>


### PR DESCRIPTION
Implements:

# GitHub Issue #170: After closing from the tray app still sends notifications and can be "revived" through them

URL: https://github.com/com-mit-group/ShuffleTask/issues/170



Codex plan:

1) Where to look
   - `WindowsTrayIconManager` in `ShuffleTask.Presentation/Platforms/Windows/Services/WindowsTrayIconManager.windows.cs`
   - `Exit and stop background activity` in `ShuffleTask.Presentation/Views/MainPage.xaml.cs`
   - `ApplyBackgroundActivityChangeAsync` in `ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs`
   - `CancelAllAsync` implementations/usages in notification services and tests
   - `BackgroundActivityEnabled` settings persistence in `AppSettings` and `IStorageService`
   - `ShuffleCoordinatorServiceTests` for focused background-disable coverage

2) Files / areas likely to touch
   - `ShuffleTask.Presentation/Platforms/Windows/Services/WindowsTrayIconManager.windows.cs`
   - `ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs`
   - `ShuffleTask.Presentation.Tests/ShuffleCoordinatorServiceTests.cs`

3) Assumptions
   - The issue refers to using the Windows tray context menu `Exit`, not merely clicking the window close button that intentionally hides to tray.
   - Exiting from the tray should behave like the existing main-page "Exit and stop background activity" command.
   - Clearing notification schedule/history is required so old toasts cannot fire or activate the app after exit.
   - Persisting `BackgroundActivityEnabled = false` is required so any later activation does not restart scheduling.
   - No domain, persistence schema, backend, or cross-platform app behavior changes are needed.

4) Plan
   - Update `ShuffleCoordinatorService.ApplyBackgroundActivityChangeAsync(false)` to pause timers, stop persistent background work, and call `INotificationService.CancelAllAsync()`.
   - Add/update `ShuffleCoordinatorServiceTests` to verify disabling background activity cancels scheduled work, stops background activity, and clears notifications.
   - Update `WindowsTrayIconManager` so tray `Exit` persists `BackgroundActivityEnabled = false`, touches/saves settings, applies the background-disable path, then removes the tray icon and quits/closes the app.
   - Keep the normal tray window close-to-hide behavior unchanged.

5) Risks / gotchas
   - `WindowsTrayIconManager` is Windows-only and difficult to unit test directly in the existing non-Windows test suite.
   - Tray exit runs from a native menu callback, so async stop/persist work must be awaited before closing the window.
   - If service resolution fails during tray exit, the app should still close rather than leave the UI stuck.
   - Notification cancellation failures should not block exit.
   - Existing dirty workspace files are baseline from before this issue; avoid touching them.

6) Recommended implementation approach
   - Option A: fastest / lowest-risk: inject the existing storage, settings, coordinator, clock, notifications, and optional logger into `WindowsTrayIconManager`, then perform the same persisted stop sequence used by the main-page exit path before quitting.
   - Option B: slightly cleaner, only if Option A is blocked or too messy: extract a small presentation-layer exit/background-stop service shared by `MainPage` and `WindowsTrayIconManager`.


Local verification:

~~~
pwsh -File "C:\Users\yaref92\codex-tools\codex-verify.ps1" -Profiles "maui"
~~~
