### PR TITLE
Finish fixing NumericStepper border clipping on Android

### DIFF
--- a/ShuffleTask.Presentation/Controls/NumericStepper.xaml
+++ b/ShuffleTask.Presentation/Controls/NumericStepper.xaml
@@ -5,7 +5,7 @@
              x:Class="ShuffleTask.Controls.NumericStepper"
              x:Name="Root"
              HorizontalOptions="Start">
-    <Grid Padding="2"
+    <Grid Padding="3"
           HorizontalOptions="Start">
         <Border StrokeShape="RoundRectangle 8"
                 StrokeThickness="1"

--- a/ShuffleTask.Presentation/Controls/NumericStepper.xaml
+++ b/ShuffleTask.Presentation/Controls/NumericStepper.xaml
@@ -4,38 +4,40 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ShuffleTask.Controls.NumericStepper"
              x:Name="Root"
-             HorizontalOptions="Start"
-             Padding="1">
-    <Border StrokeShape="RoundRectangle 8"
-            StrokeThickness="1"
-            Stroke="{AppThemeBinding Light=#C6C6C6, Dark=#555555}"
-            BackgroundColor="Transparent"
-            Padding="8,4"
-            HorizontalOptions="Start">
-        <Grid BindingContext="{x:Reference Root}"
-              ColumnDefinitions="Auto,Auto,Auto"
-              ColumnSpacing="12"
-              VerticalOptions="Center"
-              HorizontalOptions="Start">
-            <Button Text="-"
-                    WidthRequest="36"
-                    HeightRequest="36"
-                    Command="{Binding DecreaseCommand}"
-                    IsEnabled="{Binding CanDecrease}" />
-            <Entry Grid.Column="1"
-                   VerticalOptions="Center"
-                   HorizontalOptions="Start"
-                   MinimumWidthRequest="40"
-                   HorizontalTextAlignment="Center"
-                   Text="{Binding DisplayValue, Mode=OneWay}"
-                   Completed="OnValueEntryCompleted"
-                   Unfocused="OnValueEntryUnfocused" />
-            <Button Grid.Column="2"
-                    Text="+"
-                    WidthRequest="36"
-                    HeightRequest="36"
-                    Command="{Binding IncreaseCommand}"
-                    IsEnabled="{Binding CanIncrease}" />
-        </Grid>
-    </Border>
+             HorizontalOptions="Start">
+    <Grid Padding="2"
+          HorizontalOptions="Start">
+        <Border StrokeShape="RoundRectangle 8"
+                StrokeThickness="1"
+                Stroke="{AppThemeBinding Light=#C6C6C6, Dark=#555555}"
+                BackgroundColor="Transparent"
+                Padding="8,4"
+                HorizontalOptions="Start">
+            <Grid BindingContext="{x:Reference Root}"
+                  ColumnDefinitions="Auto,Auto,Auto"
+                  ColumnSpacing="12"
+                  VerticalOptions="Center"
+                  HorizontalOptions="Start">
+                <Button Text="-"
+                        WidthRequest="36"
+                        HeightRequest="36"
+                        Command="{Binding DecreaseCommand}"
+                        IsEnabled="{Binding CanDecrease}" />
+                <Entry Grid.Column="1"
+                       VerticalOptions="Center"
+                       HorizontalOptions="Start"
+                       MinimumWidthRequest="40"
+                       HorizontalTextAlignment="Center"
+                       Text="{Binding DisplayValue, Mode=OneWay}"
+                       Completed="OnValueEntryCompleted"
+                       Unfocused="OnValueEntryUnfocused" />
+                <Button Grid.Column="2"
+                        Text="+"
+                        WidthRequest="36"
+                        HeightRequest="36"
+                        Command="{Binding IncreaseCommand}"
+                        IsEnabled="{Binding CanIncrease}" />
+            </Grid>
+        </Border>
+    </Grid>
 </ContentView>


### PR DESCRIPTION
Implements:

# GitHub Issue #215: Finish fixing NumericStepper border clipping on Android

URL: https://github.com/com-mit-group/ShuffleTask/issues/215

The NumericStepper content is now aligned so both buttons are tappable and manual entry works, but the border still clips slightly out of bounds on Android. Investigate the border sizing/measurement behavior on Android and ensure the component’s border stays fully within the screen bounds across all views.

Continuation of #167 

Codex plan:

1) Where to look
Investigate `ShuffleTask.Presentation/Controls/NumericStepper.xaml` first, then scan XAML usages in the presentation views to confirm the shared control is the only necessary change.

2) Files / areas likely to touch
`ShuffleTask.Presentation/Controls/NumericStepper.xaml` is the expected implementation target. Touch code-behind only if Android-specific measurement cannot be solved with local XAML sizing constraints.

3) Assumptions
The clipping is caused by the Android layout measuring the outer `ContentView` and inner `Border` at the same starting edge while the stroke extends beyond the measured content. Fixing the control itself should apply across all views that use `NumericStepper`.

4) Plan
- Confirm all `NumericStepper` usages and whether any parent layouts constrain it tightly on Android.
- Adjust the control layout so the border stroke is inset within the measured control bounds without changing button tappability or manual entry.
- Prefer XAML-only sizing/padding changes on the shared control.
- Run the configured MAUI verification through the automation local check.

5) Risks / gotchas
Reducing padding or changing grid spacing can reintroduce the previous tappability/manual-entry issue. Adding only external padding may still let Android clip the border if the border itself remains measured at the edge. Parent views should not need individual workarounds unless a usage explicitly forces clipping.

6) Recommended implementation approach
Move the edge inset into the border layout itself by wrapping the `Border` in a small host grid or otherwise ensuring the stroke is measured inside the `ContentView` bounds, keep the existing fixed button sizes and entry minimum width, and preserve the control's `HorizontalOptions="Start"` behavior.

Local verification:
```text
bash "/home/codex-auto/automation/scripts/codex-verify.sh" --profiles "maui"
```
