### PR TITLE
Recompute Manifest Comparisons When Local Tasks Change (Avoid Stale Cached Comparison)

### DIFF
--- a/ShuffleTask.Application/Services/PeerSyncCoordinator.cs
+++ b/ShuffleTask.Application/Services/PeerSyncCoordinator.cs
@@ -28,7 +28,8 @@ public class PeerSyncCoordinator
         ArgumentNullException.ThrowIfNull(remoteManifest);
 
         var remoteEntries = remoteManifest.ToList();
-        var cacheKey = ManifestComparisonCacheKey.From(remoteEntries, userId, deviceId);
+        var localManifest = await LoadLocalManifestAsync(userId, deviceId).ConfigureAwait(false);
+        var cacheKey = ManifestComparisonCacheKey.From(remoteEntries, localManifest, userId, deviceId);
 
         await _comparisonLock.WaitAsync().ConfigureAwait(false);
         try
@@ -38,8 +39,7 @@ public class PeerSyncCoordinator
                 return _comparison;
             }
 
-            var comparison = await CompareManifestInternalAsync(remoteEntries, userId, deviceId)
-                .ConfigureAwait(false);
+            var comparison = CompareManifestInternal(remoteEntries, localManifest, userId, deviceId);
 
             _comparisonKey = cacheKey;
             _comparison = comparison;
@@ -70,8 +70,9 @@ public class PeerSyncCoordinator
         return comparison.GetTasksToAdvertise();
     }
 
-    private async Task<ManifestComparisonResult> CompareManifestInternalAsync(
+    private static ManifestComparisonResult CompareManifestInternal(
         IReadOnlyCollection<TaskManifestEntry> remoteManifest,
+        IReadOnlyCollection<TaskManifestEntry> localManifest,
         string? userId,
         string deviceId)
     {
@@ -88,8 +89,6 @@ public class PeerSyncCoordinator
             .Where(idFilterPredicate)
             .GroupBy(entry => entry.TaskId)
             .ToDictionary(group => group.Key, group => group.First());
-
-        var localManifest = await LoadLocalManifestAsync(userId, deviceId).ConfigureAwait(false);
 
         var missing = new List<TaskManifestEntry>();
         var remoteNewer = new List<TaskManifestEntry>();
@@ -208,16 +207,22 @@ public class ManifestComparisonResult
 
 internal sealed class ManifestComparisonCacheKey : IEquatable<ManifestComparisonCacheKey>
 {
-    public ManifestComparisonCacheKey(string? userId, string deviceId, IReadOnlyList<ManifestEntryKey> remoteEntries)
+    public ManifestComparisonCacheKey(
+        string? userId,
+        string deviceId,
+        IReadOnlyList<ManifestEntryKey> remoteEntries,
+        IReadOnlyList<ManifestEntryKey> localEntries)
     {
         UserId = userId;
         DeviceId = deviceId;
         RemoteEntries = remoteEntries;
+        LocalEntries = localEntries;
     }
 
     public string? UserId { get; }
     public string DeviceId { get; }
     public IReadOnlyList<ManifestEntryKey> RemoteEntries { get; }
+    public IReadOnlyList<ManifestEntryKey> LocalEntries { get; }
 
     public bool Equals(ManifestComparisonCacheKey? other)
     {
@@ -233,7 +238,8 @@ internal sealed class ManifestComparisonCacheKey : IEquatable<ManifestComparison
 
         return string.Equals(UserId, other.UserId, StringComparison.Ordinal)
             && string.Equals(DeviceId, other.DeviceId, StringComparison.Ordinal)
-            && RemoteEntries.SequenceEqual(other.RemoteEntries);
+            && RemoteEntries.SequenceEqual(other.RemoteEntries)
+            && LocalEntries.SequenceEqual(other.LocalEntries);
     }
 
     public override bool Equals(object? obj) => Equals(obj as ManifestComparisonCacheKey);
@@ -249,22 +255,34 @@ internal sealed class ManifestComparisonCacheKey : IEquatable<ManifestComparison
             hash.Add(entry);
         }
 
+        foreach (var entry in LocalEntries)
+        {
+            hash.Add(entry);
+        }
+
         return hash.ToHashCode();
     }
 
     public static ManifestComparisonCacheKey From(
         IEnumerable<TaskManifestEntry> remoteManifest,
+        IEnumerable<TaskManifestEntry> localManifest,
         string? userId,
         string deviceId)
     {
-        var entries = remoteManifest
+        var remoteEntries = BuildEntryKeys(remoteManifest);
+        var localEntries = BuildEntryKeys(localManifest);
+
+        return new ManifestComparisonCacheKey(userId, deviceId, remoteEntries, localEntries);
+    }
+
+    private static IReadOnlyList<ManifestEntryKey> BuildEntryKeys(IEnumerable<TaskManifestEntry> manifest)
+    {
+        return manifest
             .Select(entry => new ManifestEntryKey(entry.TaskId, entry.EventVersion, entry.UpdatedAt))
             .OrderBy(entry => entry.TaskId)
             .ThenBy(entry => entry.EventVersion)
             .ThenBy(entry => entry.UpdatedAt)
             .ToArray();
-
-        return new ManifestComparisonCacheKey(userId, deviceId, entries);
     }
 }
 

--- a/ShuffleTask.Tests/PeerSyncCoordinatorTests.cs
+++ b/ShuffleTask.Tests/PeerSyncCoordinatorTests.cs
@@ -135,7 +135,7 @@ public class PeerSyncCoordinatorTests
     }
 
     [Test]
