### PR TITLE
Extract sync exchange core and fix manifest request processing

### DIFF
--- a/ShuffleTask.Application.Tests/HandlersAndEventsTests.cs
+++ b/ShuffleTask.Application.Tests/HandlersAndEventsTests.cs
@@ -179,8 +179,9 @@ public class HandlersAndEventsTests
             Assert.That(started.Minutes, Is.EqualTo(15));
             Assert.That(timeUp.DeviceId, Is.EqualTo("device-a"));
             Assert.That(announced.Manifest?.Count(), Is.EqualTo(1));
-            Assert.That(request.Manifest?.Count(), Is.EqualTo(1));
+            Assert.That(request.RequestedTaskIds, Is.EquivalentTo(new[] { "task-1" }));
             Assert.That(batch.Tasks?.Count(), Is.EqualTo(1));
+            Assert.That(batch.Batch?.Tasks.Count, Is.EqualTo(1));
             Assert.That(settingsUpdated.Settings.FocusMinutes, Is.EqualTo(42));
         });
     }

--- a/ShuffleTask.Application.Tests/SyncExchangeServiceTests.cs
+++ b/ShuffleTask.Application.Tests/SyncExchangeServiceTests.cs
@@ -16,28 +16,21 @@ public class SyncExchangeServiceTests
     [Test]
     public async Task ManifestExchange_RequestsAndReturnsRemoteOnlyTasks()
     {
-        var peerAStorage = new InMemoryStorageService();
-        await peerAStorage.InitializeAsync();
+        var peerA = await CreateHarnessAsync();
+        var peerB = await CreateHarnessAsync(CreateTask("only-b", "Remote Only", version: 2, DeviceB));
 
-        var peerBStorage = new InMemoryStorageService();
-        await peerBStorage.InitializeAsync();
-        await peerBStorage.AddTaskAsync(CreateTask("only-b", "Remote Only", version: 2, DeviceB));
+        var manifestFromB = await peerB.Exchange.BuildManifestAsync(CreateContext("peer-b", DeviceB));
+        var requestFromA = await peerA.Exchange.BuildTaskRequestAsync(manifestFromB, CreateContext("peer-a", DeviceA));
+        var batchFromB = await peerB.Exchange.BuildTaskBatchAsync(requestFromA, CreateContext("peer-b", DeviceB));
 
-        var peerA = new SyncExchangeService(peerAStorage);
-        var peerB = new SyncExchangeService(peerBStorage);
+        await peerA.Exchange.ApplyTaskBatchAsync(batchFromB);
 
-        var manifestFromB = await peerB.BuildManifestAsync(CreateContext("peer-b", DeviceB));
-        var requestFromA = await peerA.BuildTaskRequestAsync(manifestFromB, CreateContext("peer-a", DeviceA));
-        var batchFromB = await peerB.BuildTaskBatchAsync(requestFromA, CreateContext("peer-b", DeviceB));
-
-        await peerA.ApplyTaskBatchAsync(batchFromB);
-
-        var received = await peerAStorage.GetTaskAsync("only-b");
+        var received = await peerA.Storage.GetTaskAsync("only-b");
 
         Assert.Multiple(() =>
         {
             Assert.That(requestFromA.RequestedTaskIds, Is.EquivalentTo(new[] { "only-b" }));
-            Assert.That(batchFromB.Tasks.Select(task => task.Id), Is.EquivalentTo(new[] { "only-b" }));
+            Assert.That(TaskIds(batchFromB), Is.EquivalentTo(new[] { "only-b" }));
             Assert.That(received, Is.Not.Null);
             Assert.That(received!.Title, Is.EqualTo("Remote Only"));
             Assert.That(received.EventVersion, Is.EqualTo(2));
@@ -47,47 +40,35 @@ public class SyncExchangeServiceTests
     [Test]
     public async Task BuildTaskBatchAsync_ReturnsExplicitlyRequestedEqualLocalTasks()
     {
-        var storage = new InMemoryStorageService();
-        await storage.InitializeAsync();
-        await storage.AddTaskAsync(CreateTask("shared", "Local", version: 3, DeviceB));
+        var harness = await CreateHarnessAsync(CreateTask("shared", "Local", version: 3, DeviceB));
 
-        var exchange = new SyncExchangeService(storage);
-        var request = new SyncTaskRequest("peer-a", UserId, DeviceA, new[] { "shared" });
+        var batch = await harness.Exchange.BuildTaskBatchAsync(CreateRequest("shared"), CreateContext("peer-b", DeviceB));
 
-        var batch = await exchange.BuildTaskBatchAsync(request, CreateContext("peer-b", DeviceB));
-
-        Assert.That(batch.Tasks.Select(task => task.Id), Is.EquivalentTo(new[] { "shared" }));
+        Assert.That(TaskIds(batch), Is.EquivalentTo(new[] { "shared" }));
     }
 
     [Test]
     public async Task BuildLocalTaskBatchAsync_ReturnsTasksMissingFromRemoteManifest()
     {
-        var storage = new InMemoryStorageService();
-        await storage.InitializeAsync();
-        await storage.AddTaskAsync(CreateTask("only-b", "Local Only", version: 2, DeviceB));
-
-        var exchange = new SyncExchangeService(storage);
+        var harness = await CreateHarnessAsync(CreateTask("only-b", "Local Only", version: 2, DeviceB));
         var remoteManifest = new SyncManifest("peer-a", UserId, DeviceA, schemaVersion: 1, Array.Empty<SyncManifestEntry>());
 
-        var batch = await exchange.BuildLocalTaskBatchAsync(remoteManifest, CreateContext("peer-b", DeviceB));
+        var batch = await harness.Exchange.BuildLocalTaskBatchAsync(remoteManifest, CreateContext("peer-b", DeviceB));
 
-        Assert.That(batch.Tasks.Select(task => task.Id), Is.EquivalentTo(new[] { "only-b" }));
+        Assert.That(TaskIds(batch), Is.EquivalentTo(new[] { "only-b" }));
     }
 
     [Test]
     public async Task ApplyTaskBatchAsync_IgnoresStaleTasks()
     {
-        var storage = new InMemoryStorageService();
-        await storage.InitializeAsync();
-        await storage.AddTaskAsync(CreateTask("shared", "Latest", version: 5, DeviceA));
+        var harness = await CreateHarnessAsync(CreateTask("shared", "Latest", version: 5, DeviceA));
 
         var staleTask = CreateTask("shared", "Stale", version: 3, DeviceB);
         var batch = new SyncTaskBatch("peer-b", UserId, DeviceB, new[] { staleTask });
 
-        var exchange = new SyncExchangeService(storage);
-        await exchange.ApplyTaskBatchAsync(batch);
+        await harness.Exchange.ApplyTaskBatchAsync(batch);
 
-        var stored = await storage.GetTaskAsync("shared");
+        var stored = await harness.Storage.GetTaskAsync("shared");
 
         Assert.Multiple(() =>
         {
@@ -99,39 +80,58 @@ public class SyncExchangeServiceTests
     [Test]
     public async Task BuildTaskBatchAsync_IgnoresTasksOutsideRequestedUserScope()
     {
-        var storage = new InMemoryStorageService();
-        await storage.InitializeAsync();
-        await storage.AddTaskAsync(new TaskItem
-        {
-            Id = "other-user-task",
-            Title = "Other User",
-            UserId = "user-b",
-            DeviceId = DeviceB,
-            EventVersion = 1,
-            CreatedAt = BaseTimeUtc,
-            UpdatedAt = BaseTimeUtc,
-        });
+        var harness = await CreateHarnessAsync(CreateTask(
+            "other-user-task",
+            "Other User",
+            version: 1,
+            DeviceB,
+            userId: "user-b"));
 
-        var exchange = new SyncExchangeService(storage);
-        var request = new SyncTaskRequest("peer-a", UserId, DeviceA, new[] { "other-user-task" });
-
-        var batch = await exchange.BuildTaskBatchAsync(request, CreateContext("peer-b", DeviceB));
+        var batch = await harness.Exchange.BuildTaskBatchAsync(
+            CreateRequest("other-user-task"),
+            CreateContext("peer-b", DeviceB));
 
         Assert.That(batch.Tasks, Is.Empty);
     }
 
+    private static async Task<ExchangeHarness> CreateHarnessAsync(params TaskItem[] tasks)
+    {
+        var storage = new InMemoryStorageService();
+        await storage.InitializeAsync();
+
+        foreach (var task in tasks)
+        {
+            await storage.AddTaskAsync(task);
+        }
+
+        return new ExchangeHarness(storage, new SyncExchangeService(storage));
+    }
+
+    private static SyncTaskRequest CreateRequest(params string[] taskIds)
+        => new("peer-a", UserId, DeviceA, taskIds);
+
     private static SyncPeerContext CreateContext(string peerId, string deviceId)
         => new(peerId, UserId, deviceId);
 
-    private static TaskItem CreateTask(string id, string title, int version, string deviceId)
+    private static IEnumerable<string> TaskIds(SyncTaskBatch batch)
+        => batch.Tasks.Select(task => task.Id);
+
+    private static TaskItem CreateTask(
+        string id,
+        string title,
+        int version,
+        string deviceId,
+        string? userId = UserId)
         => new()
         {
             Id = id,
             Title = title,
-            UserId = UserId,
+            UserId = userId,
             DeviceId = deviceId,
             EventVersion = version,
             CreatedAt = BaseTimeUtc.AddMinutes(-version),
             UpdatedAt = BaseTimeUtc.AddMinutes(version),
         };
+
+    private sealed record ExchangeHarness(InMemoryStorageService Storage, SyncExchangeService Exchange);
 }

--- a/ShuffleTask.Application.Tests/SyncExchangeServiceTests.cs
+++ b/ShuffleTask.Application.Tests/SyncExchangeServiceTests.cs
@@ -1,0 +1,137 @@
+using NUnit.Framework;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Services;
+using ShuffleTask.Application.Tests.TestDoubles;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Application.Tests;
+
+public class SyncExchangeServiceTests
+{
+    private const string UserId = "user-a";
+    private const string DeviceA = "device-a";
+    private const string DeviceB = "device-b";
+    private static readonly DateTime BaseTimeUtc = new(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task ManifestExchange_RequestsAndReturnsRemoteOnlyTasks()
+    {
+        var peerAStorage = new InMemoryStorageService();
+        await peerAStorage.InitializeAsync();
+
+        var peerBStorage = new InMemoryStorageService();
+        await peerBStorage.InitializeAsync();
+        await peerBStorage.AddTaskAsync(CreateTask("only-b", "Remote Only", version: 2, DeviceB));
+
+        var peerA = new SyncExchangeService(peerAStorage);
+        var peerB = new SyncExchangeService(peerBStorage);
+
+        var manifestFromB = await peerB.BuildManifestAsync(CreateContext("peer-b", DeviceB));
+        var requestFromA = await peerA.BuildTaskRequestAsync(manifestFromB, CreateContext("peer-a", DeviceA));
+        var batchFromB = await peerB.BuildTaskBatchAsync(requestFromA, CreateContext("peer-b", DeviceB));
+
+        await peerA.ApplyTaskBatchAsync(batchFromB);
+
+        var received = await peerAStorage.GetTaskAsync("only-b");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(requestFromA.RequestedTaskIds, Is.EquivalentTo(new[] { "only-b" }));
+            Assert.That(batchFromB.Tasks.Select(task => task.Id), Is.EquivalentTo(new[] { "only-b" }));
+            Assert.That(received, Is.Not.Null);
+            Assert.That(received!.Title, Is.EqualTo("Remote Only"));
+            Assert.That(received.EventVersion, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public async Task BuildTaskBatchAsync_ReturnsExplicitlyRequestedEqualLocalTasks()
+    {
+        var storage = new InMemoryStorageService();
+        await storage.InitializeAsync();
+        await storage.AddTaskAsync(CreateTask("shared", "Local", version: 3, DeviceB));
+
+        var exchange = new SyncExchangeService(storage);
+        var request = new SyncTaskRequest("peer-a", UserId, DeviceA, new[] { "shared" });
+
+        var batch = await exchange.BuildTaskBatchAsync(request, CreateContext("peer-b", DeviceB));
+
+        Assert.That(batch.Tasks.Select(task => task.Id), Is.EquivalentTo(new[] { "shared" }));
+    }
+
+    [Test]
+    public async Task BuildLocalTaskBatchAsync_ReturnsTasksMissingFromRemoteManifest()
+    {
+        var storage = new InMemoryStorageService();
+        await storage.InitializeAsync();
+        await storage.AddTaskAsync(CreateTask("only-b", "Local Only", version: 2, DeviceB));
+
+        var exchange = new SyncExchangeService(storage);
+        var remoteManifest = new SyncManifest("peer-a", UserId, DeviceA, schemaVersion: 1, Array.Empty<SyncManifestEntry>());
+
+        var batch = await exchange.BuildLocalTaskBatchAsync(remoteManifest, CreateContext("peer-b", DeviceB));
+
+        Assert.That(batch.Tasks.Select(task => task.Id), Is.EquivalentTo(new[] { "only-b" }));
+    }
+
+    [Test]
+    public async Task ApplyTaskBatchAsync_IgnoresStaleTasks()
+    {
+        var storage = new InMemoryStorageService();
+        await storage.InitializeAsync();
+        await storage.AddTaskAsync(CreateTask("shared", "Latest", version: 5, DeviceA));
+
+        var staleTask = CreateTask("shared", "Stale", version: 3, DeviceB);
+        var batch = new SyncTaskBatch("peer-b", UserId, DeviceB, new[] { staleTask });
+
+        var exchange = new SyncExchangeService(storage);
+        await exchange.ApplyTaskBatchAsync(batch);
+
+        var stored = await storage.GetTaskAsync("shared");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stored!.Title, Is.EqualTo("Latest"));
+            Assert.That(stored.EventVersion, Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public async Task BuildTaskBatchAsync_IgnoresTasksOutsideRequestedUserScope()
+    {
+        var storage = new InMemoryStorageService();
+        await storage.InitializeAsync();
+        await storage.AddTaskAsync(new TaskItem
+        {
+            Id = "other-user-task",
+            Title = "Other User",
+            UserId = "user-b",
+            DeviceId = DeviceB,
+            EventVersion = 1,
+            CreatedAt = BaseTimeUtc,
+            UpdatedAt = BaseTimeUtc,
+        });
+
+        var exchange = new SyncExchangeService(storage);
+        var request = new SyncTaskRequest("peer-a", UserId, DeviceA, new[] { "other-user-task" });
+
+        var batch = await exchange.BuildTaskBatchAsync(request, CreateContext("peer-b", DeviceB));
+
+        Assert.That(batch.Tasks, Is.Empty);
+    }
+
+    private static SyncPeerContext CreateContext(string peerId, string deviceId)
+        => new(peerId, UserId, deviceId);
+
+    private static TaskItem CreateTask(string id, string title, int version, string deviceId)
+        => new()
+        {
+            Id = id,
+            Title = title,
+            UserId = UserId,
+            DeviceId = deviceId,
+            EventVersion = version,
+            CreatedAt = BaseTimeUtc.AddMinutes(-version),
+            UpdatedAt = BaseTimeUtc.AddMinutes(version),
+        };
+}

--- a/ShuffleTask.Application/Abstractions/ISyncExchangeService.cs
+++ b/ShuffleTask.Application/Abstractions/ISyncExchangeService.cs
@@ -1,0 +1,27 @@
+using ShuffleTask.Application.Models;
+
+namespace ShuffleTask.Application.Abstractions;
+
+public interface ISyncExchangeService
+{
+    Task<SyncManifest> BuildManifestAsync(SyncPeerContext localPeer, CancellationToken cancellationToken = default);
+
+    Task<SyncTaskRequest> BuildTaskRequestAsync(
+        SyncManifest remoteManifest,
+        SyncPeerContext localPeer,
+        CancellationToken cancellationToken = default);
+
+    Task<SyncTaskBatch> BuildTaskBatchAsync(
+        SyncTaskRequest request,
+        SyncPeerContext localPeer,
+        CancellationToken cancellationToken = default);
+
+    Task<SyncTaskBatch> BuildLocalTaskBatchAsync(
+        SyncManifest remoteManifest,
+        SyncPeerContext localPeer,
+        CancellationToken cancellationToken = default);
+
+    Task<SyncApplyResult> ApplyTaskBatchAsync(
+        SyncTaskBatch batch,
+        CancellationToken cancellationToken = default);
+}

--- a/ShuffleTask.Application/Abstractions/ISyncTransportAdapter.cs
+++ b/ShuffleTask.Application/Abstractions/ISyncTransportAdapter.cs
@@ -1,0 +1,15 @@
+using ShuffleTask.Application.Models;
+
+namespace ShuffleTask.Application.Abstractions;
+
+public interface ISyncTransportAdapter
+{
+    event EventHandler<SyncEnvelopeReceivedEventArgs>? EnvelopeReceived;
+
+    Task SendAsync(SyncEnvelope envelope, CancellationToken cancellationToken = default);
+}
+
+public sealed class SyncEnvelopeReceivedEventArgs(SyncEnvelope envelope) : EventArgs
+{
+    public SyncEnvelope Envelope { get; } = envelope ?? throw new ArgumentNullException(nameof(envelope));
+}

--- a/ShuffleTask.Application/Events/TaskBatchResponse.cs
+++ b/ShuffleTask.Application/Events/TaskBatchResponse.cs
@@ -1,13 +1,29 @@
 using ShuffleTask.Domain.Entities;
+using ShuffleTask.Application.Models;
 using Yaref92.Events;
 
 namespace ShuffleTask.Application.Events;
 
-public class TaskBatchResponse(IEnumerable<TaskItem> tasks, string deviceId, string? userId) : DomainEventBase()
+public class TaskBatchResponse : DomainEventBase
 {
-    public IEnumerable<TaskItem> Tasks { get; set; } = tasks;
+    public TaskBatchResponse(IEnumerable<TaskItem> tasks, string deviceId, string? userId)
+        : this(new SyncTaskBatch(deviceId, userId, deviceId, tasks), deviceId, userId)
+    {
+    }
 
-    public string DeviceId { get; set; } = deviceId;
+    public TaskBatchResponse(SyncTaskBatch batch, string deviceId, string? userId)
+    {
+        Batch = batch ?? throw new ArgumentNullException(nameof(batch));
+        Tasks = Batch.Tasks;
+        DeviceId = deviceId;
+        UserId = userId;
+    }
 
-    public string? UserId { get; set; } = userId;
+    public SyncTaskBatch? Batch { get; set; }
+
+    public IEnumerable<TaskItem> Tasks { get; set; } = Array.Empty<TaskItem>();
+
+    public string DeviceId { get; set; } = string.Empty;
+
+    public string? UserId { get; set; }
 }

--- a/ShuffleTask.Application/Events/TaskManifestRequest.cs
+++ b/ShuffleTask.Application/Events/TaskManifestRequest.cs
@@ -3,11 +3,30 @@ using Yaref92.Events;
 
 namespace ShuffleTask.Application.Events;
 
-public class TaskManifestRequest(IEnumerable<TaskManifestEntry> manifest, string deviceId, string? userId) : DomainEventBase()
+public class TaskManifestRequest : DomainEventBase
 {
-    public IEnumerable<TaskManifestEntry> Manifest { get; set; } = manifest;
+    public TaskManifestRequest(IEnumerable<string> requestedTaskIds, string deviceId, string? userId)
+    {
+        RequestedTaskIds = requestedTaskIds?
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray() ?? Array.Empty<string>();
+        DeviceId = deviceId;
+        UserId = userId;
+    }
 
-    public string DeviceId { get; set; } = deviceId;
+    public TaskManifestRequest(IEnumerable<TaskManifestEntry> manifest, string deviceId, string? userId)
+        : this(manifest?.Select(entry => entry.TaskId) ?? Array.Empty<string>(), deviceId, userId)
+    {
+        Manifest = manifest ?? Array.Empty<TaskManifestEntry>();
+    }
 
-    public string? UserId { get; set; } = userId;
+    public IEnumerable<string> RequestedTaskIds { get; set; } = Array.Empty<string>();
+
+    public IEnumerable<TaskManifestEntry>? Manifest { get; set; }
+
+    public string DeviceId { get; set; } = string.Empty;
+
+    public string? UserId { get; set; }
 }

--- a/ShuffleTask.Application/Events/TaskManifestRequest.cs
+++ b/ShuffleTask.Application/Events/TaskManifestRequest.cs
@@ -7,11 +7,7 @@ public class TaskManifestRequest : DomainEventBase
 {
     public TaskManifestRequest(IEnumerable<string> requestedTaskIds, string deviceId, string? userId)
     {
-        RequestedTaskIds = requestedTaskIds?
-            .Where(id => !string.IsNullOrWhiteSpace(id))
-            .Select(id => id.Trim())
-            .Distinct(StringComparer.Ordinal)
-            .ToArray() ?? Array.Empty<string>();
+        RequestedTaskIds = SyncIdentity.DistinctIds(requestedTaskIds);
         DeviceId = deviceId;
         UserId = userId;
     }

--- a/ShuffleTask.Application/Models/PeerSession.cs
+++ b/ShuffleTask.Application/Models/PeerSession.cs
@@ -1,0 +1,10 @@
+namespace ShuffleTask.Application.Models;
+
+public sealed record PeerSession(
+    string PeerId,
+    string SharedSecret,
+    DateTime LastSeenUtc,
+    IReadOnlyCollection<string> TransportCapabilities,
+    string? UserId = null,
+    string? DeviceId = null,
+    string? RendezvousRoomId = null);

--- a/ShuffleTask.Application/Models/SyncEnvelope.cs
+++ b/ShuffleTask.Application/Models/SyncEnvelope.cs
@@ -1,0 +1,30 @@
+namespace ShuffleTask.Application.Models;
+
+public sealed class SyncEnvelope
+{
+    public Guid EnvelopeId { get; init; } = Guid.NewGuid();
+
+    public SyncEnvelopeKind Kind { get; init; }
+
+    public SyncManifest? Manifest { get; init; }
+
+    public SyncTaskRequest? TaskRequest { get; init; }
+
+    public SyncTaskBatch? TaskBatch { get; init; }
+
+    public static SyncEnvelope ForManifest(SyncManifest manifest)
+        => new() { Kind = SyncEnvelopeKind.Manifest, Manifest = manifest };
+
+    public static SyncEnvelope ForTaskRequest(SyncTaskRequest request)
+        => new() { Kind = SyncEnvelopeKind.TaskRequest, TaskRequest = request };
+
+    public static SyncEnvelope ForTaskBatch(SyncTaskBatch batch)
+        => new() { Kind = SyncEnvelopeKind.TaskBatch, TaskBatch = batch };
+}
+
+public enum SyncEnvelopeKind
+{
+    Manifest = 0,
+    TaskRequest = 1,
+    TaskBatch = 2,
+}

--- a/ShuffleTask.Application/Models/SyncIdentity.cs
+++ b/ShuffleTask.Application/Models/SyncIdentity.cs
@@ -1,0 +1,17 @@
+namespace ShuffleTask.Application.Models;
+
+internal static class SyncIdentity
+{
+    public static string Required(string? value)
+        => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+
+    public static string? Optional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public static IReadOnlyCollection<string> DistinctIds(IEnumerable<string>? values)
+        => values?
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray() ?? Array.Empty<string>();
+}

--- a/ShuffleTask.Application/Models/SyncManifest.cs
+++ b/ShuffleTask.Application/Models/SyncManifest.cs
@@ -11,9 +11,9 @@ public sealed class SyncManifest
         int schemaVersion,
         IEnumerable<SyncManifestEntry> entries)
     {
-        PeerId = string.IsNullOrWhiteSpace(peerId) ? string.Empty : peerId.Trim();
-        UserId = string.IsNullOrWhiteSpace(userId) ? null : userId.Trim();
-        DeviceId = string.IsNullOrWhiteSpace(deviceId) ? string.Empty : deviceId.Trim();
+        PeerId = SyncIdentity.Required(peerId);
+        UserId = SyncIdentity.Optional(userId);
+        DeviceId = SyncIdentity.Required(deviceId);
         SchemaVersion = schemaVersion;
         Entries = entries?.ToArray() ?? Array.Empty<SyncManifestEntry>();
     }

--- a/ShuffleTask.Application/Models/SyncManifest.cs
+++ b/ShuffleTask.Application/Models/SyncManifest.cs
@@ -2,7 +2,7 @@ using ShuffleTask.Domain.Entities;
 
 namespace ShuffleTask.Application.Models;
 
-public sealed class SyncManifest
+public sealed class SyncManifest : SyncPeerMessage
 {
     public SyncManifest(
         string peerId,
@@ -10,19 +10,11 @@ public sealed class SyncManifest
         string deviceId,
         int schemaVersion,
         IEnumerable<SyncManifestEntry> entries)
+        : base(peerId, userId, deviceId)
     {
-        PeerId = SyncIdentity.Required(peerId);
-        UserId = SyncIdentity.Optional(userId);
-        DeviceId = SyncIdentity.Required(deviceId);
         SchemaVersion = schemaVersion;
         Entries = entries?.ToArray() ?? Array.Empty<SyncManifestEntry>();
     }
-
-    public string PeerId { get; }
-
-    public string? UserId { get; }
-
-    public string DeviceId { get; }
 
     public int SchemaVersion { get; }
 

--- a/ShuffleTask.Application/Models/SyncManifest.cs
+++ b/ShuffleTask.Application/Models/SyncManifest.cs
@@ -1,0 +1,64 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Application.Models;
+
+public sealed class SyncManifest
+{
+    public SyncManifest(
+        string peerId,
+        string? userId,
+        string deviceId,
+        int schemaVersion,
+        IEnumerable<SyncManifestEntry> entries)
+    {
+        PeerId = string.IsNullOrWhiteSpace(peerId) ? string.Empty : peerId.Trim();
+        UserId = string.IsNullOrWhiteSpace(userId) ? null : userId.Trim();
+        DeviceId = string.IsNullOrWhiteSpace(deviceId) ? string.Empty : deviceId.Trim();
+        SchemaVersion = schemaVersion;
+        Entries = entries?.ToArray() ?? Array.Empty<SyncManifestEntry>();
+    }
+
+    public string PeerId { get; }
+
+    public string? UserId { get; }
+
+    public string DeviceId { get; }
+
+    public int SchemaVersion { get; }
+
+    public IReadOnlyCollection<SyncManifestEntry> Entries { get; }
+}
+
+public sealed class SyncManifestEntry
+{
+    public SyncManifestEntry()
+    {
+    }
+
+    public SyncManifestEntry(string taskId, int eventVersion, DateTime updatedAtUtc, bool deleted = false)
+    {
+        TaskId = taskId;
+        EventVersion = eventVersion;
+        UpdatedAtUtc = updatedAtUtc;
+        Deleted = deleted;
+    }
+
+    public string TaskId { get; set; } = string.Empty;
+
+    public int EventVersion { get; set; }
+
+    public DateTime UpdatedAtUtc { get; set; }
+
+    public bool Deleted { get; set; }
+
+    public static SyncManifestEntry From(TaskItem task)
+        => new(task.Id, task.EventVersion, EnsureUtc(task.UpdatedAt));
+
+    private static DateTime EnsureUtc(DateTime value)
+        => value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+}

--- a/ShuffleTask.Application/Models/SyncPeerContext.cs
+++ b/ShuffleTask.Application/Models/SyncPeerContext.cs
@@ -2,9 +2,9 @@ namespace ShuffleTask.Application.Models;
 
 public sealed record SyncPeerContext(string PeerId, string? UserId, string DeviceId)
 {
-    public string PeerId { get; init; } = string.IsNullOrWhiteSpace(PeerId) ? string.Empty : PeerId.Trim();
+    public string PeerId { get; init; } = SyncIdentity.Required(PeerId);
 
-    public string? UserId { get; init; } = string.IsNullOrWhiteSpace(UserId) ? null : UserId.Trim();
+    public string? UserId { get; init; } = SyncIdentity.Optional(UserId);
 
-    public string DeviceId { get; init; } = string.IsNullOrWhiteSpace(DeviceId) ? string.Empty : DeviceId.Trim();
+    public string DeviceId { get; init; } = SyncIdentity.Required(DeviceId);
 }

--- a/ShuffleTask.Application/Models/SyncPeerContext.cs
+++ b/ShuffleTask.Application/Models/SyncPeerContext.cs
@@ -1,0 +1,10 @@
+namespace ShuffleTask.Application.Models;
+
+public sealed record SyncPeerContext(string PeerId, string? UserId, string DeviceId)
+{
+    public string PeerId { get; init; } = string.IsNullOrWhiteSpace(PeerId) ? string.Empty : PeerId.Trim();
+
+    public string? UserId { get; init; } = string.IsNullOrWhiteSpace(UserId) ? null : UserId.Trim();
+
+    public string DeviceId { get; init; } = string.IsNullOrWhiteSpace(DeviceId) ? string.Empty : DeviceId.Trim();
+}

--- a/ShuffleTask.Application/Models/SyncPeerMessage.cs
+++ b/ShuffleTask.Application/Models/SyncPeerMessage.cs
@@ -1,0 +1,17 @@
+namespace ShuffleTask.Application.Models;
+
+public abstract class SyncPeerMessage
+{
+    protected SyncPeerMessage(string peerId, string? userId, string deviceId)
+    {
+        PeerId = SyncIdentity.Required(peerId);
+        UserId = SyncIdentity.Optional(userId);
+        DeviceId = SyncIdentity.Required(deviceId);
+    }
+
+    public string PeerId { get; }
+
+    public string? UserId { get; }
+
+    public string DeviceId { get; }
+}

--- a/ShuffleTask.Application/Models/SyncTaskBatch.cs
+++ b/ShuffleTask.Application/Models/SyncTaskBatch.cs
@@ -1,0 +1,35 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Application.Models;
+
+public sealed class SyncTaskBatch
+{
+    public SyncTaskBatch(
+        string peerId,
+        string? userId,
+        string deviceId,
+        IEnumerable<TaskItem> tasks,
+        IEnumerable<string>? deletedTaskIds = null)
+    {
+        PeerId = string.IsNullOrWhiteSpace(peerId) ? string.Empty : peerId.Trim();
+        UserId = string.IsNullOrWhiteSpace(userId) ? null : userId.Trim();
+        DeviceId = string.IsNullOrWhiteSpace(deviceId) ? string.Empty : deviceId.Trim();
+        Tasks = tasks?.Select(TaskItem.Clone).ToArray() ?? Array.Empty<TaskItem>();
+        DeletedTaskIds = deletedTaskIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Distinct().ToArray()
+            ?? Array.Empty<string>();
+    }
+
+    public string PeerId { get; }
+
+    public string? UserId { get; }
+
+    public string DeviceId { get; }
+
+    public IReadOnlyCollection<TaskItem> Tasks { get; }
+
+    public IReadOnlyCollection<string> DeletedTaskIds { get; }
+}
+
+public sealed record SyncApplyResult(
+    IReadOnlyCollection<string> AppliedTaskIds,
+    IReadOnlyCollection<string> IgnoredTaskIds);

--- a/ShuffleTask.Application/Models/SyncTaskBatch.cs
+++ b/ShuffleTask.Application/Models/SyncTaskBatch.cs
@@ -11,12 +11,11 @@ public sealed class SyncTaskBatch
         IEnumerable<TaskItem> tasks,
         IEnumerable<string>? deletedTaskIds = null)
     {
-        PeerId = string.IsNullOrWhiteSpace(peerId) ? string.Empty : peerId.Trim();
-        UserId = string.IsNullOrWhiteSpace(userId) ? null : userId.Trim();
-        DeviceId = string.IsNullOrWhiteSpace(deviceId) ? string.Empty : deviceId.Trim();
+        PeerId = SyncIdentity.Required(peerId);
+        UserId = SyncIdentity.Optional(userId);
+        DeviceId = SyncIdentity.Required(deviceId);
         Tasks = tasks?.Select(TaskItem.Clone).ToArray() ?? Array.Empty<TaskItem>();
-        DeletedTaskIds = deletedTaskIds?.Where(id => !string.IsNullOrWhiteSpace(id)).Distinct().ToArray()
-            ?? Array.Empty<string>();
+        DeletedTaskIds = SyncIdentity.DistinctIds(deletedTaskIds);
     }
 
     public string PeerId { get; }

--- a/ShuffleTask.Application/Models/SyncTaskBatch.cs
+++ b/ShuffleTask.Application/Models/SyncTaskBatch.cs
@@ -2,7 +2,7 @@ using ShuffleTask.Domain.Entities;
 
 namespace ShuffleTask.Application.Models;
 
-public sealed class SyncTaskBatch
+public sealed class SyncTaskBatch : SyncPeerMessage
 {
     public SyncTaskBatch(
         string peerId,
@@ -10,19 +10,11 @@ public sealed class SyncTaskBatch
         string deviceId,
         IEnumerable<TaskItem> tasks,
         IEnumerable<string>? deletedTaskIds = null)
+        : base(peerId, userId, deviceId)
     {
-        PeerId = SyncIdentity.Required(peerId);
-        UserId = SyncIdentity.Optional(userId);
-        DeviceId = SyncIdentity.Required(deviceId);
         Tasks = tasks?.Select(TaskItem.Clone).ToArray() ?? Array.Empty<TaskItem>();
         DeletedTaskIds = SyncIdentity.DistinctIds(deletedTaskIds);
     }
-
-    public string PeerId { get; }
-
-    public string? UserId { get; }
-
-    public string DeviceId { get; }
 
     public IReadOnlyCollection<TaskItem> Tasks { get; }
 

--- a/ShuffleTask.Application/Models/SyncTaskRequest.cs
+++ b/ShuffleTask.Application/Models/SyncTaskRequest.cs
@@ -1,0 +1,24 @@
+namespace ShuffleTask.Application.Models;
+
+public sealed class SyncTaskRequest
+{
+    public SyncTaskRequest(string peerId, string? userId, string deviceId, IEnumerable<string> requestedTaskIds)
+    {
+        PeerId = string.IsNullOrWhiteSpace(peerId) ? string.Empty : peerId.Trim();
+        UserId = string.IsNullOrWhiteSpace(userId) ? null : userId.Trim();
+        DeviceId = string.IsNullOrWhiteSpace(deviceId) ? string.Empty : deviceId.Trim();
+        RequestedTaskIds = requestedTaskIds?
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray() ?? Array.Empty<string>();
+    }
+
+    public string PeerId { get; }
+
+    public string? UserId { get; }
+
+    public string DeviceId { get; }
+
+    public IReadOnlyCollection<string> RequestedTaskIds { get; }
+}

--- a/ShuffleTask.Application/Models/SyncTaskRequest.cs
+++ b/ShuffleTask.Application/Models/SyncTaskRequest.cs
@@ -4,14 +4,10 @@ public sealed class SyncTaskRequest
 {
     public SyncTaskRequest(string peerId, string? userId, string deviceId, IEnumerable<string> requestedTaskIds)
     {
-        PeerId = string.IsNullOrWhiteSpace(peerId) ? string.Empty : peerId.Trim();
-        UserId = string.IsNullOrWhiteSpace(userId) ? null : userId.Trim();
-        DeviceId = string.IsNullOrWhiteSpace(deviceId) ? string.Empty : deviceId.Trim();
-        RequestedTaskIds = requestedTaskIds?
-            .Where(id => !string.IsNullOrWhiteSpace(id))
-            .Select(id => id.Trim())
-            .Distinct(StringComparer.Ordinal)
-            .ToArray() ?? Array.Empty<string>();
+        PeerId = SyncIdentity.Required(peerId);
+        UserId = SyncIdentity.Optional(userId);
+        DeviceId = SyncIdentity.Required(deviceId);
+        RequestedTaskIds = SyncIdentity.DistinctIds(requestedTaskIds);
     }
 
     public string PeerId { get; }

--- a/ShuffleTask.Application/Models/SyncTaskRequest.cs
+++ b/ShuffleTask.Application/Models/SyncTaskRequest.cs
@@ -1,20 +1,12 @@
 namespace ShuffleTask.Application.Models;
 
-public sealed class SyncTaskRequest
+public sealed class SyncTaskRequest : SyncPeerMessage
 {
     public SyncTaskRequest(string peerId, string? userId, string deviceId, IEnumerable<string> requestedTaskIds)
+        : base(peerId, userId, deviceId)
     {
-        PeerId = SyncIdentity.Required(peerId);
-        UserId = SyncIdentity.Optional(userId);
-        DeviceId = SyncIdentity.Required(deviceId);
         RequestedTaskIds = SyncIdentity.DistinctIds(requestedTaskIds);
     }
-
-    public string PeerId { get; }
-
-    public string? UserId { get; }
-
-    public string DeviceId { get; }
 
     public IReadOnlyCollection<string> RequestedTaskIds { get; }
 }

--- a/ShuffleTask.Application/Services/NetworkSyncService.cs
+++ b/ShuffleTask.Application/Services/NetworkSyncService.cs
@@ -19,7 +19,7 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
 #if DEBUG
     private readonly INotificationService? _notifications;
 #endif
-    private readonly PeerSyncCoordinator _coordinator;
+    private readonly ISyncExchangeService _syncExchange;
     private readonly AsyncLocal<bool> _suppressBroadcast = new();
     private readonly SemaphoreSlim _initLock = new(1, 1);
     private readonly NetworkedEventAggregator _aggregator;
@@ -39,6 +39,7 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
         AppSettings appSettings,
         NetworkedEventAggregator aggregator,
         IEventTransport transport,
+        ISyncExchangeService syncExchange,
         ILogger<NetworkSyncService>? logger = null,
         INotificationService? notifications = null)
     {
@@ -46,11 +47,11 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
         _appSettings = appSettings ?? throw new ArgumentNullException(nameof(appSettings));
         _aggregator = aggregator ?? throw new ArgumentNullException(nameof(aggregator));
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _syncExchange = syncExchange ?? throw new ArgumentNullException(nameof(syncExchange));
         _logger = logger;
 #if DEBUG
         _notifications = notifications;
 #endif
-        _coordinator = new PeerSyncCoordinator(_storage);
         DeviceId = Environment.MachineName;
         UserId = Environment.UserName;
     }
@@ -422,31 +423,35 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
 
         await DebugToastAsync("Manifest announced", $"Received manifest announcement from {domainEvent.DeviceId}.").ConfigureAwait(false);
 
-        var manifest = domainEvent.Manifest.ToList();
         using var linkedCts = LinkToConnection(cancellationToken);
+        var remoteManifest = BuildRemoteManifest(domainEvent);
+        var localPeer = CreateLocalPeerContext();
 
-        var comparison = await _coordinator
-            .CompareManifestAsync(manifest, UserId, DeviceId)
+        var request = await _syncExchange
+            .BuildTaskRequestAsync(remoteManifest, localPeer, linkedCts.Token)
             .WaitAsync(linkedCts.Token)
             .ConfigureAwait(false);
 
-        var tasksToRequest = comparison.GetTasksToRequest();
-        if (tasksToRequest.Count > 0)
+        if (request.RequestedTaskIds.Count > 0)
         {
-            await PublishManifestRequestAsync(manifest, tasksToRequest, linkedCts.Token).ConfigureAwait(false);
+            await PublishManifestRequestAsync(request, linkedCts.Token).ConfigureAwait(false);
         }
 
-        var tasksToAdvertise = comparison.GetTasksToAdvertise();
-        if (tasksToAdvertise.Count > 0)
+        var localBatch = await _syncExchange
+            .BuildLocalTaskBatchAsync(remoteManifest, localPeer, linkedCts.Token)
+            .WaitAsync(linkedCts.Token)
+            .ConfigureAwait(false);
+
+        if (localBatch.Tasks.Count > 0)
         {
-            await PublishTaskBatchesAsync(tasksToAdvertise, linkedCts.Token).ConfigureAwait(false);
+            await PublishTaskBatchesAsync(localBatch, linkedCts.Token).ConfigureAwait(false);
         }
     }
 
     internal async Task HandleManifestRequestAsync(TaskManifestRequest domainEvent, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(domainEvent);
-        if (domainEvent.Manifest is null)
+        if (domainEvent.RequestedTaskIds is null)
         {
             return;
         }
@@ -454,30 +459,35 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
         await DebugToastAsync("Manifest request", $"Received manifest request from {domainEvent.DeviceId}.").ConfigureAwait(false);
 
         using var linkedCts = LinkToConnection(cancellationToken);
+        var request = new SyncTaskRequest(
+            domainEvent.DeviceId,
+            domainEvent.UserId,
+            domainEvent.DeviceId,
+            domainEvent.RequestedTaskIds);
 
-        var requestedTaskIds = domainEvent.Manifest
-            .Select(entry => entry.TaskId)
-            .ToHashSet(StringComparer.Ordinal);
-
-        string[] tasksToAdvertise = (await _coordinator
-            .GetTasksToAdvertiseAsync(domainEvent.Manifest, UserId, DeviceId)
+        var batch = await _syncExchange
+            .BuildTaskBatchAsync(request, CreateLocalPeerContext(), linkedCts.Token)
             .WaitAsync(linkedCts.Token)
-            .ConfigureAwait(false))
-            .Where(requestedTaskIds.Contains)
-            .ToArray();
+            .ConfigureAwait(false);
 
-        if (tasksToAdvertise.Length == 0)
+        if (batch.Tasks.Count == 0)
         {
             return;
         }
 
-        await PublishTaskBatchesAsync(tasksToAdvertise, linkedCts.Token).ConfigureAwait(false);
+        await PublishTaskBatchesAsync(batch, linkedCts.Token).ConfigureAwait(false);
     }
 
     internal async Task HandleTaskBatchResponseAsync(TaskBatchResponse domainEvent, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(domainEvent);
-        if (domainEvent.Tasks is null)
+        var batch = domainEvent.Batch ?? new SyncTaskBatch(
+            domainEvent.DeviceId,
+            domainEvent.UserId,
+            domainEvent.DeviceId,
+            domainEvent.Tasks ?? Array.Empty<TaskItem>());
+
+        if (batch.Tasks.Count == 0)
         {
             return;
         }
@@ -485,14 +495,7 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
         await DebugToastAsync("Task batch response", $"Received task batch response from {domainEvent.DeviceId}.").ConfigureAwait(false);
 
         using var linkedCts = LinkToConnection(cancellationToken);
-        await RunWithoutBroadcastAsync(async () =>
-        {
-            foreach (var task in domainEvent.Tasks)
-            {
-                var upsertedEvent = new TaskUpsertedEvent(task, domainEvent.DeviceId, domainEvent.UserId);
-                await _aggregator.PublishEventAsync(upsertedEvent, linkedCts.Token).ConfigureAwait(false);
-            }
-        }).ConfigureAwait(false);
+        await RunWithoutBroadcastAsync(() => _syncExchange.ApplyTaskBatchAsync(batch, linkedCts.Token)).ConfigureAwait(false);
     }
 
     private async Task PublishManifestAnnouncementAsync(CancellationToken cancellationToken)
@@ -509,57 +512,53 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
             .ConfigureAwait(false);
     }
 
-    private async Task PublishManifestRequestAsync(
-        IReadOnlyCollection<TaskManifestEntry> remoteManifest,
-        IReadOnlyCollection<string> tasksToRequest,
-        CancellationToken cancellationToken)
+    private async Task PublishManifestRequestAsync(SyncTaskRequest request, CancellationToken cancellationToken)
     {
         if (!ShouldBroadcast)
         {
             return;
         }
 
-        var requestEntries = remoteManifest
-            .Where(entry => tasksToRequest.Contains(entry.TaskId))
-            .ToArray();
-
-        if (requestEntries.Length == 0)
+        if (request.RequestedTaskIds.Count == 0)
         {
             return;
         }
 
-        var request = new TaskManifestRequest(requestEntries, DeviceId, UserId);
-        await PublishWithTrackingAsync(() => _aggregator.PublishEventAsync(request, cancellationToken), cancellationToken)
+        var domainEvent = new TaskManifestRequest(request.RequestedTaskIds, DeviceId, UserId);
+        await PublishWithTrackingAsync(() => _aggregator.PublishEventAsync(domainEvent, cancellationToken), cancellationToken)
             .ConfigureAwait(false);
     }
 
-    private async Task PublishTaskBatchesAsync(IEnumerable<string> taskIds, CancellationToken cancellationToken)
+    private async Task PublishTaskBatchesAsync(SyncTaskBatch batch, CancellationToken cancellationToken)
     {
         if (!ShouldBroadcast)
         {
             return;
         }
 
-        foreach (var batch in taskIds.Chunk(TaskBatchSize))
+        foreach (var taskChunk in batch.Tasks.Chunk(TaskBatchSize))
         {
-            var tasks = await LoadTasksAsync(batch, cancellationToken).ConfigureAwait(false);
-            foreach (var task in tasks)
-            {
-                await PublishTaskUpsertAsync(task, cancellationToken).ConfigureAwait(false);
-            }
+            var chunkBatch = new SyncTaskBatch(DeviceId, batch.UserId, DeviceId, taskChunk, batch.DeletedTaskIds);
+            var response = new TaskBatchResponse(chunkBatch, DeviceId, UserId);
+            await PublishWithTrackingAsync(() => _aggregator.PublishEventAsync(response, cancellationToken), cancellationToken)
+                .ConfigureAwait(false);
         }
     }
 
     private async Task<IReadOnlyCollection<TaskManifestEntry>> BuildLocalManifestAsync(CancellationToken cancellationToken)
     {
-        var tasks = await _storage.GetTasksAsync(UserId, DeviceId).WaitAsync(cancellationToken).ConfigureAwait(false);
-        return tasks.Select(task => new TaskManifestEntry
+        var manifest = await _syncExchange
+            .BuildManifestAsync(CreateLocalPeerContext(), cancellationToken)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return manifest.Entries.Select(entry => new TaskManifestEntry
         {
-            TaskId = task.Id,
-            EventVersion = task.EventVersion,
-            UpdatedAt = task.UpdatedAt,
-            DeviceId = task.DeviceId,
-            UserId = task.UserId,
+            TaskId = entry.TaskId,
+            EventVersion = entry.EventVersion,
+            UpdatedAt = entry.UpdatedAtUtc,
+            DeviceId = manifest.DeviceId,
+            UserId = manifest.UserId,
         }).ToArray();
     }
 
@@ -601,5 +600,23 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
     private CancellationTokenSource LinkToConnection(CancellationToken cancellationToken)
     {
         return CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, EnsureConnectionCts().Token);
+    }
+
+    private SyncPeerContext CreateLocalPeerContext()
+        => new(DeviceId, UserId, DeviceId);
+
+    private static SyncManifest BuildRemoteManifest(TaskManifestAnnounced domainEvent)
+    {
+        var entries = domainEvent.Manifest.Select(entry => new SyncManifestEntry(
+            entry.TaskId,
+            entry.EventVersion,
+            entry.UpdatedAt));
+
+        return new SyncManifest(
+            domainEvent.DeviceId,
+            domainEvent.UserId,
+            domainEvent.DeviceId,
+            schemaVersion: 1,
+            entries);
     }
 }

--- a/ShuffleTask.Application/Services/NetworkSyncService.cs
+++ b/ShuffleTask.Application/Services/NetworkSyncService.cs
@@ -562,27 +562,6 @@ public sealed class NetworkSyncService : INetworkSyncService, IDisposable
         }).ToArray();
     }
 
-    private async Task<IReadOnlyCollection<TaskItem>> LoadTasksAsync(IEnumerable<string> taskIds, CancellationToken cancellationToken)
-    {
-        var tasks = new List<TaskItem>();
-
-        foreach (var taskId in taskIds)
-        {
-            if (string.IsNullOrWhiteSpace(taskId))
-            {
-                continue;
-            }
-
-            var task = await _storage.GetTaskAsync(taskId).WaitAsync(cancellationToken).ConfigureAwait(false);
-            if (task is not null)
-            {
-                tasks.Add(task);
-            }
-        }
-
-        return tasks;
-    }
-
     private async Task RunWithoutBroadcastAsync(Func<Task> action)
     {
         var previous = _suppressBroadcast.Value;

--- a/ShuffleTask.Application/Services/SyncExchangeService.cs
+++ b/ShuffleTask.Application/Services/SyncExchangeService.cs
@@ -120,7 +120,7 @@ public sealed class SyncExchangeService : ISyncExchangeService
             }
 
             var existing = await _storage.GetTaskAsync(task.Id).WaitAsync(cancellationToken).ConfigureAwait(false);
-            var incoming = NormalizeIncoming(task, existing);
+            var incoming = TaskSyncMerge.NormalizeIncoming(task, existing);
 
             if (existing is null)
             {
@@ -129,7 +129,7 @@ public sealed class SyncExchangeService : ISyncExchangeService
                 continue;
             }
 
-            if (IsStale(incoming, existing))
+            if (TaskSyncMerge.IsStaleBatchTask(incoming, existing))
             {
                 ignored.Add(incoming.Id);
                 continue;
@@ -187,62 +187,4 @@ public sealed class SyncExchangeService : ISyncExchangeService
         return string.IsNullOrWhiteSpace(task.UserId);
     }
 
-    private static bool IsStale(TaskItem incoming, TaskItem existing)
-    {
-        if (incoming.EventVersion > existing.EventVersion)
-        {
-            return false;
-        }
-
-        if (incoming.EventVersion < existing.EventVersion)
-        {
-            return true;
-        }
-
-        if (incoming.UpdatedAt != default && existing.UpdatedAt != default)
-        {
-            return incoming.UpdatedAt <= existing.UpdatedAt;
-        }
-
-        return true;
-    }
-
-    private static TaskItem NormalizeIncoming(TaskItem task, TaskItem? existing)
-    {
-        var normalized = task.Clone();
-
-        if (string.IsNullOrWhiteSpace(normalized.Id))
-        {
-            normalized.Id = existing?.Id ?? Guid.NewGuid().ToString("n");
-        }
-
-        if (normalized.CreatedAt == default)
-        {
-            normalized.CreatedAt = existing?.CreatedAt ?? DateTime.UtcNow;
-        }
-
-        if (normalized.UpdatedAt == default)
-        {
-            normalized.UpdatedAt = existing?.UpdatedAt ?? DateTime.UtcNow;
-        }
-
-        if (normalized.EventVersion <= 0)
-        {
-            normalized.EventVersion = (existing?.EventVersion ?? 0) + 1;
-        }
-
-        if (!string.IsNullOrWhiteSpace(normalized.UserId))
-        {
-            normalized.DeviceId = null;
-        }
-        else
-        {
-            normalized.UserId = existing?.UserId;
-            normalized.DeviceId = string.IsNullOrWhiteSpace(normalized.DeviceId)
-                ? existing?.DeviceId ?? Environment.MachineName
-                : normalized.DeviceId.Trim();
-        }
-
-        return normalized;
-    }
 }

--- a/ShuffleTask.Application/Services/SyncExchangeService.cs
+++ b/ShuffleTask.Application/Services/SyncExchangeService.cs
@@ -1,0 +1,247 @@
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Application.Services;
+
+public sealed class SyncExchangeService : ISyncExchangeService
+{
+    private const int CurrentSyncSchemaVersion = 1;
+
+    private readonly IStorageService _storage;
+    private readonly PeerSyncCoordinator _coordinator;
+
+    public SyncExchangeService(IStorageService storage)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _coordinator = new PeerSyncCoordinator(storage);
+    }
+
+    public async Task<SyncManifest> BuildManifestAsync(
+        SyncPeerContext localPeer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(localPeer);
+
+        var tasks = await _storage
+            .GetTasksAsync(localPeer.UserId, localPeer.DeviceId)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var entries = tasks.Select(SyncManifestEntry.From).ToArray();
+        return new SyncManifest(
+            localPeer.PeerId,
+            localPeer.UserId,
+            localPeer.DeviceId,
+            CurrentSyncSchemaVersion,
+            entries);
+    }
+
+    public async Task<SyncTaskRequest> BuildTaskRequestAsync(
+        SyncManifest remoteManifest,
+        SyncPeerContext localPeer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(remoteManifest);
+        ArgumentNullException.ThrowIfNull(localPeer);
+
+        var comparisonManifest = remoteManifest.Entries
+            .Where(entry => !entry.Deleted)
+            .Select(entry => new TaskManifestEntry(entry.TaskId, entry.EventVersion, entry.UpdatedAtUtc)
+            {
+                UserId = remoteManifest.UserId,
+                DeviceId = remoteManifest.DeviceId,
+            })
+            .ToArray();
+
+        var comparison = await _coordinator
+            .CompareManifestAsync(comparisonManifest, localPeer.UserId, localPeer.DeviceId)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new SyncTaskRequest(
+            localPeer.PeerId,
+            localPeer.UserId,
+            localPeer.DeviceId,
+            comparison.GetTasksToRequest());
+    }
+
+    public async Task<SyncTaskBatch> BuildTaskBatchAsync(
+        SyncTaskRequest request,
+        SyncPeerContext localPeer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(localPeer);
+
+        var tasks = new List<TaskItem>();
+        foreach (var taskId in request.RequestedTaskIds)
+        {
+            var task = await _storage.GetTaskAsync(taskId).WaitAsync(cancellationToken).ConfigureAwait(false);
+            if (task is null || !MatchesRequestedScope(task, request))
+            {
+                continue;
+            }
+
+            tasks.Add(task);
+        }
+
+        return new SyncTaskBatch(localPeer.PeerId, request.UserId, localPeer.DeviceId, tasks);
+    }
+
+    public async Task<SyncTaskBatch> BuildLocalTaskBatchAsync(
+        SyncManifest remoteManifest,
+        SyncPeerContext localPeer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(remoteManifest);
+        ArgumentNullException.ThrowIfNull(localPeer);
+
+        var comparisonManifest = remoteManifest.Entries
+            .Where(entry => !entry.Deleted)
+            .Select(entry => new TaskManifestEntry(entry.TaskId, entry.EventVersion, entry.UpdatedAtUtc)
+            {
+                UserId = remoteManifest.UserId,
+                DeviceId = remoteManifest.DeviceId,
+            })
+            .ToArray();
+
+        var comparison = await _coordinator
+            .CompareManifestAsync(comparisonManifest, localPeer.UserId, localPeer.DeviceId)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var request = new SyncTaskRequest(
+            localPeer.PeerId,
+            localPeer.UserId,
+            localPeer.DeviceId,
+            comparison.GetTasksToAdvertise());
+
+        return await BuildTaskBatchAsync(request, localPeer, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<SyncApplyResult> ApplyTaskBatchAsync(
+        SyncTaskBatch batch,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        var applied = new List<string>();
+        var ignored = new List<string>();
+
+        foreach (var task in batch.Tasks)
+        {
+            if (task is null || !MatchesBatchScope(task, batch))
+            {
+                if (task is not null)
+                {
+                    ignored.Add(task.Id);
+                }
+
+                continue;
+            }
+
+            var existing = await _storage.GetTaskAsync(task.Id).WaitAsync(cancellationToken).ConfigureAwait(false);
+            var incoming = NormalizeIncoming(task, existing);
+
+            if (existing is null)
+            {
+                await _storage.AddTaskAsync(incoming).WaitAsync(cancellationToken).ConfigureAwait(false);
+                applied.Add(incoming.Id);
+                continue;
+            }
+
+            if (IsStale(incoming, existing))
+            {
+                ignored.Add(incoming.Id);
+                continue;
+            }
+
+            incoming.CreatedAt = existing.CreatedAt;
+            await _storage.UpdateTaskAsync(incoming).WaitAsync(cancellationToken).ConfigureAwait(false);
+            applied.Add(incoming.Id);
+        }
+
+        return new SyncApplyResult(applied, ignored);
+    }
+
+    private static bool MatchesRequestedScope(TaskItem task, SyncTaskRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.UserId))
+        {
+            return string.Equals(task.UserId, request.UserId, StringComparison.Ordinal);
+        }
+
+        return string.IsNullOrWhiteSpace(task.UserId)
+            && string.Equals(task.DeviceId, request.DeviceId, StringComparison.Ordinal);
+    }
+
+    private static bool MatchesBatchScope(TaskItem task, SyncTaskBatch batch)
+    {
+        if (!string.IsNullOrWhiteSpace(batch.UserId))
+        {
+            return string.Equals(task.UserId, batch.UserId, StringComparison.Ordinal);
+        }
+
+        return string.IsNullOrWhiteSpace(task.UserId);
+    }
+
+    private static bool IsStale(TaskItem incoming, TaskItem existing)
+    {
+        if (incoming.EventVersion > existing.EventVersion)
+        {
+            return false;
+        }
+
+        if (incoming.EventVersion < existing.EventVersion)
+        {
+            return true;
+        }
+
+        if (incoming.UpdatedAt != default && existing.UpdatedAt != default)
+        {
+            return incoming.UpdatedAt <= existing.UpdatedAt;
+        }
+
+        return true;
+    }
+
+    private static TaskItem NormalizeIncoming(TaskItem task, TaskItem? existing)
+    {
+        var normalized = task.Clone();
+
+        if (string.IsNullOrWhiteSpace(normalized.Id))
+        {
+            normalized.Id = existing?.Id ?? Guid.NewGuid().ToString("n");
+        }
+
+        if (normalized.CreatedAt == default)
+        {
+            normalized.CreatedAt = existing?.CreatedAt ?? DateTime.UtcNow;
+        }
+
+        if (normalized.UpdatedAt == default)
+        {
+            normalized.UpdatedAt = existing?.UpdatedAt ?? DateTime.UtcNow;
+        }
+
+        if (normalized.EventVersion <= 0)
+        {
+            normalized.EventVersion = (existing?.EventVersion ?? 0) + 1;
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalized.UserId))
+        {
+            normalized.DeviceId = null;
+        }
+        else
+        {
+            normalized.UserId = existing?.UserId;
+            normalized.DeviceId = string.IsNullOrWhiteSpace(normalized.DeviceId)
+                ? existing?.DeviceId ?? Environment.MachineName
+                : normalized.DeviceId.Trim();
+        }
+
+        return normalized;
+    }
+}

--- a/ShuffleTask.Application/Services/SyncExchangeService.cs
+++ b/ShuffleTask.Application/Services/SyncExchangeService.cs
@@ -45,18 +45,7 @@ public sealed class SyncExchangeService : ISyncExchangeService
         ArgumentNullException.ThrowIfNull(remoteManifest);
         ArgumentNullException.ThrowIfNull(localPeer);
 
-        var comparisonManifest = remoteManifest.Entries
-            .Where(entry => !entry.Deleted)
-            .Select(entry => new TaskManifestEntry(entry.TaskId, entry.EventVersion, entry.UpdatedAtUtc)
-            {
-                UserId = remoteManifest.UserId,
-                DeviceId = remoteManifest.DeviceId,
-            })
-            .ToArray();
-
-        var comparison = await _coordinator
-            .CompareManifestAsync(comparisonManifest, localPeer.UserId, localPeer.DeviceId)
-            .WaitAsync(cancellationToken)
+        var comparison = await CompareRemoteManifestAsync(remoteManifest, localPeer, cancellationToken)
             .ConfigureAwait(false);
 
         return new SyncTaskRequest(
@@ -97,18 +86,7 @@ public sealed class SyncExchangeService : ISyncExchangeService
         ArgumentNullException.ThrowIfNull(remoteManifest);
         ArgumentNullException.ThrowIfNull(localPeer);
 
-        var comparisonManifest = remoteManifest.Entries
-            .Where(entry => !entry.Deleted)
-            .Select(entry => new TaskManifestEntry(entry.TaskId, entry.EventVersion, entry.UpdatedAtUtc)
-            {
-                UserId = remoteManifest.UserId,
-                DeviceId = remoteManifest.DeviceId,
-            })
-            .ToArray();
-
-        var comparison = await _coordinator
-            .CompareManifestAsync(comparisonManifest, localPeer.UserId, localPeer.DeviceId)
-            .WaitAsync(cancellationToken)
+        var comparison = await CompareRemoteManifestAsync(remoteManifest, localPeer, cancellationToken)
             .ConfigureAwait(false);
 
         var request = new SyncTaskRequest(
@@ -175,6 +153,29 @@ public sealed class SyncExchangeService : ISyncExchangeService
         return string.IsNullOrWhiteSpace(task.UserId)
             && string.Equals(task.DeviceId, request.DeviceId, StringComparison.Ordinal);
     }
+
+    private async Task<ManifestComparisonResult> CompareRemoteManifestAsync(
+        SyncManifest remoteManifest,
+        SyncPeerContext localPeer,
+        CancellationToken cancellationToken)
+    {
+        var comparisonManifest = remoteManifest.Entries
+            .Where(entry => !entry.Deleted)
+            .Select(entry => ToLegacyManifestEntry(entry, remoteManifest))
+            .ToArray();
+
+        return await _coordinator
+            .CompareManifestAsync(comparisonManifest, localPeer.UserId, localPeer.DeviceId)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static TaskManifestEntry ToLegacyManifestEntry(SyncManifestEntry entry, SyncManifest manifest)
+        => new(entry.TaskId, entry.EventVersion, entry.UpdatedAtUtc)
+        {
+            UserId = manifest.UserId,
+            DeviceId = manifest.DeviceId,
+        };
 
     private static bool MatchesBatchScope(TaskItem task, SyncTaskBatch batch)
     {

--- a/ShuffleTask.Application/Services/TaskSyncMerge.cs
+++ b/ShuffleTask.Application/Services/TaskSyncMerge.cs
@@ -1,0 +1,75 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Application.Services;
+
+internal static class TaskSyncMerge
+{
+    public static TaskItem NormalizeIncoming(TaskItem task, TaskItem? existing)
+    {
+        var normalized = task.Clone();
+
+        if (string.IsNullOrWhiteSpace(normalized.Id))
+        {
+            normalized.Id = existing?.Id ?? Guid.NewGuid().ToString("n");
+        }
+
+        if (normalized.CreatedAt == default)
+        {
+            normalized.CreatedAt = existing?.CreatedAt ?? DateTime.UtcNow;
+        }
+
+        if (normalized.UpdatedAt == default)
+        {
+            normalized.UpdatedAt = existing?.UpdatedAt ?? DateTime.UtcNow;
+        }
+
+        if (normalized.EventVersion <= 0)
+        {
+            normalized.EventVersion = (existing?.EventVersion ?? 0) + 1;
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalized.UserId))
+        {
+            normalized.DeviceId = null;
+        }
+        else
+        {
+            normalized.UserId = existing?.UserId;
+            normalized.DeviceId = string.IsNullOrWhiteSpace(normalized.DeviceId)
+                ? existing?.DeviceId ?? Environment.MachineName
+                : normalized.DeviceId.Trim();
+        }
+
+        return normalized;
+    }
+
+    public static bool IsStaleBatchTask(TaskItem incoming, TaskItem existing)
+    {
+        if (incoming.EventVersion > existing.EventVersion)
+        {
+            return false;
+        }
+
+        if (incoming.EventVersion < existing.EventVersion)
+        {
+            return true;
+        }
+
+        if (incoming.UpdatedAt != default && existing.UpdatedAt != default)
+        {
+            return incoming.UpdatedAt <= existing.UpdatedAt;
+        }
+
+        return true;
+    }
+
+    public static bool IsStaleEventTask(TaskItem incoming, TaskItem existing)
+    {
+        if (incoming.EventVersion > 0)
+        {
+            return incoming.EventVersion <= existing.EventVersion;
+        }
+
+        return incoming.UpdatedAt != default && incoming.UpdatedAt <= existing.UpdatedAt;
+    }
+}

--- a/ShuffleTask.Application/Services/TaskUpsertedAsyncHandler.cs
+++ b/ShuffleTask.Application/Services/TaskUpsertedAsyncHandler.cs
@@ -28,7 +28,7 @@ internal class TaskUpsertedAsyncHandler : IAsyncEventHandler<TaskUpsertedEvent>
         try
         {
             TaskItem? existing = await _storage.GetTaskAsync(domainEvent.Task.Id).ConfigureAwait(false);
-            TaskItem incoming = NormalizeIncoming(domainEvent.Task, existing);
+            TaskItem incoming = TaskSyncMerge.NormalizeIncoming(domainEvent.Task, existing);
 
             if (existing == null)
             {
@@ -36,7 +36,7 @@ internal class TaskUpsertedAsyncHandler : IAsyncEventHandler<TaskUpsertedEvent>
                 return;
             }
 
-            if (IsStale(incoming, existing))
+            if (TaskSyncMerge.IsStaleEventTask(incoming, existing))
             {
                 _logger?.LogInformation(
                     "Ignoring stale task update for {TaskId} with version {Version}",
@@ -54,55 +54,4 @@ internal class TaskUpsertedAsyncHandler : IAsyncEventHandler<TaskUpsertedEvent>
         }
     }
 
-    private static bool IsStale(TaskItem incoming, TaskItem existing)
-    {
-        if (incoming.EventVersion > 0 && incoming.EventVersion <= existing.EventVersion)
-        {
-            return true;
-        }
-
-        return incoming.EventVersion <= 0 && incoming.UpdatedAt != default && incoming.UpdatedAt <= existing.UpdatedAt;
-    }
-
-    private static TaskItem NormalizeIncoming(TaskItem task, TaskItem? existing)
-    {
-        TaskItem normalized = task.Clone();
-
-        if (string.IsNullOrWhiteSpace(normalized.Id) && existing != null)
-        {
-            normalized.Id = existing.Id;
-        }
-        else if (string.IsNullOrWhiteSpace(normalized.Id))
-        {
-            normalized.Id = Guid.NewGuid().ToString("n");
-        }
-
-        if (normalized.CreatedAt == default)
-        {
-            normalized.CreatedAt = existing?.CreatedAt ?? DateTime.UtcNow;
-        }
-
-        if (normalized.UpdatedAt == default)
-        {
-            normalized.UpdatedAt = existing?.UpdatedAt ?? DateTime.UtcNow;
-        }
-
-        if (normalized.EventVersion <= 0)
-        {
-            normalized.EventVersion = (existing?.EventVersion ?? 0) + 1;
-        }
-
-        if (!string.IsNullOrWhiteSpace(normalized.UserId))
-        {
-            normalized.DeviceId = null;
-        }
-        else
-        {
-            normalized.UserId = existing?.UserId;
-            normalized.DeviceId = string.IsNullOrWhiteSpace(normalized.DeviceId)
-                ? existing?.DeviceId ?? Environment.MachineName
-                : normalized.DeviceId.Trim();
-        }
-        return normalized;
-    }
 }

--- a/ShuffleTask.Presentation/MauiProgram.cs
+++ b/ShuffleTask.Presentation/MauiProgram.cs
@@ -156,6 +156,7 @@ public static partial class MauiProgram
             return transport;
         });
         builder.Services.AddSingleton<NetworkedEventAggregator>();
+        builder.Services.AddSingleton<ISyncExchangeService, SyncExchangeService>();
         builder.Services.AddSingleton<INetworkSyncService, NetworkSyncService>();
 
         builder.Services.AddSingleton<TaskStartedAsyncHandler>();


### PR DESCRIPTION
## Summary
- Introduce an adapter-neutral sync exchange layer in the application core with explicit manifest, request, and batch models
- Fix manifest request handling so peers request concrete task IDs and receive real task batches instead of reusing manifest payloads
- Refactor `NetworkSyncService` to delegate sync semantics to the new core while keeping transport concerns isolated
- Add regression coverage for explicit request handling, idempotent batch apply, and scope filtering

## Testing
- `dotnet test ShuffleTask.Application.Tests/ShuffleTask.Application.Tests.csproj --filter Sync`
- `dotnet test ShuffleTask.Tests/ShuffleTask.Tests.csproj --filter PeerSyncCoordinator`
- `dotnet test ShuffleTask.sln`