-    public async Task CompareManifestAsync_ReusesComparisonForSameManifest()
+    public async Task CompareManifestAsync_ReusesComparisonForSameRemoteAndLocalManifest()
     {
         var storage = new StorageServiceStub();
         await storage.InitializeAsync();
@@ -147,12 +147,31 @@ public class PeerSyncCoordinatorTests
 
         var coordinator = new PeerSyncCoordinator(storage);
 
-        var requestIds = await coordinator.GetTasksToRequestAsync(remoteManifest);
-        var advertiseIds = await coordinator.GetTasksToAdvertiseAsync(remoteManifest);
+        var first = await coordinator.CompareManifestAsync(remoteManifest);
+        var second = await coordinator.CompareManifestAsync(remoteManifest);
 
-        Assert.That(requestIds, Is.EquivalentTo(new[] { "remote-only" }));
-        Assert.That(advertiseIds, Is.Empty);
-        Assert.That(storage.GetTasksCallCount, Is.EqualTo(1));
+        Assert.That(second, Is.SameAs(first));
+        Assert.That(second.GetTasksToRequest(), Is.EquivalentTo(new[] { "remote-only" }));
+        Assert.That(second.GetTasksToAdvertise(), Is.Empty);
+        Assert.That(storage.GetTasksCallCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task CompareManifestAsync_RecomputesWhenLocalTasksChange()
+    {
+        var storage = new StorageServiceStub();
+        await storage.InitializeAsync();
+
+        var coordinator = new PeerSyncCoordinator(storage);
+        var remoteManifest = Array.Empty<TaskManifestEntry>();
+
+        var beforeMutation = await coordinator.CompareManifestAsync(remoteManifest);
+        await storage.AddTaskAsync(CreateTask("local-after-first-compare", version: 1, updatedAt: BaseTimeUtc));
+        var afterMutation = await coordinator.CompareManifestAsync(remoteManifest);
+
+        Assert.That(beforeMutation.GetTasksToAdvertise(), Is.Empty);
+        Assert.That(afterMutation, Is.Not.SameAs(beforeMutation));
+        Assert.That(afterMutation.GetTasksToAdvertise(), Is.EquivalentTo(new[] { "local-after-first-compare" }));
     }
 
     private static TaskItem CreateTask(string id, int version, DateTime updatedAt)


### PR DESCRIPTION
Implements:

# GitHub Issue #211: Recompute Manifest Comparisons When Local Tasks Change (Avoid Stale Cached Comparison)

URL: https://github.com/com-mit-group/ShuffleTask/issues/211

## Context
File: `ShuffleTask.Application/Services/PeerSyncCoordinator.cs`

`CompareManifestAsync` caches comparison results using only the **remote manifest + userId + deviceId** key.
If the **local task set changes** between calls (e.g., after `TaskUpsertedAsyncHandler` runs or a local edit),
the cached comparison may be reused and the new local state is ignored.

This can cause:
- stale requests/advertisements
- duplicated requests/advertisements
- missed updates (local changes not reflected in sync decisions)

## Problem
Caching does not account for local state mutations. The comparison result is treated as valid even when local tasks have changed.

## Expected Behavior
If local tasks change, any cached manifest comparison must be invalidated or made un-matchable, so a new comparison is computed.

## Suggested Fix Options
### Option A — Invalidate cache on local changes
- When a local task is added/updated/deleted, invalidate `_comparison` / `_comparisonKey`.

### Option B — Include local state version/hash in cache key
- Extend `ManifestComparisonCacheKey` to include a `localVersion` or `localHash`
  (e.g., monotonic counter, last-changed timestamp, or deterministic hash of local manifest snapshot).

## Acceptance Criteria
- [ ] After any local task mutation, subsequent `CompareManifestAsync` calls do **not** reuse a stale comparison
- [ ] Sync does not emit stale or duplicated requests/advertisements caused by outdated cache
- [ ] Unit/integration test added that changes local tasks between compare calls and verifies recomputation
- [ ] No performance regression (if using hashing, keep it lightweight or version-based)

## Notes
This is a correctness bug that may manifest as "weird sync duplication" or "sync not reflecting my latest local edits".

Codex plan:

1) Where to look

- `ShuffleTask.Application/Services/PeerSyncCoordinator.cs`, especially cache-key construction and local manifest loading.
- Existing coordinator coverage in `ShuffleTask.Tests/PeerSyncCoordinatorTests.cs`.

2) Files / areas likely to touch

- `ShuffleTask.Application/Services/PeerSyncCoordinator.cs`
- `ShuffleTask.Tests/PeerSyncCoordinatorTests.cs`

3) Assumptions

- Local task mutations can occur outside the coordinator, so explicit invalidation cannot reliably cover every write path without broad coupling.
- A deterministic key built from the already scoped local manifest is lightweight and avoids hashing full task payloads.

4) Plan

- Load the scoped local manifest before evaluating the cached comparison.
- Extend the comparison cache key with sorted local task identity/version/timestamp entries.
- Pass the loaded local manifest into comparison logic so a cache miss does not perform a second storage read.
- Add a regression test that mutates local storage between identical remote comparisons and verifies the second result reflects the new local task.

5) Risks / gotchas

- Cache hits will still require reading the scoped local task list to detect external mutations; avoid any second read on cache misses.
- Key ordering must be deterministic and include the fields used by comparison (`TaskId`, `EventVersion`, and `UpdatedAt`).
- Preserve user/device scoping when loading and keying local entries.

6) Recommended implementation approach

Extend `ManifestComparisonCacheKey` to represent both remote and local manifest entry keys. Build it from materialized remote entries and one scoped local-manifest snapshot, then reuse that same local snapshot when computing a cache miss. This is localized to the coordinator, covers all storage mutation paths, and keeps the key calculation proportional to manifest size without hashing full task objects.

Local verification:
```text
bash "/home/codex-auto/automation/scripts/codex-verify.sh" --profiles "backend"
```
