### PR TITLE
Split reusable MAUI layer from standalone app presentation host

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,9 +8,9 @@ ShuffleTask follows a clean layered architecture with clear separation of concer
 ┌─────────────────────────────────────────────────────────────┐
 │                    Presentation Layer                       │
 │  ┌─────────────────┐  ┌─────────────────────────────────────┐ │
-│  │   MAUI UI       │  │     Services                       │ │
-│  │   Views         │  │ ┌─────────────────────────────────┐ │ │
-│  │   ViewModels    │  │ │   ShuffleCoordinatorService    │ │ │
+│  │   MAUI Hosts    │  │ Shared Presentation               │ │
+│  │   Views/Shell   │  │ ┌─────────────────────────────────┐ │ │
+│  │   Resources     │  │ │ ViewModels/Coordinator State    │ │ │
 │  │                 │  │ │   NotificationService          │ │ │
 │  └─────────────────┘  │ └─────────────────────────────────┘ │ │
 │                       │                                     │ │
@@ -63,6 +63,16 @@ ShuffleTask follows a clean layered architecture with clear separation of concer
 ```
 
 ## Core Components
+
+### Presentation Project Boundaries
+
+The MAUI presentation layer is split into a reusable shared project and a standalone runnable host:
+
+- `ShuffleTask.Presentation.Shared` contains reusable presentation logic: host-neutral ViewModels, `ShuffleCoordinatorService`, scheduler/timer persistence helpers, selection catalogs, and preference keys. It references Application and Domain, but not Persistence or app resources.
+- `ShuffleTask.Presentation.Shared` exposes `AddShuffleTaskSharedPresentation` so a host can register reusable ViewModels and coordinator services without taking a dependency on the standalone app's Views, Shell, resources, or platform integrations. Hosts must still provide storage, settings, notification, background, and optional network-sync implementations.
+- `ShuffleTask.Presentation` remains the standalone app host. It owns `App`, `AppShell`, concrete Views, XAML controls, resources, platform integrations, notification/background implementations, persistence wiring, and MAUI startup composition.
+- Current Views are intentionally host-specific. SecondBrain can reference `ShuffleTask.Presentation.Shared` and provide its own Views, Shell/navigation, resources, platform services, and startup wiring rather than being forced to mirror the standalone app UI.
+- Settings and peer-management presentation remain in the standalone host for now because they directly use app-specific MAUI UI prompts, file/share pickers, and host composition.
 
 ### 1. Task Lifecycle Management
 

--- a/ShuffleTask.Presentation.Shared/PreferenceKeys.cs
+++ b/ShuffleTask.Presentation.Shared/PreferenceKeys.cs
@@ -1,0 +1,14 @@
+namespace ShuffleTask.Presentation;
+
+// Shared preference keys used by host-specific persistence adapters.
+public static class PreferenceKeys
+{
+    public const string CurrentTaskId = "pref.currentTaskId";
+    public const string TimerDurationSeconds = "pref.timerDurationSecs";
+    public const string TimerExpiresAt = "pref.timerExpiresAt";
+    public const string NextShuffleAt = "pref.nextShuffleAt";
+    public const string PendingShuffleTaskId = "pref.pendingTaskId";
+    public const string ShuffleCountDate = "pref.shuffleCountDate";
+    public const string ShuffleCount = "pref.shuffleCount";
+    public const string CutInLineTaskId = "pref.cutInLineTaskId";
+}

--- a/ShuffleTask.Presentation.Shared/Services/IPersistentBackgroundService.cs
+++ b/ShuffleTask.Presentation.Shared/Services/IPersistentBackgroundService.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ShuffleTask.Presentation.Services;
+
+// Host-provided background scheduler contract consumed by shared presentation services.
+public interface IPersistentBackgroundService
+{
+    Task InitializeAsync();
+
+    Task ScheduleAsync(TimeSpan delay, CancellationToken cancellationToken, Func<Task> callback);
+
+    void Schedule(DateTimeOffset when, string? taskId);
+
+    void Cancel();
+
+    void Stop();
+}

--- a/ShuffleTask.Presentation.Shared/Services/ShuffleCoordinatorService.cs
+++ b/ShuffleTask.Presentation.Shared/Services/ShuffleCoordinatorService.cs
@@ -1,0 +1,983 @@
+using System.Diagnostics;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Utilities;
+using ShuffleTask.Application.Services;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Utilities;
+using ShuffleTask.ViewModels;
+using Microsoft.Maui.ApplicationModel;
+
+namespace ShuffleTask.Presentation.Services;
+
+// Host-neutral coordinator for reusable shuffle timer and notification orchestration.
+public class ShuffleCoordinatorService : IDisposable
+{
+    private readonly IStorageService _storage;
+    private readonly ISchedulerService _scheduler;
+    private readonly INotificationService _notifications;
+    private readonly AppSettings _settings;
+    private readonly INetworkSyncService? _networkSync;
+    private readonly TimeProvider _clock;
+    private readonly IPersistentBackgroundService _backgroundService;
+
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly object _initLock = new();
+    private Task? _initializationTask;
+    private CancellationTokenSource? _timerCts;
+    private WeakReference<DashboardViewModel>? _dashboardRef;
+    private bool _isPaused;
+    private bool _disposed;
+
+    public ShuffleCoordinatorService(
+        IStorageService storage,
+        ISchedulerService scheduler,
+        INotificationService notifications,
+        AppSettings settings,
+        TimeProvider clock,
+        IPersistentBackgroundService backgroundService,
+        INetworkSyncService? networkSync = null)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
+        _notifications = notifications ?? throw new ArgumentNullException(nameof(notifications));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _backgroundService = backgroundService ?? throw new ArgumentNullException(nameof(backgroundService));
+        _networkSync = networkSync;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            CancelTimerInternal();
+            _gate.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    public void RegisterDashboard(DashboardViewModel dashboard)
+    {
+        _dashboardRef = new WeakReference<DashboardViewModel>(dashboard);
+    }
+
+    public Task StartAsync() => ResumeInternalAsync();
+
+    public Task ResumeAsync() => ResumeInternalAsync();
+
+    public async Task ApplyBackgroundActivityChangeAsync(bool enabled)
+    {
+        if (enabled)
+        {
+            await ResumeInternalAsync().ConfigureAwait(false);
+            return;
+        }
+
+        await PauseAsync().ConfigureAwait(false);
+        await _notifications.CancelAllAsync().ConfigureAwait(false);
+        _backgroundService.Stop();
+    }
+
+    private async Task ResumeInternalAsync()
+    {
+        await EnsureInitializedAsync().ConfigureAwait(false);
+
+        await RunWithGateAsync(() =>
+        {
+            _isPaused = false;
+            return Task.CompletedTask;
+        }).ConfigureAwait(false);
+
+        await ScheduleNextShuffleAsync().ConfigureAwait(false);
+    }
+
+    public async Task PauseAsync()
+    {
+        await EnsureInitializedAsync().ConfigureAwait(false);
+
+        await RunWithGateAsync(() =>
+        {
+            _isPaused = true;
+            CancelTimerInternal();
+            return Task.CompletedTask;
+        }).ConfigureAwait(false);
+    }
+
+    public void SuspendInProcessTimer()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        CancelInProcessTimer();
+    }
+
+    public async Task RefreshAsync()
+    {
+        await EnsureInitializedAsync().ConfigureAwait(false);
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            CancelTimerInternal();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        if (!_isPaused && IsBackgroundActivityEnabled(_settings))
+        {
+            await ScheduleNextShuffleAsync().ConfigureAwait(false);
+        }
+    }
+
+    private Task EnsureInitializedAsync()
+    {
+        lock (_initLock)
+        {
+            _initializationTask ??= InitializeAsync();
+            return _initializationTask;
+        }
+    }
+
+    private Task RunWithGateAsync(Func<Task> action)
+    {
+        return RunWithGateAsync(async () =>
+        {
+            await action().ConfigureAwait(false);
+            return true;
+        });
+    }
+
+    private async Task<T> RunWithGateAsync<T>(Func<Task<T>> action)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return await action().ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task InitializeAsync()
+    {
+        await _storage.InitializeAsync().ConfigureAwait(false);
+        await _notifications.InitializeAsync().ConfigureAwait(false);
+        await _backgroundService.InitializeAsync().ConfigureAwait(false);
+    }
+
+    private async Task ScheduleNextShuffleAsync()
+    {
+        if (_isPaused)
+        {
+            return;
+        }
+
+        await EnsureInitializedAsync().ConfigureAwait(false);
+
+        if (!IsBackgroundActivityEnabled(_settings))
+        {
+            CancelTimerInternal();
+            return;
+        }
+
+        await RunWithGateAsync(() => ScheduleNextShuffleUnsafeAsync()).ConfigureAwait(false);
+    }
+
+    private async Task ScheduleNextShuffleUnsafeAsync()
+    {
+        CancelTimerInternal();
+
+        var settings = _settings;
+        if (HandleAutoShuffleDisabled(settings))
+        {
+            return;
+        }
+
+        DateTimeOffset now = GetCurrentInstant();
+        ResetDailyCountIfNeeded(now);
+
+        if (TryScheduleAfterDailyLimit(settings, now))
+        {
+            return;
+        }
+
+        if (await TryResumePendingShuffleAsync(settings, now).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        await ScheduleFromAvailableTasksAsync(settings, now).ConfigureAwait(false);
+    }
+
+    private bool HandleAutoShuffleDisabled(AppSettings settings)
+    {
+        if (ShouldAutoShuffle(settings))
+        {
+            return false;
+        }
+
+        ClearPendingShuffle();
+        return true;
+    }
+
+    private bool TryScheduleAfterDailyLimit(AppSettings settings, DateTimeOffset now)
+    {
+        if (!HasReachedDailyLimit(settings, now))
+        {
+            return false;
+        }
+
+        DateTimeOffset resumeAt = EnsureAllowed(GetNextDayStart(now, settings), settings);
+        StartTimer(resumeAt, null);
+        return true;
+    }
+
+    private async Task<bool> TryResumePendingShuffleAsync(AppSettings settings, DateTimeOffset now)
+    {
+        var pending = LoadPendingShuffle();
+        if (!pending.NextAt.HasValue)
+        {
+            return false;
+        }
+
+        DateTimeOffset target = NormalizePendingTarget(pending.NextAt.Value, now);
+        if (await TryRestorePendingTaskAsync(pending.TaskId, target, settings).ConfigureAwait(false))
+        {
+            return true;
+        }
+
+        StartTimer(target, null);
+        return true;
+    }
+
+    private async Task ScheduleFromAvailableTasksAsync(AppSettings settings, DateTimeOffset now)
+    {
+        var tasks = await LoadAvailableTasksAsync(settings).ConfigureAwait(false);
+        if (HandleEmptyTaskList(tasks, settings, now))
+        {
+            return;
+        }
+
+        DateTimeOffset target = ComputeNextTarget(now, settings);
+        if (TryScheduleCandidate(tasks, settings, target))
+        {
+            return;
+        }
+
+        if (ShouldDelayForWeekend(tasks, target))
+        {
+            DateTimeOffset resumeAt = TimeWindowService.NextWeekdayStart(target, settings.WorkStart);
+            resumeAt = EnsureAllowed(resumeAt, settings);
+            StartTimer(resumeAt, null);
+            return;
+        }
+
+        DateTimeOffset retryAt = EnsureAllowed(now.AddMinutes(Math.Max(5, settings.MinGapMinutes)), settings);
+        StartTimer(retryAt, null);
+    }
+
+    private static DateTimeOffset NormalizePendingTarget(DateTimeOffset nextAt, DateTimeOffset now)
+    {
+        return nextAt <= now ? now : nextAt;
+    }
+
+    private async Task<bool> TryRestorePendingTaskAsync(string taskId, DateTimeOffset target, AppSettings settings)
+    {
+        if (string.IsNullOrEmpty(taskId))
+        {
+            return false;
+        }
+
+        var pendingTask = await _storage.GetTaskAsync(taskId).ConfigureAwait(false);
+        if (pendingTask != null && IsTaskValid(pendingTask, settings, target))
+        {
+            StartTimer(target, taskId);
+            return true;
+        }
+
+        return false;
+    }
+
+    private async Task<IReadOnlyList<TaskItem>> LoadAvailableTasksAsync(AppSettings settings)
+    {
+        var network = settings.Network;
+        return await _storage.GetTasksAsync(network?.UserId, network?.DeviceId ?? string.Empty).ConfigureAwait(false);
+    }
+
+    private bool HandleEmptyTaskList(IReadOnlyCollection<TaskItem> tasks, AppSettings settings, DateTimeOffset now)
+    {
+        if (tasks.Count > 0)
+        {
+            return false;
+        }
+
+        ClearPendingShuffle();
+        var retryAtEmpty = EnsureAllowed(now.AddMinutes(30), settings);
+        StartTimer(retryAtEmpty, null);
+        return true;
+    }
+
+    private bool TryScheduleCandidate(IReadOnlyList<TaskItem> tasks, AppSettings settings, DateTimeOffset target)
+    {
+        var candidate = _scheduler.PickNextTask(tasks, settings, target);
+        if (candidate == null)
+        {
+            return false;
+        }
+
+        StartTimer(target, candidate.Id);
+        return true;
+    }
+
+    private DateTimeOffset ComputeNextTarget(DateTimeOffset now, AppSettings settings)
+    {
+        TimeSpan gap = _scheduler.NextGap(settings, now);
+        DateTimeOffset target = now + gap;
+        if (target <= now)
+        {
+            target = now.AddMinutes(1);
+        }
+
+        target = EnsureAllowed(target, settings);
+        if (target <= now)
+        {
+            target = now.AddMinutes(1);
+        }
+
+        return target;
+    }
+
+    private void StartTimer(DateTimeOffset scheduledAt, string? taskId)
+    {
+        CancelTimerInternal();
+        PersistPendingShuffle(taskId, scheduledAt);
+        SchedulePersistentTimer(scheduledAt, taskId);
+        ScheduleInProcessTimer(scheduledAt, taskId);
+    }
+
+    private void SchedulePersistentTimer(DateTimeOffset scheduledAt, string? taskId)
+    {
+        try
+        {
+            _backgroundService.Schedule(scheduledAt, taskId);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"ShuffleCoordinatorService persistent schedule error: {ex}");
+        }
+    }
+
+    private void ScheduleInProcessTimer(DateTimeOffset scheduledAt, string? taskId)
+    {
+        var cts = new CancellationTokenSource();
+        _timerCts = cts;
+
+        TimeSpan delay = scheduledAt - GetCurrentInstant();
+        if (delay < TimeSpan.Zero)
+        {
+            delay = TimeSpan.Zero;
+        }
+
+        _ = _backgroundService.ScheduleAsync(delay, cts.Token, async () =>
+        {
+            if (cts.Token.IsCancellationRequested)
+            {
+                Debug.WriteLine("ShuffleCoordinatorService timer cancelled");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(taskId))
+            {
+                await OnTimerReevaluateAsync(cts).ConfigureAwait(false);
+            }
+            else
+            {
+                await ExecuteShuffleAsync(taskId, cts).ConfigureAwait(false);
+            }
+        });
+    }
+
+    private async Task OnTimerReevaluateAsync(CancellationTokenSource cts)
+    {
+        CancelPersistentSchedule();
+
+        await RunWithGateAsync(() =>
+        {
+            ClearTimerReferenceIfCurrent(cts);
+            return Task.CompletedTask;
+        }).ConfigureAwait(false);
+
+        if (_isPaused)
+        {
+            return;
+        }
+
+        await ScheduleNextShuffleAsync().ConfigureAwait(false);
+    }
+
+    private async Task ExecuteShuffleAsync(string taskId, CancellationTokenSource cts)
+    {
+        CancelPersistentSchedule();
+
+        bool executed = false;
+
+        await RunWithGateAsync(async () =>
+        {
+            executed = await ExecuteShuffleUnsafeAsync(taskId, cts).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        if (executed && !_isPaused)
+        {
+            await ScheduleNextShuffleAsync().ConfigureAwait(false);
+        }
+    }
+
+    private void ClearTimerReferenceIfCurrent(CancellationTokenSource cts)
+    {
+        if (ReferenceEquals(_timerCts, cts))
+        {
+            _timerCts = null;
+        }
+    }
+
+    public async Task HandlePersistentTriggerAsync()
+    {
+        await EnsureInitializedAsync().ConfigureAwait(false);
+
+        if (!IsBackgroundActivityEnabled(_settings))
+        {
+            CancelTimerInternal();
+            return;
+        }
+
+        if (Volatile.Read(ref _timerCts) != null)
+        {
+            CancelPersistentSchedule();
+            return;
+        }
+
+        bool paused;
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            paused = _isPaused;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        if (paused)
+        {
+            CancelPersistentSchedule();
+            return;
+        }
+
+        var (scheduledAt, taskId) = LoadPendingShuffle();
+        if (scheduledAt.HasValue)
+        {
+            DateTimeOffset now = GetCurrentInstant();
+            if (scheduledAt.Value - now > TimeSpan.FromMinutes(1))
+            {
+                try
+                {
+                    _backgroundService.Schedule(scheduledAt.Value, string.IsNullOrEmpty(taskId) ? null : taskId);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"ShuffleCoordinatorService persistent reschedule error: {ex}");
+                }
+
+                return;
+            }
+        }
+
+        if (string.IsNullOrEmpty(taskId))
+        {
+            CancelPersistentSchedule();
+            await ScheduleNextShuffleAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            await NotifyExpiredTimerAsync().ConfigureAwait(false);
+            using var cts = new CancellationTokenSource();
+            await ExecuteShuffleAsync(taskId, cts).ConfigureAwait(false);
+        }
+    }
+
+    private async Task NotifyExpiredTimerAsync()
+    {
+        if (!IsBackgroundActivityEnabled(_settings))
+        {
+            return;
+        }
+
+        if (!PersistedTimerState.TryGetActiveTimer(
+                out _,
+                out _,
+                out bool expired,
+                out _,
+                out DateTimeOffset expiresAt))
+        {
+            return;
+        }
+
+        DateTimeOffset now = GetCurrentInstant();
+        if (!expired && expiresAt - now > TimeSpan.FromSeconds(5))
+        {
+            return;
+        }
+
+        var settings = _settings;
+        const string TimeUpTitle = "Time's up";
+        const string TimeUpMessage = "Shuffling a new task...";
+        await _notifications.ShowToastAsync(TimeUpTitle, TimeUpMessage, settings).ConfigureAwait(false);
+        if (_networkSync != null)
+        {
+            await _networkSync.PublishTimeUpNotificationAsync().ConfigureAwait(false);
+        }
+        PersistedTimerState.Clear();
+    }
+
+    private async Task<bool> ExecuteShuffleUnsafeAsync(string taskId, CancellationTokenSource cts)
+    {
+        if (ReferenceEquals(_timerCts, cts))
+        {
+            _timerCts = null;
+        }
+
+        if (_isPaused)
+        {
+            return false;
+        }
+
+        var settings = _settings;
+        if (!ShouldAutoShuffle(settings))
+        {
+            ClearPendingShuffle();
+            return false;
+        }
+
+        DateTimeOffset now = GetCurrentInstant();
+
+        // Guard: Prevent auto-shuffle from replacing an already active task.
+        // This ensures that once a task is active, it remains active until the user
+        // explicitly marks it done, snoozes it, or manually shuffles to a different task.
+        // This guard only affects automatic shuffles; manual shuffles via UI are not blocked.
+        if (HasActiveTask())
+        {
+            Debug.WriteLine("ShuffleCoordinatorService: Auto-shuffle blocked - active task already exists");
+            DateTimeOffset resumeAt = ComputeNextTarget(now, settings);
+            StartTimer(resumeAt, taskId);
+            return false;
+        }
+
+        ResetDailyCountIfNeeded(now);
+
+        if (HandleQuietHoursOrLimit(settings, now, taskId))
+        {
+            return false;
+        }
+
+        TaskItem? task = await ResolveTaskAsync(taskId, settings, now).ConfigureAwait(false);
+        if (task == null)
+        {
+            return false;
+        }
+
+        ClearPendingShuffle();
+
+        EffectiveTimerSettings effectiveSettings = TaskTimerSettings.Resolve(task, settings);
+        PersistActiveTask(task, effectiveSettings);
+        await HandleCutInLineModeAsync(task).ConfigureAwait(false);
+        await NotifyAsync(task, settings, effectiveSettings).ConfigureAwait(false);
+        IncrementDailyCount(now);
+        return true;
+    }
+
+    private bool HandleQuietHoursOrLimit(AppSettings settings, DateTimeOffset now, string taskId)
+    {
+        if (IsWithinQuietHours(now, settings))
+        {
+            DateTimeOffset resumeAt = EnsureAllowed(now, settings);
+            StartTimer(resumeAt, taskId);
+            return true;
+        }
+
+        if (HasReachedDailyLimit(settings, now))
+        {
+            DateTimeOffset resumeAt = EnsureAllowed(GetNextDayStart(now, settings), settings);
+            StartTimer(resumeAt, null);
+            return true;
+        }
+
+        return false;
+    }
+
+    private async Task<TaskItem?> ResolveTaskAsync(string taskId, AppSettings settings, DateTimeOffset now)
+    {
+        TaskItem? task = await _storage.GetTaskAsync(taskId).ConfigureAwait(false);
+        if (task != null && IsTaskValid(task, settings, now))
+        {
+            return task;
+        }
+
+        var network = settings.Network;
+        var tasks = await _storage.GetTasksAsync(network?.UserId, network?.DeviceId ?? string.Empty).ConfigureAwait(false);
+        TaskItem? candidate = _scheduler.PickNextTask(tasks, settings, now);
+        if (candidate != null)
+        {
+            return candidate;
+        }
+
+        ClearPendingShuffle();
+        DateTimeOffset retryAt = EnsureAllowed(now.AddMinutes(30), settings);
+        StartTimer(retryAt, null);
+        return null;
+    }
+
+    private async Task NotifyAsync(TaskItem task, AppSettings settings, EffectiveTimerSettings effectiveSettings)
+    {
+        if (_dashboardRef != null && _dashboardRef.TryGetTarget(out var dashboard))
+        {
+            Task applyTask = MainThread.InvokeOnMainThreadAsync(() => dashboard.ApplyAutoOrCrossDeviceShuffleAsync(task, settings));
+            await applyTask.ConfigureAwait(false);
+        }
+
+        int minutes = Math.Max(1, effectiveSettings.InitialMinutes);
+        await _notifications.NotifyTaskAsync(task, minutes, settings).ConfigureAwait(false);
+        if (_networkSync != null)
+        {
+            await _networkSync.PublishTaskStartedAsync(task.Id, minutes).ConfigureAwait(false);
+        }
+    }
+
+    private async Task HandleCutInLineModeAsync(TaskItem task)
+    {
+        await CutInLineUtilities.ClearCutInLineOnceAsync(task, _storage).ConfigureAwait(false);
+        // UntilCompletion mode is handled when the task is marked done
+    }
+
+    private static bool ShouldAutoShuffle(AppSettings settings)
+    {
+        if (settings is null)
+        {
+            return false;
+        }
+
+        if (!IsBackgroundActivityEnabled(settings))
+        {
+            return false;
+        }
+
+        if (!settings.Active)
+        {
+            return false;
+        }
+
+        if (!settings.AutoShuffleEnabled)
+        {
+            return false;
+        }
+
+        if (!settings.EnableNotifications)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsBackgroundActivityEnabled(AppSettings settings)
+    {
+        return settings.BackgroundActivityEnabled;
+    }
+
+    private static bool HasReachedDailyLimit(AppSettings settings, DateTimeOffset now)
+    {
+        int max = settings.MaxDailyShuffles;
+        if (max <= 0)
+        {
+            return false;
+        }
+
+        var (date, count) = LoadDailyCount();
+        if (!date.HasValue)
+        {
+            return false;
+        }
+
+        DateTimeOffset local = TimeZoneInfo.ConvertTime(now, TimeZoneInfo.Local);
+        return date.Value.Date == local.Date && count >= max;
+    }
+
+    private static DateTimeOffset GetNextDayStart(DateTimeOffset now, AppSettings settings)
+    {
+        DateTimeOffset local = TimeZoneInfo.ConvertTime(now, TimeZoneInfo.Local);
+        DateTime nextDay = local.Date.AddDays(1);
+        if (settings.QuietHoursStart != settings.QuietHoursEnd)
+        {
+            DateTime localCandidate = nextDay + settings.QuietHoursEnd;
+            return new DateTimeOffset(localCandidate, local.Offset).ToOffset(TimeSpan.Zero);
+        }
+
+        DateTime defaultCandidate = nextDay + settings.WorkStart;
+        return new DateTimeOffset(defaultCandidate, local.Offset).ToOffset(TimeSpan.Zero);
+    }
+
+    private static bool IsWithinQuietHours(DateTimeOffset time, AppSettings settings)
+    {
+        var start = settings.QuietHoursStart;
+        var end = settings.QuietHoursEnd;
+
+        if (start == end)
+        {
+            return false;
+        }
+
+        DateTimeOffset local = TimeZoneInfo.ConvertTime(time, TimeZoneInfo.Local);
+        TimeSpan t = local.TimeOfDay;
+        if (start < end)
+        {
+            return t >= start && t < end;
+        }
+
+        return t >= start || t < end;
+    }
+
+    private static DateTimeOffset EnsureAllowed(DateTimeOffset candidate, AppSettings settings)
+    {
+        if (!IsWithinQuietHours(candidate, settings))
+        {
+            return candidate;
+        }
+
+        return GetQuietHoursEnd(candidate, settings);
+    }
+
+    private static DateTimeOffset GetQuietHoursEnd(DateTimeOffset current, AppSettings settings)
+    {
+        var start = settings.QuietHoursStart;
+        var end = settings.QuietHoursEnd;
+        DateTimeOffset local = TimeZoneInfo.ConvertTime(current, TimeZoneInfo.Local);
+        DateTime baseDate = local.Date;
+
+        if (start < end)
+        {
+            DateTime quietEnd = baseDate + end;
+            if (local.TimeOfDay < end)
+            {
+                return new DateTimeOffset(quietEnd, local.Offset).ToOffset(TimeSpan.Zero);
+            }
+
+            DateTime next = quietEnd.AddDays(1);
+            return new DateTimeOffset(next, local.Offset).ToOffset(TimeSpan.Zero);
+        }
+        else
+        {
+            if (local.TimeOfDay >= start)
+            {
+                DateTime next = baseDate.AddDays(1) + end;
+                return new DateTimeOffset(next, local.Offset).ToOffset(TimeSpan.Zero);
+            }
+
+            if (local.TimeOfDay < end)
+            {
+                DateTime sameDay = baseDate + end;
+                return new DateTimeOffset(sameDay, local.Offset).ToOffset(TimeSpan.Zero);
+            }
+
+            DateTime fallback = baseDate + start;
+            return new DateTimeOffset(fallback, local.Offset).ToOffset(TimeSpan.Zero);
+        }
+    }
+
+    private static bool IsTaskValid(TaskItem task, AppSettings settings, DateTimeOffset when)
+    {
+        if (task.Paused)
+        {
+            return false;
+        }
+
+        return TimeWindowService.AllowedNow(task, when, settings);
+    }
+
+    private bool ShouldDelayForWeekend(IReadOnlyList<TaskItem> tasks, DateTimeOffset target)
+    {
+        if (!TimeWindowService.IsWeekend(target))
+        {
+            return false;
+        }
+
+        bool hasWeekendBlocked = false;
+        foreach (var task in tasks)
+        {
+            if (task is null)
+            {
+                continue;
+            }
+
+            if (task.Paused || !task.AutoShuffleAllowed)
+            {
+                continue;
+            }
+
+            if (!UtilityMethods.LifecycleEligible(task, target.UtcDateTime))
+            {
+                continue;
+            }
+
+            if (TimeWindowService.AllowsWeekend(task, _settings))
+            {
+                return false;
+            }
+
+            hasWeekendBlocked = true;
+        }
+
+        return hasWeekendBlocked;
+    }
+
+    private static void PersistPendingShuffle(string? taskId, DateTimeOffset scheduledAt)
+    {
+        PersistedSchedulerState.SavePendingShuffle(taskId, scheduledAt);
+    }
+
+    private static void PersistActiveTask(TaskItem task, EffectiveTimerSettings timerSettings)
+    {
+        int seconds = Math.Max(1, timerSettings.InitialMinutes) * 60;
+        PersistedTimerState.SaveActiveTimer(
+            task.Id,
+            seconds,
+            DateTimeOffset.UtcNow.AddSeconds(seconds),
+            new PersistedTimerState.TimerDetails(
+                (int)timerSettings.Mode,
+                timerSettings.Mode == TimerMode.Pomodoro ? 0 : null,
+                1,
+                timerSettings.PomodoroCycles,
+                timerSettings.FocusMinutes,
+                timerSettings.BreakMinutes));
+    }
+
+    /// <summary>
+    /// Checks if there is currently an active task based on stored preferences.
+    /// A task is considered active if both the task ID exists and there is remaining time > 0.
+    /// </summary>
+    /// <returns>True if an active task exists; otherwise, false.</returns>
+    private static bool HasActiveTask()
+    {
+        return PersistedTimerState.TryGetActiveTimer(
+            out _,
+            out _,
+            out bool expired,
+            out _,
+            out _)
+            && !expired;
+    }
+
+    private static (DateTimeOffset? NextAt, string TaskId) LoadPendingShuffle()
+    {
+        return PersistedSchedulerState.LoadPendingShuffle();
+    }
+
+    private static (DateTimeOffset? Date, int Count) LoadDailyCount()
+    {
+        return PersistedSchedulerState.LoadDailyCount();
+    }
+
+    private static void ResetDailyCountIfNeeded(DateTimeOffset now)
+    {
+        DateTimeOffset local = TimeZoneInfo.ConvertTime(now, TimeZoneInfo.Local);
+        bool needsReset = true;
+        var (date, _) = LoadDailyCount();
+        if (date.HasValue)
+        {
+            DateTimeOffset existingLocal = TimeZoneInfo.ConvertTime(date.Value, TimeZoneInfo.Local);
+            needsReset = existingLocal.Date != local.Date;
+        }
+
+        if (needsReset)
+        {
+            var storedLocal = new DateTimeOffset(local.Date, local.Offset);
+            PersistedSchedulerState.SaveDailyCount(storedLocal, 0);
+        }
+    }
+
+    private static void IncrementDailyCount(DateTimeOffset now)
+    {
+        var (date, count) = LoadDailyCount();
+        DateTimeOffset local = TimeZoneInfo.ConvertTime(now, TimeZoneInfo.Local);
+        if (!date.HasValue || TimeZoneInfo.ConvertTime(date.Value, TimeZoneInfo.Local).Date != local.Date)
+        {
+            date = new DateTimeOffset(local.Date, local.Offset);
+            count = 0;
+        }
+
+        PersistedSchedulerState.SaveDailyCount(date.Value, count + 1);
+    }
+
+    private static void ClearPendingShuffle()
+    {
+        PersistedSchedulerState.ClearPendingShuffle();
+    }
+
+    private void CancelPersistentSchedule()
+    {
+        try
+        {
+            _backgroundService.Cancel();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"ShuffleCoordinatorService persistent cancel error: {ex}");
+        }
+    }
+
+    private void CancelTimerInternal()
+    {
+        CancelInProcessTimer();
+        CancelPersistentSchedule();
+    }
+
+    private void CancelInProcessTimer()
+    {
+        var existing = Interlocked.Exchange(ref _timerCts, null);
+        if (existing != null)
+        {
+            try
+            {
+                existing.Cancel();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"ShuffleCoordinatorService cancellation error: {ex}");
+            }
+            finally
+            {
+                existing.Dispose();
+            }
+        }
+    }
+
+    private DateTimeOffset GetCurrentInstant()
+        => _clock.GetUtcNow();
+}

--- a/ShuffleTask.Presentation.Shared/SharedPresentationServiceCollectionExtensions.cs
+++ b/ShuffleTask.Presentation.Shared/SharedPresentationServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Services;
+using ShuffleTask.Presentation.Services;
+using ShuffleTask.ViewModels;
+
+namespace ShuffleTask.Presentation;
+
+public static class SharedPresentationServiceCollectionExtensions
+{
+    public static IServiceCollection AddShuffleTaskSharedPresentation(
+        this IServiceCollection services,
+        Action<IServiceProvider, DashboardViewModel>? configureDashboard = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<TimeProvider>(_ => TimeProvider.System);
+        services.TryAddSingleton<ISchedulerService>(_ => new SchedulerService(deterministic: false));
+        services.TryAddSingleton<ShuffleCoordinatorService>();
+        services.TryAddSingleton<TasksViewModel>();
+        services.TryAddSingleton<EditTaskViewModel>();
+        services.TryAddSingleton<PeriodDefinitionEditorViewModel>();
+        services.TryAddSingleton(sp =>
+        {
+            var dashboardViewModel = new DashboardViewModel(
+                sp.GetRequiredService<IStorageService>(),
+                sp.GetRequiredService<ISchedulerService>(),
+                sp.GetRequiredService<INotificationService>(),
+                sp.GetRequiredService<ShuffleCoordinatorService>(),
+                sp.GetRequiredService<TimeProvider>(),
+                sp.GetRequiredService<INetworkSyncService>(),
+                sp.GetRequiredService<AppSettings>());
+
+            configureDashboard?.Invoke(sp, dashboardViewModel);
+            return dashboardViewModel;
+        });
+
+        return services;
+    }
+}

--- a/ShuffleTask.Presentation.Shared/SharedPresentationServiceCollectionExtensions.cs
+++ b/ShuffleTask.Presentation.Shared/SharedPresentationServiceCollectionExtensions.cs
@@ -6,7 +6,7 @@ using ShuffleTask.Application.Services;
 using ShuffleTask.Presentation.Services;
 using ShuffleTask.ViewModels;
 
-namespace ShuffleTask.Presentation;
+namespace ShuffleTask.Presentation.Shared;
 
 public static class SharedPresentationServiceCollectionExtensions
 {

--- a/ShuffleTask.Presentation.Shared/ShuffleTask.Presentation.Shared.csproj
+++ b/ShuffleTask.Presentation.Shared/ShuffleTask.Presentation.Shared.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks Condition="'$(TargetFramework)' == ''">net10.0;net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFramework)' == '' and $([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('ios'))">$(TargetFrameworks);net10.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('maccatalyst'))">$(TargetFrameworks);net10.0-maccatalyst</TargetFrameworks>
+    <RootNamespace>ShuffleTask.Presentation</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net10.0'">
+    <UseMaui>true</UseMaui>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <DefineConstants>$(DefineConstants);TEST</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
+    <Compile Remove="TestShims\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
+    <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.51" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ShuffleTask.Application\ShuffleTask.Application.csproj" />
+    <ProjectReference Include="..\ShuffleTask.Domain\ShuffleTask.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ShuffleTask.Presentation.Shared/TestShims/MauiStubs.cs
+++ b/ShuffleTask.Presentation.Shared/TestShims/MauiStubs.cs
@@ -1,0 +1,71 @@
+using System.Collections.Concurrent;
+
+namespace Microsoft.Maui.ApplicationModel
+{
+    // Test-only MAUI stand-ins for shared presentation code on net10.0.
+    public static class MainThread
+    {
+        public static bool IsMainThread => true;
+
+        public static void BeginInvokeOnMainThread(Action action)
+        {
+            ArgumentNullException.ThrowIfNull(action);
+            action();
+        }
+
+        public static Task InvokeOnMainThreadAsync(Func<Task> function)
+        {
+            ArgumentNullException.ThrowIfNull(function);
+            return function();
+        }
+    }
+}
+
+namespace Microsoft.Maui.Storage
+{
+    public interface IPreferences
+    {
+        T Get<T>(string key, T defaultValue);
+
+        void Set<T>(string key, T value);
+
+        void Remove(string key);
+    }
+
+    public sealed class InMemoryPreferences : IPreferences
+    {
+        private readonly ConcurrentDictionary<string, object?> _values = new();
+
+        public T Get<T>(string key, T defaultValue)
+        {
+            return _values.TryGetValue(key, out var value) && value is T typed
+                ? typed
+                : defaultValue;
+        }
+
+        public void Set<T>(string key, T value)
+        {
+            _values[key] = value;
+        }
+
+        public void Remove(string key)
+        {
+            _values.TryRemove(key, out _);
+        }
+
+        public void Clear()
+        {
+            _values.Clear();
+        }
+    }
+
+    public static class Preferences
+    {
+        public static IPreferences Default { get; } = new InMemoryPreferences();
+
+        public static void Clear()
+        {
+            (Default as InMemoryPreferences)?.Clear();
+        }
+    }
+}

--- a/ShuffleTask.Presentation.Shared/Utilities/AlignmentModeCatalog.cs
+++ b/ShuffleTask.Presentation.Shared/Utilities/AlignmentModeCatalog.cs
@@ -1,0 +1,37 @@
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.ViewModels;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+// Shared alignment options used by host-specific period definition views.
+public static class AlignmentModeCatalog
+{
+    public static IReadOnlyList<AlignmentModeOption> Defaults { get; } =
+        new[]
+        {
+            new AlignmentModeOption(
+                "Fixed time window",
+                "Use the start and end times below.",
+                PeriodDefinitionMode.None),
+            new AlignmentModeOption(
+                "Align with work hours",
+                "Uses Settings → Work hours for the time range.",
+                PeriodDefinitionMode.AlignWithWorkHours),
+            new AlignmentModeOption(
+                "Align with off-work hours",
+                "Schedules outside Settings → Work hours (includes weekends).",
+                PeriodDefinitionMode.AlignWithWorkHours | PeriodDefinitionMode.OffWorkRelativeToWorkHours),
+            new AlignmentModeOption(
+                "Morning (settings)",
+                "Uses Settings → Morning hours for the time range.",
+                PeriodDefinitionMode.Morning),
+            new AlignmentModeOption(
+                "Lunch (settings)",
+                "Uses Settings → Lunch hours for the time range.",
+                PeriodDefinitionMode.Lunch),
+            new AlignmentModeOption(
+                "Evening (settings)",
+                "Uses Settings → Evening hours for the time range.",
+                PeriodDefinitionMode.Evening)
+        };
+}

--- a/ShuffleTask.Presentation.Shared/Utilities/PersistedSchedulerState.cs
+++ b/ShuffleTask.Presentation.Shared/Utilities/PersistedSchedulerState.cs
@@ -1,0 +1,183 @@
+using Microsoft.Maui.Storage;
+using ShuffleTask.Application.Abstractions;
+using System.Globalization;
+using System.Text.Json;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+// Shared scheduler state persistence helper backed by host-provided MAUI preferences.
+public static class PersistedSchedulerState
+{
+    public const string SchedulerEnvelopeKey = "pref.schedulerEnvelope";
+    public const string SchedulerQuarantinePrefix = "pref.schedulerEnvelope.quarantine.";
+    private const int CurrentSchemaVersion = 1;
+
+    public static void SavePendingShuffle(string? taskId, DateTimeOffset scheduledAt, IShuffleLogger? logger = null)
+    {
+        var envelope = LoadEnvelopeOrDefault(logger);
+        envelope.PendingNextAt = scheduledAt;
+        envelope.PendingTaskId = string.IsNullOrWhiteSpace(taskId) ? null : taskId.Trim();
+        SaveEnvelope(envelope, logger, "pending-save");
+
+        Preferences.Default.Set(PreferenceKeys.NextShuffleAt, scheduledAt.ToString("O", CultureInfo.InvariantCulture));
+        if (string.IsNullOrWhiteSpace(envelope.PendingTaskId))
+        {
+            Preferences.Default.Remove(PreferenceKeys.PendingShuffleTaskId);
+        }
+        else
+        {
+            Preferences.Default.Set(PreferenceKeys.PendingShuffleTaskId, envelope.PendingTaskId);
+        }
+    }
+
+    public static (DateTimeOffset? NextAt, string TaskId) LoadPendingShuffle(IShuffleLogger? logger = null)
+    {
+        if (TryReadEnvelope(out SchedulerEnvelope? envelope, logger) && envelope!.PendingNextAt.HasValue)
+        {
+            return (envelope.PendingNextAt.Value, envelope.PendingTaskId ?? string.Empty);
+        }
+
+        string iso = Preferences.Default.Get(PreferenceKeys.NextShuffleAt, string.Empty);
+        string taskId = Preferences.Default.Get(PreferenceKeys.PendingShuffleTaskId, string.Empty);
+
+        if (!string.IsNullOrWhiteSpace(iso)
+            && DateTimeOffset.TryParse(iso, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var nextAt))
+        {
+            return (nextAt, taskId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(iso))
+        {
+            QuarantineLegacySchedulerState("invalid-pending-date", logger);
+        }
+
+        return (null, taskId);
+    }
+
+    public static void ClearPendingShuffle(IShuffleLogger? logger = null)
+    {
+        var envelope = LoadEnvelopeOrDefault(logger);
+        envelope.PendingNextAt = null;
+        envelope.PendingTaskId = null;
+        SaveEnvelope(envelope, logger, "pending-clear");
+        Preferences.Default.Remove(PreferenceKeys.NextShuffleAt);
+        Preferences.Default.Remove(PreferenceKeys.PendingShuffleTaskId);
+    }
+
+    public static (DateTimeOffset? Date, int Count) LoadDailyCount(IShuffleLogger? logger = null)
+    {
+        if (TryReadEnvelope(out SchedulerEnvelope? envelope, logger) && envelope!.ShuffleCountDate.HasValue)
+        {
+            return (envelope.ShuffleCountDate.Value, Math.Max(0, envelope.ShuffleCount));
+        }
+
+        string iso = Preferences.Default.Get(PreferenceKeys.ShuffleCountDate, string.Empty);
+        int count = Preferences.Default.Get(PreferenceKeys.ShuffleCount, 0);
+
+        if (!string.IsNullOrWhiteSpace(iso)
+            && DateTimeOffset.TryParse(iso, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var date))
+        {
+            return (date, Math.Max(0, count));
+        }
+
+        if (!string.IsNullOrWhiteSpace(iso))
+        {
+            QuarantineLegacySchedulerState("invalid-daily-count-date", logger);
+        }
+
+        return (null, 0);
+    }
+
+    public static void SaveDailyCount(DateTimeOffset date, int count, IShuffleLogger? logger = null)
+    {
+        var envelope = LoadEnvelopeOrDefault(logger);
+        envelope.ShuffleCountDate = date;
+        envelope.ShuffleCount = Math.Max(0, count);
+        SaveEnvelope(envelope, logger, "daily-count-save");
+
+        Preferences.Default.Set(PreferenceKeys.ShuffleCountDate, date.ToString("O", CultureInfo.InvariantCulture));
+        Preferences.Default.Set(PreferenceKeys.ShuffleCount, Math.Max(0, count));
+    }
+
+    private static SchedulerEnvelope LoadEnvelopeOrDefault(IShuffleLogger? logger)
+    {
+        return TryReadEnvelope(out SchedulerEnvelope? envelope, logger)
+            ? envelope!
+            : new SchedulerEnvelope { SchemaVersion = CurrentSchemaVersion };
+    }
+
+    private static void SaveEnvelope(SchedulerEnvelope envelope, IShuffleLogger? logger, string operation)
+    {
+        logger?.LogSyncEvent("PersistenceSaveStarted", $"domain=scheduler-state; operation={operation}");
+        envelope.SchemaVersion = CurrentSchemaVersion;
+        envelope.SavedAtUtc = DateTimeOffset.UtcNow;
+        Preferences.Default.Set(SchedulerEnvelopeKey, JsonSerializer.Serialize(envelope));
+        logger?.LogSyncEvent("PersistenceSaveCompleted", $"domain=scheduler-state; operation={operation}");
+    }
+
+    private static bool TryReadEnvelope(out SchedulerEnvelope? envelope, IShuffleLogger? logger)
+    {
+        envelope = null;
+        string json = Preferences.Default.Get(SchedulerEnvelopeKey, string.Empty);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            var candidate = JsonSerializer.Deserialize<SchedulerEnvelope>(json);
+            if (candidate == null)
+            {
+                QuarantineSchedulerEnvelope(json, "invalid-envelope", logger);
+                return false;
+            }
+
+            if (candidate.SchemaVersion > CurrentSchemaVersion)
+            {
+                logger?.LogSyncEvent("PersistenceLoadUnsupportedSchema", $"domain=scheduler-state; schemaVersion={candidate.SchemaVersion}");
+                return false;
+            }
+
+            envelope = candidate;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            QuarantineSchedulerEnvelope(json, "corrupt-envelope", logger, ex);
+            return false;
+        }
+    }
+
+    private static void QuarantineSchedulerEnvelope(string json, string reason, IShuffleLogger? logger, Exception? exception = null)
+    {
+        string key = SchedulerQuarantinePrefix + DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmssfffffff", CultureInfo.InvariantCulture);
+        Preferences.Default.Set(key, json);
+        Preferences.Default.Remove(SchedulerEnvelopeKey);
+        logger?.LogSyncEvent("PersistenceQuarantine", $"domain=scheduler-state; reason={reason}; artifact={key}", exception);
+    }
+
+    private static void QuarantineLegacySchedulerState(string reason, IShuffleLogger? logger)
+    {
+        var legacy = new
+        {
+            NextShuffleAt = Preferences.Default.Get(PreferenceKeys.NextShuffleAt, string.Empty),
+            PendingTaskId = Preferences.Default.Get(PreferenceKeys.PendingShuffleTaskId, string.Empty),
+            ShuffleCountDate = Preferences.Default.Get(PreferenceKeys.ShuffleCountDate, string.Empty),
+            ShuffleCount = Preferences.Default.Get(PreferenceKeys.ShuffleCount, 0)
+        };
+        string key = SchedulerQuarantinePrefix + "legacy." + DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmssfffffff", CultureInfo.InvariantCulture);
+        Preferences.Default.Set(key, JsonSerializer.Serialize(legacy));
+        logger?.LogSyncEvent("PersistenceQuarantine", $"domain=scheduler-state; reason={reason}; artifact={key}");
+    }
+
+    private sealed class SchedulerEnvelope
+    {
+        public int SchemaVersion { get; set; }
+        public DateTimeOffset? PendingNextAt { get; set; }
+        public string? PendingTaskId { get; set; }
+        public DateTimeOffset? ShuffleCountDate { get; set; }
+        public int ShuffleCount { get; set; }
+        public DateTimeOffset SavedAtUtc { get; set; }
+    }
+}

--- a/ShuffleTask.Presentation.Shared/Utilities/PersistedTimerState.cs
+++ b/ShuffleTask.Presentation.Shared/Utilities/PersistedTimerState.cs
@@ -1,0 +1,337 @@
+using Microsoft.Maui.Storage;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Domain.Entities;
+using System.Globalization;
+using System.Text.Json;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+// Shared timer state persistence helper backed by host-provided MAUI preferences.
+public static class PersistedTimerState
+{
+    public const string TimerEnvelopeKey = "pref.timerEnvelope";
+    public const string TimerQuarantinePrefix = "pref.timerEnvelope.quarantine.";
+    private const int CurrentSchemaVersion = 1;
+
+#if TEST
+    public static Action<string>? FaultInjector { get; set; }
+#endif
+
+    public static bool TryGetActiveTimer(
+        out string taskId,
+        out TimeSpan remaining,
+        out bool expired,
+        out int durationSeconds,
+        out DateTimeOffset expiresAt,
+        IShuffleLogger? logger = null)
+        => TryGetActiveTimer(
+            out taskId,
+            out remaining,
+            out expired,
+            out durationSeconds,
+            out expiresAt,
+            out _,
+            logger);
+
+    public static bool TryGetActiveTimer(
+        out string taskId,
+        out TimeSpan remaining,
+        out bool expired,
+        out int durationSeconds,
+        out DateTimeOffset expiresAt,
+        out TimerDetails? details,
+        IShuffleLogger? logger = null)
+    {
+        details = null;
+        var started = DateTimeOffset.UtcNow;
+        logger?.LogSyncEvent("PersistenceLoadStarted", "domain=timer; operation=get-active");
+
+        if (TryReadEnvelope(out TimerEnvelope? envelope, logger))
+        {
+            var activeEnvelope = envelope!;
+            taskId = activeEnvelope.TaskId;
+            durationSeconds = activeEnvelope.DurationSeconds;
+            expiresAt = activeEnvelope.ExpiresAt;
+            remaining = expiresAt - DateTimeOffset.UtcNow;
+            expired = remaining <= TimeSpan.Zero;
+            if (expired) remaining = TimeSpan.Zero;
+            if (durationSeconds <= 0)
+            {
+                durationSeconds = Math.Max(1, (int)Math.Ceiling(remaining.TotalSeconds));
+            }
+
+            details = activeEnvelope.ToDetails();
+            logger?.LogSyncEvent("PersistenceLoadCompleted", $"domain=timer; source=canonical; expired={expired}; durationMs={(DateTimeOffset.UtcNow - started).TotalMilliseconds:0}");
+            return !string.IsNullOrWhiteSpace(taskId);
+        }
+
+        taskId = Preferences.Default.Get(PreferenceKeys.CurrentTaskId, string.Empty);
+        int seconds = Preferences.Default.Get(PreferenceKeys.TimerDurationSeconds, -1);
+
+        durationSeconds = seconds;
+        remaining = TimeSpan.Zero;
+        expired = false;
+        expiresAt = default;
+
+        if (string.IsNullOrEmpty(taskId))
+        {
+            logger?.LogSyncEvent("PersistenceLoadCompleted", $"domain=timer; source=empty; durationMs={(DateTimeOffset.UtcNow - started).TotalMilliseconds:0}");
+            return false;
+        }
+
+        string expiresIso = Preferences.Default.Get(PreferenceKeys.TimerExpiresAt, string.Empty);
+        if (!TryGetExpiration(expiresIso, out expiresAt))
+        {
+            QuarantineLegacyTimerState("invalid-legacy-expiration", logger);
+            logger?.LogSyncEvent("PersistenceLoadCompleted", $"domain=timer; source=invalid-legacy; durationMs={(DateTimeOffset.UtcNow - started).TotalMilliseconds:0}");
+            return false;
+        }
+
+        remaining = expiresAt - DateTimeOffset.UtcNow;
+        if (remaining <= TimeSpan.Zero)
+        {
+            remaining = TimeSpan.Zero;
+            expired = true;
+        }
+
+        if (durationSeconds <= 0)
+        {
+            durationSeconds = Math.Max(1, (int)Math.Ceiling(remaining.TotalSeconds));
+        }
+
+        logger?.LogSyncEvent("PersistenceLoadCompleted", $"domain=timer; source=legacy; expired={expired}; durationMs={(DateTimeOffset.UtcNow - started).TotalMilliseconds:0}");
+        return true;
+    }
+
+    private static bool TryGetExpiration(string expiresIso, out DateTimeOffset expiresAt)
+    {
+        if (!string.IsNullOrWhiteSpace(expiresIso)
+            && DateTimeOffset.TryParse(
+                expiresIso,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out expiresAt))
+        {
+            return true;
+        }
+
+        expiresAt = default;
+        return false;
+    }
+
+
+    public static void SaveActiveTimer(
+        string taskId,
+        int durationSeconds,
+        DateTimeOffset expiresAt,
+        TimerDetails? details = null,
+        IShuffleLogger? logger = null)
+    {
+        var started = DateTimeOffset.UtcNow;
+        logger?.LogSyncEvent("PersistenceSaveStarted", "domain=timer; operation=save-active");
+        var normalizedTaskId = taskId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalizedTaskId) || durationSeconds <= 0)
+        {
+            Clear(logger);
+            return;
+        }
+
+        var envelope = new TimerEnvelope
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            TaskId = normalizedTaskId,
+            DurationSeconds = durationSeconds,
+            ExpiresAt = expiresAt,
+            SavedAtUtc = DateTimeOffset.UtcNow,
+            TimerMode = details?.TimerMode,
+            PomodoroPhase = details?.PomodoroPhase,
+            CycleIndex = details?.CycleIndex,
+            CycleCount = details?.CycleCount,
+            FocusMinutes = details?.FocusMinutes,
+            BreakMinutes = details?.BreakMinutes
+        };
+
+        string json = JsonSerializer.Serialize(envelope);
+        Preferences.Default.Set(TimerEnvelopeKey, json);
+#if TEST
+        FaultInjector?.Invoke("timer.after-canonical-write");
+#endif
+        Preferences.Default.Set(PreferenceKeys.CurrentTaskId, normalizedTaskId);
+        Preferences.Default.Set(PreferenceKeys.TimerDurationSeconds, durationSeconds);
+        Preferences.Default.Set(PreferenceKeys.TimerExpiresAt, expiresAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture));
+        logger?.LogSyncEvent("PersistenceSaveCompleted", $"domain=timer; operation=save-active; durationMs={(DateTimeOffset.UtcNow - started).TotalMilliseconds:0}");
+    }
+
+    public static async Task<bool> RecoverAgainstStorageAsync(IStorageService storage, IShuffleLogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(storage);
+
+        if (!TryGetActiveTimer(
+                out string taskId,
+                out _,
+                out _,
+                out _,
+                out _,
+                logger))
+        {
+            return true;
+        }
+
+        TaskItem? task = await storage.GetTaskAsync(taskId).ConfigureAwait(false);
+        if (task == null)
+        {
+            QuarantineActiveTimer("missing-task", logger);
+            Clear(logger);
+            return false;
+        }
+
+        if (task.Status == TaskLifecycleStatus.Completed)
+        {
+            QuarantineActiveTimer("completed-task", logger);
+            Clear(logger);
+            return false;
+        }
+
+        if (task.Status == TaskLifecycleStatus.Snoozed)
+        {
+            QuarantineActiveTimer("snoozed-task", logger);
+            Clear(logger);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadEnvelope(out TimerEnvelope? envelope, IShuffleLogger? logger)
+    {
+        envelope = null;
+        string json = Preferences.Default.Get(TimerEnvelopeKey, string.Empty);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            var candidate = JsonSerializer.Deserialize<TimerEnvelope>(json);
+            if (candidate == null || string.IsNullOrWhiteSpace(candidate.TaskId))
+            {
+                QuarantineTimerEnvelope(json, "invalid-envelope", logger);
+                return false;
+            }
+
+            if (candidate.SchemaVersion > CurrentSchemaVersion)
+            {
+                logger?.LogSyncEvent("PersistenceLoadUnsupportedSchema", $"domain=timer; schemaVersion={candidate.SchemaVersion}");
+                return false;
+            }
+
+            if (candidate.DurationSeconds <= 0 || candidate.ExpiresAt == default)
+            {
+                QuarantineTimerEnvelope(json, "invalid-envelope-values", logger);
+                return false;
+            }
+
+            envelope = candidate;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            QuarantineTimerEnvelope(json, "corrupt-envelope", logger, ex);
+            return false;
+        }
+    }
+
+    public static void Clear(IShuffleLogger? logger = null)
+    {
+        logger?.LogSyncEvent("PersistenceSaveStarted", "domain=timer; operation=clear");
+        Preferences.Default.Remove(PreferenceKeys.CurrentTaskId);
+        Preferences.Default.Remove(PreferenceKeys.TimerDurationSeconds);
+        Preferences.Default.Remove(PreferenceKeys.TimerExpiresAt);
+        Preferences.Default.Remove(TimerEnvelopeKey);
+        logger?.LogSyncEvent("PersistenceSaveCompleted", "domain=timer; operation=clear");
+    }
+
+    private static void QuarantineActiveTimer(string reason, IShuffleLogger? logger)
+    {
+        string json = Preferences.Default.Get(TimerEnvelopeKey, string.Empty);
+        if (!string.IsNullOrWhiteSpace(json))
+        {
+            QuarantineTimerEnvelope(json, reason, logger);
+            return;
+        }
+
+        QuarantineLegacyTimerState(reason, logger);
+    }
+
+    private static void QuarantineTimerEnvelope(string json, string reason, IShuffleLogger? logger, Exception? exception = null)
+    {
+        string key = TimerQuarantinePrefix + DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmssfffffff", CultureInfo.InvariantCulture);
+        Preferences.Default.Set(key, json);
+        Preferences.Default.Remove(TimerEnvelopeKey);
+        logger?.LogSyncEvent("PersistenceQuarantine", $"domain=timer; reason={reason}; artifact={key}", exception);
+    }
+
+    private static void QuarantineLegacyTimerState(string reason, IShuffleLogger? logger)
+    {
+        string taskId = Preferences.Default.Get(PreferenceKeys.CurrentTaskId, string.Empty);
+        string expiresAt = Preferences.Default.Get(PreferenceKeys.TimerExpiresAt, string.Empty);
+        int durationSeconds = Preferences.Default.Get(PreferenceKeys.TimerDurationSeconds, -1);
+        if (string.IsNullOrEmpty(taskId) && string.IsNullOrEmpty(expiresAt) && durationSeconds <= 0)
+        {
+            return;
+        }
+
+        var legacy = new
+        {
+            TaskId = taskId,
+            ExpiresAt = expiresAt,
+            DurationSeconds = durationSeconds
+        };
+        string key = TimerQuarantinePrefix + "legacy." + DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmssfffffff", CultureInfo.InvariantCulture);
+        Preferences.Default.Set(key, JsonSerializer.Serialize(legacy));
+        Preferences.Default.Remove(PreferenceKeys.CurrentTaskId);
+        Preferences.Default.Remove(PreferenceKeys.TimerDurationSeconds);
+        Preferences.Default.Remove(PreferenceKeys.TimerExpiresAt);
+        logger?.LogSyncEvent("PersistenceQuarantine", $"domain=timer; reason={reason}; artifact={key}");
+    }
+
+    public sealed record TimerDetails(
+        int TimerMode,
+        int? PomodoroPhase,
+        int CycleIndex,
+        int CycleCount,
+        int FocusMinutes,
+        int BreakMinutes);
+
+    private sealed class TimerEnvelope
+    {
+        public int SchemaVersion { get; set; }
+        public string TaskId { get; set; } = string.Empty;
+        public int DurationSeconds { get; set; }
+        public DateTimeOffset ExpiresAt { get; set; }
+        public DateTimeOffset SavedAtUtc { get; set; }
+        public int? TimerMode { get; set; }
+        public int? PomodoroPhase { get; set; }
+        public int? CycleIndex { get; set; }
+        public int? CycleCount { get; set; }
+        public int? FocusMinutes { get; set; }
+        public int? BreakMinutes { get; set; }
+
+        public TimerDetails? ToDetails()
+        {
+            if (!TimerMode.HasValue)
+            {
+                return null;
+            }
+
+            return new TimerDetails(
+                TimerMode.Value,
+                PomodoroPhase,
+                Math.Max(1, CycleIndex ?? 1),
+                Math.Max(1, CycleCount ?? 1),
+                Math.Max(1, FocusMinutes ?? 15),
+                Math.Max(1, BreakMinutes ?? 5));
+        }
+    }
+}

--- a/ShuffleTask.Presentation.Shared/Utilities/TaskTimerSettings.cs
+++ b/ShuffleTask.Presentation.Shared/Utilities/TaskTimerSettings.cs
@@ -1,0 +1,35 @@
+using ShuffleTask.Application.Models;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+// Shared timer setting resolution for reusable dashboard and task list ViewModels.
+public readonly record struct EffectiveTimerSettings(
+    TimerMode Mode,
+    int ReminderMinutes,
+    int FocusMinutes,
+    int BreakMinutes,
+    int PomodoroCycles)
+{
+    public int InitialMinutes => Mode == TimerMode.Pomodoro ? FocusMinutes : ReminderMinutes;
+}
+
+public static class TaskTimerSettings
+{
+    public static EffectiveTimerSettings Resolve(TaskItem task, AppSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        TimerMode mode = task.CustomTimerMode.HasValue
+            ? (TimerMode)task.CustomTimerMode.Value
+            : settings.TimerMode;
+
+        int reminderMinutes = task.CustomReminderMinutes ?? settings.ReminderMinutes;
+        int focusMinutes = task.CustomFocusMinutes ?? settings.FocusMinutes;
+        int breakMinutes = task.CustomBreakMinutes ?? settings.BreakMinutes;
+        int pomodoroCycles = task.CustomPomodoroCycles ?? settings.PomodoroCycles;
+
+        return new EffectiveTimerSettings(mode, reminderMinutes, focusMinutes, breakMinutes, pomodoroCycles);
+    }
+}

--- a/ShuffleTask.Presentation.Shared/Utilities/ViewModelWithWeekdaySelection.cs
+++ b/ShuffleTask.Presentation.Shared/Utilities/ViewModelWithWeekdaySelection.cs
@@ -1,0 +1,87 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Presentation.Utilities;
+
+// Shared weekday-selection behavior for host-specific editor views.
+public abstract class ViewModelWithWeekdaySelection : ObservableObject
+{
+    private Weekdays _selectedWeekdays;
+
+    public Weekdays SelectedWeekdays
+    {
+        get => _selectedWeekdays;
+        set
+        {
+            if (SetProperty(ref _selectedWeekdays, value))
+            {
+                RaiseWeekdayPropertiesChanged();
+            }
+        }
+    }
+
+    protected static Weekdays ApplyWeekdaySelection(Weekdays current, Weekdays day, bool enabled)
+    {
+        return enabled ? current | day : current & ~day;
+    }
+
+    protected bool GetWeekday(Weekdays day) => _selectedWeekdays.HasFlag(day);
+
+    protected void SetWeekday(Weekdays day, bool isSelected)
+    {
+        SelectedWeekdays = ApplyWeekdaySelection(SelectedWeekdays, day, isSelected);
+    }
+
+    protected void RaiseWeekdayPropertiesChanged()
+    {
+        OnPropertyChanged(nameof(Sunday));
+        OnPropertyChanged(nameof(Monday));
+        OnPropertyChanged(nameof(Tuesday));
+        OnPropertyChanged(nameof(Wednesday));
+        OnPropertyChanged(nameof(Thursday));
+        OnPropertyChanged(nameof(Friday));
+        OnPropertyChanged(nameof(Saturday));
+    }
+
+    public bool Sunday
+    {
+        get => GetWeekday(Weekdays.Sun);
+        set => SetWeekday(Weekdays.Sun, value);
+    }
+
+    public bool Monday
+    {
+        get => GetWeekday(Weekdays.Mon);
+        set => SetWeekday(Weekdays.Mon, value);
+    }
+
+    public bool Tuesday
+    {
+        get => GetWeekday(Weekdays.Tue);
+        set => SetWeekday(Weekdays.Tue, value);
+    }
+
+    public bool Wednesday
+    {
+        get => GetWeekday(Weekdays.Wed);
+        set => SetWeekday(Weekdays.Wed, value);
+    }
+
+    public bool Thursday
+    {
+        get => GetWeekday(Weekdays.Thu);
+        set => SetWeekday(Weekdays.Thu, value);
+    }
+
+    public bool Friday
+    {
+        get => GetWeekday(Weekdays.Fri);
+        set => SetWeekday(Weekdays.Fri, value);
+    }
+
+    public bool Saturday
+    {
+        get => GetWeekday(Weekdays.Sat);
+        set => SetWeekday(Weekdays.Sat, value);
+    }
+}

--- a/ShuffleTask.Presentation.Shared/ViewModels/AlignmentModeOption.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/AlignmentModeOption.cs
@@ -1,0 +1,20 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.ViewModels;
+
+// Shared display model for period alignment choices.
+public sealed class AlignmentModeOption
+{
+    public AlignmentModeOption(string name, string description, PeriodDefinitionMode mode)
+    {
+        Name = name;
+        Description = description;
+        Mode = mode;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public PeriodDefinitionMode Mode { get; }
+}

--- a/ShuffleTask.Presentation.Shared/ViewModels/DashboardViewModel.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,706 @@
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Services;
+using ShuffleTask.Application.Utilities;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Services;
+using ShuffleTask.Presentation.Utilities;
+
+namespace ShuffleTask.ViewModels;
+
+// Host-neutral dashboard state and commands for MAUI presentation hosts.
+public partial class DashboardViewModel : ObservableObject
+{
+    private readonly IStorageService _storage;
+    private readonly ISchedulerService _scheduler;
+    private readonly INetworkSyncService _networkSyncService;
+    private readonly INotificationService _notifications;
+    private readonly ShuffleCoordinatorService _coordinator;
+    private readonly TimeProvider _clock;
+    private readonly AppSettings _settings;
+
+    private TaskItem? _activeTask;
+    private PomodoroSession? _pomodoroSession;
+    private TimerRequest? _currentTimer;
+    private bool _isInitialized;
+
+    private const string DefaultTitle = "Shuffle a task";
+    private const string DefaultDescription = "Tap Shuffle to pick what comes next.";
+    private const string DefaultSchedule = "No schedule yet.";
+
+    public DashboardViewModel(IStorageService storage, ISchedulerService scheduler, INotificationService notifications, ShuffleCoordinatorService coordinator, TimeProvider clock, INetworkSyncService networkSyncService, AppSettings settings)
+    {
+        _storage = storage;
+        _scheduler = scheduler;
+        _notifications = notifications;
+        _coordinator = coordinator;
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+        Title = DefaultTitle;
+        Description = DefaultDescription;
+        Schedule = DefaultSchedule;
+        TimerText = "--:--";
+        CycleStatus = string.Empty;
+        PhaseBadge = string.Empty;
+        _networkSyncService = networkSyncService;
+    }
+
+    public event EventHandler<TimerRequest>? CountdownRequested;
+    public event EventHandler? CountdownCleared;
+
+    public enum PomodoroPhase
+    {
+        Focus,
+        Break
+    }
+
+    public sealed record TimerRequest(
+        TimeSpan Duration,
+        TimerMode Mode,
+        PomodoroPhase? Phase,
+        int CycleIndex,
+        int CycleCount,
+        int FocusMinutes,
+        int BreakMinutes)
+    {
+        public static TimerRequest Pomodoro(TimeSpan duration, PomodoroPhase phase, int cycleIndex, int cycleCount, int focusMinutes, int breakMinutes)
+            => new(duration, TimerMode.Pomodoro, phase, cycleIndex, cycleCount, focusMinutes, breakMinutes);
+
+        public static TimerRequest PomodoroFromMinutes(PomodoroPhase phase, int cycleIndex, int cycleCount, int focusMinutes, int breakMinutes)
+        {
+            int safeFocus = Math.Max(1, focusMinutes);
+            int safeBreak = Math.Max(1, breakMinutes);
+            var duration = phase == PomodoroPhase.Break
+                ? TimeSpan.FromMinutes(safeBreak)
+                : TimeSpan.FromMinutes(safeFocus);
+
+            return Pomodoro(duration, phase, cycleIndex, cycleCount, safeFocus, safeBreak);
+        }
+
+        public static TimerRequest LongInterval(TimeSpan duration)
+            => new(duration, TimerMode.LongInterval, null, 0, 0, 0, 0);
+
+        public static TimerRequest LongIntervalFromMinutes(int minutes)
+            => LongInterval(TimeSpan.FromMinutes(Math.Max(1, minutes)));
+    }
+
+    [ObservableProperty]
+    private string title;
+
+    [ObservableProperty]
+    private string description;
+
+    [ObservableProperty]
+    private string schedule;
+
+    [ObservableProperty]
+    private string timerText;
+
+    [ObservableProperty]
+    private bool hasTask;
+
+    [ObservableProperty]
+    private bool isBusy;
+
+    [ObservableProperty]
+    private string cycleStatus = string.Empty;
+
+    [ObservableProperty]
+    private string phaseBadge = string.Empty;
+
+    [ObservableProperty]
+    private bool isPomodoroVisible;
+
+    public string? ActiveTaskId => _activeTask?.Id;
+
+    public async Task InitializeAsync()
+    {
+        if (!_isInitialized)
+        {
+            await _storage.InitializeAsync();
+            await _notifications.InitializeAsync();
+            _coordinator.RegisterDashboard(this);
+            _isInitialized = true;
+        }
+    }
+
+    [RelayCommand]
+    private Task ShuffleAsync() => ShuffleInternalAsync(allowRepeat: false);
+
+    public Task ShuffleAfterTimeoutAsync() => ShuffleInternalAsync(allowRepeat: true);
+
+    private async Task ShuffleInternalAsync(bool allowRepeat)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await InitializeAsync();
+            var settings = _settings;
+
+            if (!settings.Active)
+            {
+                ShowMessage("Scheduling paused", "Enable the scheduler from Settings to shuffle tasks.");
+                return;
+            }
+
+            var network = _settings.Network;
+            var tasks = await _storage.GetTasksAsync(network?.UserId, network?.DeviceId ?? string.Empty);
+            DateTimeOffset now = _clock.GetUtcNow();
+            string? previousId = _activeTask?.Id;
+
+            var next = PickNextCandidate(tasks, settings, now, previousId);
+            if (next == null)
+            {
+                ShowMessage("No tasks ready", "Add a task or adjust filters to get started.");
+                return;
+            }
+
+            bool isSameTask = !string.IsNullOrEmpty(previousId) && next.Id == previousId;
+            if (isSameTask && !allowRepeat)
+            {
+                return;
+            }
+
+            await CutInLineUtilities.ClearCutInLineOnceAsync(next, _storage);
+
+            BindTask(next);
+
+            var effectiveSettings = TaskTimerSettings.Resolve(next, settings);
+            var (mode, reminderMinutes, focusMinutes, breakMinutes, pomodoroCycles) = effectiveSettings;
+
+            if (mode == TimerMode.Pomodoro)
+            {
+                _pomodoroSession = PomodoroSession.Create(focusMinutes, breakMinutes, pomodoroCycles);
+                var request = _pomodoroSession.CurrentRequest();
+                _currentTimer = request;
+                UpdateIndicators(request);
+                TimerText = FormatTimerText(request.Duration);
+                CountdownRequested?.Invoke(this, request);
+
+                if (settings.EnableNotifications)
+                {
+                    await _notifications.NotifyTaskAsync(next, _pomodoroSession.FocusMinutes, settings);
+                    await SchedulePomodoroNotificationsAsync(next, _pomodoroSession, settings);
+                }
+            }
+            else
+            {
+                _pomodoroSession = null;
+                int minutes = Math.Max(1, reminderMinutes);
+                var request = TimerRequest.LongIntervalFromMinutes(minutes);
+                _currentTimer = request;
+                UpdateIndicators(request);
+                TimerText = FormatTimerText(request.Duration);
+                CountdownRequested?.Invoke(this, request);
+
+                if (settings.EnableNotifications)
+                {
+                    await _notifications.NotifyTaskAsync(next, minutes, settings);
+                }
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task DoneAsync()
+    {
+        if (_activeTask == null)
+        {
+            return;
+        }
+
+        var updated = await _storage.MarkTaskDoneAsync(_activeTask.Id);
+        if (updated != null)
+        {
+            _activeTask = updated;
+        }
+
+        await _notifications.CancelAllAsync();
+        _coordinator.SuspendInProcessTimer();
+
+        var snapshot = _activeTask;
+        ShowMessage("Task complete", "Shuffle another task when you're ready.");
+        EmitTimerResetTelemetry("done", snapshot);
+    }
+
+    [RelayCommand]
+    private async Task SnoozeAsync()
+    {
+        if (_activeTask == null)
+        {
+            return;
+        }
+
+        await InitializeAsync();
+        var settings = _settings;
+
+        int snoozeMinutes = Math.Max(15, settings.MinGapMinutes);
+        var duration = TimeSpan.FromMinutes(snoozeMinutes);
+
+        var updated = await _storage.SnoozeTaskAsync(_activeTask.Id, duration);
+
+        if (updated is not null)
+        {
+            _activeTask = updated;
+            await _networkSyncService.PublishTaskUpsertAsync(_activeTask);
+        }
+
+        await _notifications.CancelAllAsync();
+        _coordinator.SuspendInProcessTimer();
+
+        var snapshot = _activeTask;
+        ShowMessage("Task snoozed", "Shuffle another task when you're ready.");
+        EmitTimerResetTelemetry("snooze", snapshot);
+    }
+
+    public async Task<bool> RestoreTaskAsync(string? taskId, TimeSpan? remaining, TimerRequest? timerState)
+    {
+        if (string.IsNullOrWhiteSpace(taskId))
+        {
+            ShowDefaultState();
+            return false;
+        }
+
+        await InitializeAsync();
+        var task = await _storage.GetTaskAsync(taskId);
+        if (task == null || task.Status == TaskLifecycleStatus.Completed || task.Status == TaskLifecycleStatus.Snoozed)
+        {
+            ShowDefaultState();
+            return false;
+        }
+
+        BindTask(task);
+
+        if (timerState?.Mode == TimerMode.Pomodoro && timerState.Phase.HasValue)
+        {
+            _pomodoroSession = PomodoroSession.FromState(timerState);
+            _currentTimer = _pomodoroSession.CurrentRequest();
+            UpdateIndicators(_currentTimer);
+        }
+        else if (timerState != null)
+        {
+            _pomodoroSession = null;
+            _currentTimer = timerState;
+            UpdateIndicators(timerState);
+        }
+        else
+        {
+            _pomodoroSession = null;
+            UpdateIndicators(null);
+        }
+
+        if (remaining.HasValue)
+        {
+            TimerText = FormatTimerText(remaining.Value);
+        }
+        else if (_currentTimer != null)
+        {
+            TimerText = FormatTimerText(_currentTimer.Duration);
+        }
+
+        return true;
+    }
+
+    public async Task HandleCountdownCompletedAsync()
+    {
+        await InitializeAsync();
+
+        if (_currentTimer?.Mode == TimerMode.Pomodoro && _pomodoroSession != null && _activeTask != null)
+        {
+            var next = _pomodoroSession.Advance();
+            if (next != null)
+            {
+                _currentTimer = next;
+                UpdateIndicators(next);
+                TimerText = FormatTimerText(next.Duration);
+                CountdownRequested?.Invoke(this, next);
+            }
+            else
+            {
+                await CompletePomodoroAsync();
+            }
+
+            return;
+        }
+
+        await _notifications.ShowToastAsync("Time's up", "Shuffling a new task...", _settings);
+        await ShuffleAfterTimeoutAsync();
+    }
+
+    private Task CompletePomodoroAsync()
+    {
+        int cycles = _pomodoroSession?.CycleCount ?? _settings.PomodoroCycles;
+        TimerText = "--:--";
+        ShowPomodoroCompletion(cycles);
+        _pomodoroSession = null;
+        _currentTimer = null;
+        CountdownCleared?.Invoke(this, EventArgs.Empty);
+        return Task.CompletedTask;
+    }
+
+    public Task ApplyAutoOrCrossDeviceShuffleAsync(TaskItem task, AppSettings settings)
+    {
+        BindTask(task);
+
+        var effectiveSettings = TaskTimerSettings.Resolve(task, settings);
+        var (mode, reminderMinutes, focusMinutes, breakMinutes, pomodoroCycles) = effectiveSettings;
+
+        if (mode == TimerMode.Pomodoro)
+        {
+            _pomodoroSession = PomodoroSession.Create(focusMinutes, breakMinutes, pomodoroCycles);
+            var request = _pomodoroSession.CurrentRequest();
+            _currentTimer = request;
+            UpdateIndicators(request);
+            TimerText = FormatTimerText(request.Duration);
+            CountdownRequested?.Invoke(this, request);
+        }
+        else
+        {
+            _pomodoroSession = null;
+            int minutes = Math.Max(1, reminderMinutes);
+            var request = TimerRequest.LongIntervalFromMinutes(minutes);
+            _currentTimer = request;
+            UpdateIndicators(request);
+            TimerText = FormatTimerText(request.Duration);
+            CountdownRequested?.Invoke(this, request);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public static string FormatTimerText(TimeSpan remaining)
+    {
+        if (remaining <= TimeSpan.Zero)
+        {
+            return "00:00";
+        }
+
+        return remaining.ToString(@"mm\:ss");
+    }
+
+    public void ClearActiveTask()
+    {
+        ShowDefaultState();
+    }
+
+    private void BindTask(TaskItem task)
+    {
+        _activeTask = task;
+        Title = string.IsNullOrWhiteSpace(task.Title) ? "Untitled task" : task.Title;
+        Description = string.IsNullOrWhiteSpace(task.Description)
+            ? "No description provided."
+            : task.Description;
+        Schedule = BuildScheduleText(task);
+        HasTask = true;
+    }
+
+    private void ShowDefaultState()
+    {
+        ShowMessage(DefaultTitle, DefaultDescription);
+    }
+
+    private void ShowMessage(string title, string description)
+    {
+        ResetTimerState();
+        _activeTask = null;
+        Title = title;
+        Description = description;
+        Schedule = DefaultSchedule;
+        TimerText = "--:--";
+        HasTask = false;
+        CountdownCleared?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void UpdateIndicators(TimerRequest? request)
+    {
+        if (request?.Mode == TimerMode.Pomodoro && request.Phase.HasValue)
+        {
+            IsPomodoroVisible = true;
+            PhaseBadge = request.Phase.Value == PomodoroPhase.Focus ? "Focus" : "Break";
+            int cycleIndex = Math.Max(1, request.CycleIndex);
+            int cycleCount = Math.Max(cycleIndex, request.CycleCount);
+            CycleStatus = $"Cycle {cycleIndex} of {cycleCount}";
+        }
+        else
+        {
+            IsPomodoroVisible = false;
+            PhaseBadge = string.Empty;
+            CycleStatus = string.Empty;
+        }
+    }
+
+    private void ShowPomodoroCompletion(int cycles)
+    {
+        IsPomodoroVisible = true;
+        PhaseBadge = "Complete";
+        CycleStatus = cycles > 0
+            ? $"{cycles} cycle(s) finished"
+            : "Session complete";
+    }
+
+    private void ResetTimerState()
+    {
+        _currentTimer = null;
+        _pomodoroSession = null;
+        IsPomodoroVisible = false;
+        PhaseBadge = string.Empty;
+        CycleStatus = string.Empty;
+    }
+
+    private async Task SchedulePomodoroNotificationsAsync(TaskItem task, PomodoroSession session, AppSettings settings)
+    {
+        int focusMinutes = session.FocusMinutes;
+        int breakMinutes = session.BreakMinutes;
+        int cycles = session.CycleCount;
+
+        var focusDuration = TimeSpan.FromMinutes(focusMinutes);
+        var breakDuration = TimeSpan.FromMinutes(breakMinutes);
+        TimeSpan offset = TimeSpan.Zero;
+        var schedulingTasks = new List<Task>();
+
+        for (int cycle = 1; cycle <= cycles; cycle++)
+        {
+            offset += focusDuration;
+            string focusTitle = $"{task.Title}: Focus complete";
+            string focusMessage;
+            if (breakMinutes > 0)
+            {
+                focusMessage = "Take a short break.";
+            }
+            else
+            {
+                focusMessage = cycle < cycles ? "Start the next cycle." : "Pomodoro cycles finished!";
+            }
+            schedulingTasks.Add(_notifications.NotifyPhaseAsync(focusTitle, focusMessage, offset, settings));
+
+            if (breakMinutes > 0)
+            {
+                offset += breakDuration;
+                if (cycle == cycles)
+                {
+                    string summaryTitle = $"{task.Title}: Pomodoro complete";
+                    string summaryMessage = $"Finished {cycles} cycle(s).";
+                    schedulingTasks.Add(_notifications.NotifyPhaseAsync(summaryTitle, summaryMessage, offset, settings));
+                }
+                else
+                {
+                    string breakTitle = $"{task.Title}: Break complete";
+                    const string breakMessage = "Focus time again.";
+                    schedulingTasks.Add(_notifications.NotifyPhaseAsync(breakTitle, breakMessage, offset, settings));
+                }
+            }
+            else if (cycle == cycles)
+            {
+                string summaryTitle = $"{task.Title}: Pomodoro complete";
+                string summaryMessage = $"Finished {cycles} cycle(s).";
+                schedulingTasks.Add(_notifications.NotifyPhaseAsync(summaryTitle, summaryMessage, offset, settings));
+            }
+        }
+
+        if (schedulingTasks.Count > 0)
+        {
+            await Task.WhenAll(schedulingTasks);
+        }
+    }
+
+    private sealed class PomodoroSession
+    {
+        public PomodoroSession(int focusMinutes, int breakMinutes, int cycles)
+        {
+            FocusMinutes = Math.Max(1, focusMinutes);
+            BreakMinutes = Math.Max(1, breakMinutes);
+            CycleCount = Math.Max(1, cycles);
+            CurrentCycle = 1;
+            Phase = PomodoroPhase.Focus;
+        }
+
+        private PomodoroSession(int focusMinutes, int breakMinutes, int cycles, int currentCycle, PomodoroPhase phase)
+        {
+            FocusMinutes = Math.Max(1, focusMinutes);
+            BreakMinutes = Math.Max(1, breakMinutes);
+            CycleCount = Math.Max(1, cycles);
+            CurrentCycle = Math.Clamp(currentCycle, 1, CycleCount);
+            Phase = phase;
+
+            if (Phase == PomodoroPhase.Break && BreakMinutes <= 0)
+            {
+                Phase = PomodoroPhase.Focus;
+            }
+        }
+
+        public int FocusMinutes { get; }
+
+        public int BreakMinutes { get; }
+
+        public int CycleCount { get; }
+
+        public int CurrentCycle { get; private set; }
+
+        public PomodoroPhase Phase { get; private set; }
+
+        public static PomodoroSession Create(AppSettings settings)
+            => new PomodoroSession(settings.FocusMinutes, settings.BreakMinutes, settings.PomodoroCycles);
+
+        public static PomodoroSession Create(int focusMinutes, int breakMinutes, int cycles)
+            => new PomodoroSession(focusMinutes, breakMinutes, cycles);
+
+        public static PomodoroSession FromState(TimerRequest state)
+            => new PomodoroSession(state.FocusMinutes, state.BreakMinutes, state.CycleCount, state.CycleIndex, state.Phase ?? PomodoroPhase.Focus);
+
+        public TimerRequest CurrentRequest()
+            => TimerRequest.Pomodoro(CurrentDuration, Phase, CurrentCycle, CycleCount, FocusMinutes, BreakMinutes);
+
+        public TimerRequest? Advance()
+        {
+            if (Phase == PomodoroPhase.Focus && BreakMinutes > 0)
+            {
+                Phase = PomodoroPhase.Break;
+                return CurrentRequest();
+            }
+
+            if (Phase == PomodoroPhase.Focus && BreakMinutes <= 0)
+            {
+                if (CurrentCycle >= CycleCount)
+                {
+                    return null;
+                }
+
+                CurrentCycle++;
+                Phase = PomodoroPhase.Focus;
+                return CurrentRequest();
+            }
+
+            if (CurrentCycle >= CycleCount)
+            {
+                return null;
+            }
+
+            CurrentCycle++;
+            Phase = PomodoroPhase.Focus;
+            return CurrentRequest();
+        }
+
+        private TimeSpan CurrentDuration => Phase == PomodoroPhase.Focus
+            ? TimeSpan.FromMinutes(FocusMinutes)
+            : TimeSpan.FromMinutes(BreakMinutes);
+    }
+
+    private TaskItem? PickNextCandidate(IList<TaskItem> tasks, AppSettings settings, DateTimeOffset now, string? previousId)
+    {
+        List<TaskItem> candidatePool = ManualShuffleService.CreateCandidatePool(tasks, settings);
+        var chosenClone = _scheduler.PickNextTask(candidatePool, settings, now);
+        if (chosenClone == null)
+        {
+            return null;
+        }
+
+        var chosen = FindOriginal(tasks, chosenClone.Id);
+        if (chosen == null)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(previousId) || !string.Equals(chosen.Id, previousId, StringComparison.Ordinal))
+        {
+            return chosen;
+        }
+
+        var alternatives = tasks
+            .Where(t => !string.Equals(t.Id, previousId, StringComparison.Ordinal))
+            .ToList();
+
+        if (alternatives.Count == 0)
+        {
+            return chosen;
+        }
+
+        List<TaskItem> alternativePool = ManualShuffleService.CreateCandidatePool(alternatives, settings);
+        var alternativeClone = _scheduler.PickNextTask(alternativePool, settings, now);
+        if (alternativeClone == null)
+        {
+            return chosen;
+        }
+
+        var alternative = FindOriginal(alternatives, alternativeClone.Id);
+        return alternative ?? chosen;
+    }
+
+    private static TaskItem? FindOriginal(IEnumerable<TaskItem> tasks, string id)
+    {
+        return tasks.FirstOrDefault(t => string.Equals(t.Id, id, StringComparison.Ordinal));
+    }
+
+    private static void EmitTimerResetTelemetry(string reason, TaskItem? task)
+    {
+        if (task == null)
+        {
+            Debug.WriteLine($"[ShuffleTask] Timer reset ({reason})");
+            return;
+        }
+
+        Debug.WriteLine($"[ShuffleTask] Timer reset ({reason}) for task {task.Id} -> status={task.Status}, nextEligible={task.NextEligibleAt:O}");
+    }
+
+    private static string BuildScheduleText(TaskItem task)
+    {
+        string deadline = task.Deadline.HasValue
+            ? $"Deadline {task.Deadline:MMM d, yyyy HH:mm}"
+            : "No deadline";
+
+        string repeat = task.Repeat switch
+        {
+            RepeatType.None => "One-off task",
+            RepeatType.Daily => "Repeats daily",
+            RepeatType.Weekly => $"Weekly on {FormatWeekdays(task.Weekdays)}",
+            RepeatType.Interval => $"Every {Math.Max(1, task.IntervalDays)} day(s)",
+            _ => "Schedule unknown"
+        };
+
+        string allowed = PeriodDefinitionFormatter.FormatAllowedPeriodLabel(task);
+
+        return $"{deadline} • {repeat} • {allowed}";
+    }
+
+    private static string FormatWeekdays(Weekdays weekdays)
+    {
+        if (weekdays == Weekdays.None)
+        {
+            return "no specific days";
+        }
+
+        var names = new List<string>();
+
+        void Add(Weekdays day, string name)
+        {
+            if (weekdays.HasFlag(day))
+            {
+                names.Add(name);
+            }
+        }
+
+        Add(Weekdays.Mon, "Mon");
+        Add(Weekdays.Tue, "Tue");
+        Add(Weekdays.Wed, "Wed");
+        Add(Weekdays.Thu, "Thu");
+        Add(Weekdays.Fri, "Fri");
+        Add(Weekdays.Sat, "Sat");
+        Add(Weekdays.Sun, "Sun");
+
+        return string.Join(", ", names);
+    }
+
+    
+}

--- a/ShuffleTask.Presentation.Shared/ViewModels/EditTaskViewModel.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/EditTaskViewModel.cs
@@ -1,0 +1,631 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Utilities;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Utilities;
+using System.Collections.ObjectModel;
+
+namespace ShuffleTask.ViewModels;
+
+// Host-neutral task editing state and commands for MAUI presentation hosts.
+public partial class EditTaskViewModel : ViewModelWithWeekdaySelection
+{
+    private readonly IStorageService _storage;
+    private readonly TimeProvider _clock;
+
+    private TaskItem _workingCopy = new();
+
+    private Weekdays _selectedAdHocWeekdays;
+
+    private static readonly Weekdays AllWeekdays = Weekdays.Sun | Weekdays.Mon | Weekdays.Tue | Weekdays.Wed | Weekdays.Thu | Weekdays.Fri | Weekdays.Sat;
+
+    private const double MinSizePoints = 0.5;
+    private const double MaxSizePoints = 13.0;
+    private const double DefaultSizePoints = 3.0;
+
+    public Weekdays SelectedAdHocWeekdays
+    {
+        get => _selectedAdHocWeekdays;
+        set
+        {
+            if (SetProperty(ref _selectedAdHocWeekdays, value))
+            {
+                OnPropertyChanged(nameof(AdHocSunday));
+                OnPropertyChanged(nameof(AdHocMonday));
+                OnPropertyChanged(nameof(AdHocTuesday));
+                OnPropertyChanged(nameof(AdHocWednesday));
+                OnPropertyChanged(nameof(AdHocThursday));
+                OnPropertyChanged(nameof(AdHocFriday));
+                OnPropertyChanged(nameof(AdHocSaturday));
+                OnPropertyChanged(nameof(SelectedPeriodDefinitionDescription));
+            }
+        }
+    }
+
+    [ObservableProperty]
+    private string title = string.Empty;
+
+    [ObservableProperty]
+    private string description = string.Empty;
+
+    [ObservableProperty]
+    private double importance = 1;
+
+    [ObservableProperty]
+    private double sizePoints = DefaultSizePoints;
+
+    [ObservableProperty]
+    private bool hasDeadline;
+
+    [ObservableProperty]
+    private DateTime deadlineDate = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+
+    [ObservableProperty]
+    private TimeSpan deadlineTime = new(9, 0, 0);
+
+    [ObservableProperty]
+    private RepeatType repeat;
+
+    [ObservableProperty]
+    private double intervalDays = 1;
+
+    [ObservableProperty]
+    private AllowedPeriod allowedPeriod;
+
+    [ObservableProperty]
+    private bool autoShuffleAllowed = true;
+
+    [ObservableProperty]
+    private TimeSpan adHocStartTime = new(9, 0, 0);
+
+    [ObservableProperty]
+    private TimeSpan adHocEndTime = new(17, 0, 0);
+
+    [ObservableProperty]
+    private bool adHocIsAllDay;
+
+    [ObservableProperty]
+    private bool isPaused;
+
+    [ObservableProperty]
+    private CutInLineMode cutInLineMode;
+
+    [ObservableProperty]
+    private bool isBusy;
+
+    // Per-task timer override _settings
+    [ObservableProperty]
+    private bool useCustomTimer;
+
+    [ObservableProperty]
+    private int customTimerMode; // 0=LongInterval, 1=Pomodoro
+
+    [ObservableProperty]
+    private double customReminderMinutes = 60;
+
+    [ObservableProperty]
+    private double customFocusMinutes = 15;
+
+    [ObservableProperty]
+    private double customBreakMinutes = 5;
+
+    [ObservableProperty]
+    private double customPomodoroCycles = 3;
+
+    [ObservableProperty]
+    private AlignmentModeOption selectedAlignmentMode;
+
+    [ObservableProperty]
+    private PeriodDefinitionOption? selectedPeriodDefinition;
+
+    private bool _isNew = true;
+    public bool IsNew
+    {
+        get => _isNew;
+        private set => SetProperty(ref _isNew, value);
+    }
+
+    public EditTaskViewModel(IStorageService storage, TimeProvider clock, AppSettings appSettings)
+    {
+        _storage = storage;
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        AppSettings = appSettings;
+        DeadlineDate = GetTodayUtcDate();
+        AlignmentModeOptions = AlignmentModeCatalog.Defaults;
+        SelectedAlignmentMode = AlignmentModeOptions[0];
+    }
+
+    public RepeatType[] RepeatOptions { get; } = Enum.GetValues<RepeatType>();
+
+    public CutInLineMode[] CutInLineModeOptions { get; } = Enum.GetValues<CutInLineMode>();
+
+    public ObservableCollection<PeriodDefinitionOption> PeriodDefinitionOptions { get; } = new();
+
+    public IReadOnlyList<AlignmentModeOption> AlignmentModeOptions { get; }
+
+    public string[] TimerModeOptions { get; } = new[] { "Long Interval", "Pomodoro" };
+
+    public bool IsAdHocSelection => SelectedPeriodDefinition?.IsAdHoc ?? false;
+
+    public bool CanEditSelectedDefinition => SelectedPeriodDefinition?.IsEditable ?? false;
+
+    public string SelectedPeriodDefinitionDescription
+    {
+        get
+        {
+            if (SelectedPeriodDefinition == null)
+            {
+                return string.Empty;
+            }
+
+            if (SelectedPeriodDefinition.IsAdHoc)
+            {
+                return PeriodDefinitionFormatter.DescribeDefinition(BuildAdHocDefinition());
+            }
+
+            return SelectedPeriodDefinition.Description;
+        }
+    }
+
+    private bool GetAdHocWeekday(Weekdays day) => _selectedAdHocWeekdays.HasFlag(day);
+
+    private void SetAdHocWeekday(Weekdays day, bool isSelected)
+    {
+        SelectedAdHocWeekdays = ApplyWeekdaySelection(SelectedAdHocWeekdays, day, isSelected);
+    }
+
+    public bool AdHocSunday
+    {
+        get => GetAdHocWeekday(Weekdays.Sun);
+        set => SetAdHocWeekday(Weekdays.Sun, value);
+    }
+
+    public bool AdHocMonday
+    {
+        get => GetAdHocWeekday(Weekdays.Mon);
+        set => SetAdHocWeekday(Weekdays.Mon, value);
+    }
+
+    public bool AdHocTuesday
+    {
+        get => GetAdHocWeekday(Weekdays.Tue);
+        set => SetAdHocWeekday(Weekdays.Tue, value);
+    }
+
+    public bool AdHocWednesday
+    {
+        get => GetAdHocWeekday(Weekdays.Wed);
+        set => SetAdHocWeekday(Weekdays.Wed, value);
+    }
+
+    public bool AdHocThursday
+    {
+        get => GetAdHocWeekday(Weekdays.Thu);
+        set => SetAdHocWeekday(Weekdays.Thu, value);
+    }
+
+    public bool AdHocFriday
+    {
+        get => GetAdHocWeekday(Weekdays.Fri);
+        set => SetAdHocWeekday(Weekdays.Fri, value);
+    }
+
+    public bool AdHocSaturday
+    {
+        get => GetAdHocWeekday(Weekdays.Sat);
+        set => SetAdHocWeekday(Weekdays.Sat, value);
+    }
+    public AppSettings AppSettings { get; }
+
+    public event EventHandler? Saved;
+
+    public async Task LoadAsync(TaskItem? task)
+    {
+        IsBusy = false;
+        await _storage.InitializeAsync();
+        await LoadPeriodDefinitionOptionsAsync();
+        _workingCopy = task != null ? TaskItem.Clone(task) : new TaskItem();
+        IsNew = task == null || string.IsNullOrWhiteSpace(task.Id);
+
+        Title = _workingCopy.Title;
+        Description = _workingCopy.Description;
+        Importance = Math.Max(1, _workingCopy.Importance);
+        SizePoints = SanitizeSizePoints(_workingCopy.SizePoints);
+        Repeat = _workingCopy.Repeat;
+        IntervalDays = _workingCopy.IntervalDays > 0 ? _workingCopy.IntervalDays : 1;
+        AllowedPeriod = _workingCopy.AllowedPeriod;
+        AutoShuffleAllowed = _workingCopy.AutoShuffleAllowed;
+        AdHocStartTime = _workingCopy.AdHocStartTime ?? _workingCopy.CustomStartTime ?? new TimeSpan(9, 0, 0);
+        AdHocEndTime = _workingCopy.AdHocEndTime ?? _workingCopy.CustomEndTime ?? new TimeSpan(17, 0, 0);
+        bool isLegacyCustomAllDay = _workingCopy.AllowedPeriod == AllowedPeriod.Custom
+            && string.IsNullOrWhiteSpace(_workingCopy.PeriodDefinitionId)
+            && _workingCopy.AdHocMode == PeriodDefinitionMode.None
+            && !_workingCopy.AdHocStartTime.HasValue
+            && !_workingCopy.AdHocEndTime.HasValue;
+        AdHocIsAllDay = _workingCopy.AdHocIsAllDay || isLegacyCustomAllDay;
+        IsPaused = _workingCopy.Paused;
+        CutInLineMode = _workingCopy.CutInLineMode;
+        SelectedWeekdays = _workingCopy.Weekdays;
+        SelectedAdHocWeekdays = _workingCopy.AdHocWeekdays ?? _workingCopy.CustomWeekdays ?? AllWeekdays;
+        SelectedAlignmentMode = AlignmentModeOptions.FirstOrDefault(option => option.Mode == _workingCopy.AdHocMode)
+            ?? AlignmentModeOptions[0];
+
+        // Load custom timer _settings
+        UseCustomTimer = _workingCopy.CustomTimerMode.HasValue;
+        if (UseCustomTimer)
+        {
+            CustomTimerMode = _workingCopy.CustomTimerMode ?? 0;
+            CustomReminderMinutes = _workingCopy.CustomReminderMinutes ?? 60;
+            CustomFocusMinutes = _workingCopy.CustomFocusMinutes ?? 15;
+            CustomBreakMinutes = _workingCopy.CustomBreakMinutes ?? 5;
+            CustomPomodoroCycles = _workingCopy.CustomPomodoroCycles ?? 3;
+        }
+        else
+        {
+            CustomTimerMode = 0;
+            CustomReminderMinutes = 60;
+            CustomFocusMinutes = 15;
+            CustomBreakMinutes = 5;
+            CustomPomodoroCycles = 3;
+        }
+
+        if (_workingCopy.Deadline.HasValue)
+        {
+            HasDeadline = true;
+            DateTime deadlineUtc = EnsureUtc(_workingCopy.Deadline.Value);
+            DeadlineDate = deadlineUtc.Date;
+            DeadlineTime = deadlineUtc.TimeOfDay;
+        }
+        else
+        {
+            HasDeadline = false;
+            DeadlineDate = GetTodayUtcDate();
+            DeadlineTime = new TimeSpan(9, 0, 0);
+        }
+
+        SelectPeriodDefinitionOption(_workingCopy);
+        OnPropertyChanged(nameof(SelectedPeriodDefinitionDescription));
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Title))
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await _storage.InitializeAsync();
+
+            _workingCopy.Title = Title.Trim();
+            _workingCopy.Description = Description?.Trim() ?? string.Empty;
+            _workingCopy.Importance = (int)Math.Max(1, Math.Round(Importance));
+            _workingCopy.SizePoints = SanitizeSizePoints(SizePoints);
+            _workingCopy.Repeat = Repeat;
+            _workingCopy.Weekdays = Repeat == RepeatType.Weekly ? SelectedWeekdays : Weekdays.None;
+            int intervalValue = (int)Math.Max(1, Math.Round(IntervalDays));
+            _workingCopy.IntervalDays = Repeat == RepeatType.Interval ? intervalValue : 0;
+            _workingCopy.AutoShuffleAllowed = AutoShuffleAllowed;
+            _workingCopy.CustomStartTime = null;
+            _workingCopy.CustomEndTime = null;
+            _workingCopy.CustomWeekdays = null;
+            ApplyPeriodDefinitionSelection(_workingCopy);
+            _workingCopy.Paused = IsPaused;
+            _workingCopy.CutInLineMode = CutInLineMode;
+
+            // Save custom timer _settings
+            if (UseCustomTimer)
+            {
+                _workingCopy.CustomTimerMode = CustomTimerMode;
+                _workingCopy.CustomReminderMinutes = (int)Math.Max(1, Math.Round(CustomReminderMinutes));
+                _workingCopy.CustomFocusMinutes = (int)Math.Max(1, Math.Round(CustomFocusMinutes));
+                _workingCopy.CustomBreakMinutes = (int)Math.Max(1, Math.Round(CustomBreakMinutes));
+                _workingCopy.CustomPomodoroCycles = (int)Math.Max(1, Math.Round(CustomPomodoroCycles));
+            }
+            else
+            {
+                _workingCopy.CustomTimerMode = null;
+                _workingCopy.CustomReminderMinutes = null;
+                _workingCopy.CustomFocusMinutes = null;
+                _workingCopy.CustomBreakMinutes = null;
+                _workingCopy.CustomPomodoroCycles = null;
+            }
+
+            if (HasDeadline)
+            {
+                DateTime combined = DeadlineDate.Date + DeadlineTime;
+                _workingCopy.Deadline = EnsureUtc(combined);
+            }
+            else
+            {
+                _workingCopy.Deadline = null;
+            }
+
+            if (string.IsNullOrWhiteSpace(_workingCopy.Id))
+            {
+                _workingCopy.Id = Guid.NewGuid().ToString("n");
+            }
+
+            if (!string.IsNullOrWhiteSpace(AppSettings.Network.UserId))
+            {
+                _workingCopy.UserId = AppSettings.Network.UserId;
+                _workingCopy.DeviceId = string.Empty;
+            }
+            else
+            {
+                
+                _workingCopy.UserId =  string.Empty;
+                _workingCopy.DeviceId = AppSettings.Network.DeviceId;
+            }
+
+            if (IsNew)
+            {
+                await _storage.AddTaskAsync(_workingCopy);
+            }
+            else
+            {
+                await _storage.UpdateTaskAsync(_workingCopy);
+            }
+
+            Saved?.Invoke(this, EventArgs.Empty);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static double SanitizeSizePoints(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
+        {
+            return DefaultSizePoints;
+        }
+
+        if (value < MinSizePoints)
+        {
+            return MinSizePoints;
+        }
+
+        if (value > MaxSizePoints)
+        {
+            return MaxSizePoints;
+        }
+
+        // Stepper may return values like 2.4999999997, round to 0.5 increments
+        double rounded = Math.Round(value * 2.0, MidpointRounding.AwayFromZero) / 2.0;
+        return Math.Max(MinSizePoints, Math.Min(MaxSizePoints, rounded));
+    }
+
+    private async Task LoadPeriodDefinitionOptionsAsync()
+    {
+        var definitions = await _storage.GetPeriodDefinitionsAsync();
+        var options = new List<PeriodDefinitionOption>
+        {
+            CreateOption(PeriodDefinitionCatalog.Any, isCoreBuiltIn: true),
+            CreateOption(PeriodDefinitionCatalog.Work, isCoreBuiltIn: true),
+            CreateOption(PeriodDefinitionCatalog.OffWork, isCoreBuiltIn: true)
+        };
+
+        foreach (PeriodDefinition definition in definitions)
+        {
+            if (string.Equals(definition.Id, PeriodDefinitionCatalog.AnyId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(definition.Id, PeriodDefinitionCatalog.WorkId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(definition.Id, PeriodDefinitionCatalog.OffWorkId, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            options.Add(CreateOption(definition, isCoreBuiltIn: false));
+        }
+
+        options.Add(new PeriodDefinitionOption(
+            "ad-hoc",
+            "Ad-hoc custom",
+            "Define a one-off window just for this task.",
+            definition: null,
+            isAdHoc: true,
+            isCoreBuiltIn: false));
+
+        PeriodDefinitionOptions.Clear();
+        foreach (PeriodDefinitionOption option in options)
+        {
+            PeriodDefinitionOptions.Add(option);
+        }
+    }
+
+    public async Task RefreshPeriodDefinitionsAsync(string? selectDefinitionId = null)
+    {
+        await _storage.InitializeAsync();
+        string? desiredId = selectDefinitionId ?? SelectedPeriodDefinition?.Id;
+        await LoadPeriodDefinitionOptionsAsync();
+
+        if (!string.IsNullOrWhiteSpace(desiredId))
+        {
+            PeriodDefinitionOption? match = PeriodDefinitionOptions
+                .FirstOrDefault(option => string.Equals(option.Id, desiredId, StringComparison.OrdinalIgnoreCase));
+            if (match != null)
+            {
+                SelectedPeriodDefinition = match;
+            }
+        }
+
+        OnPropertyChanged(nameof(SelectedPeriodDefinitionDescription));
+    }
+
+    private void SelectPeriodDefinitionOption(TaskItem task)
+    {
+        PeriodDefinitionOption? selected = null;
+
+        if (!string.IsNullOrWhiteSpace(task.PeriodDefinitionId))
+        {
+            selected = PeriodDefinitionOptions
+                .FirstOrDefault(option => string.Equals(option.Id, task.PeriodDefinitionId, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (selected == null && HasAdHocDefinition(task))
+        {
+            selected = PeriodDefinitionOptions.FirstOrDefault(option => option.IsAdHoc);
+        }
+
+        if (selected == null)
+        {
+            selected = task.AllowedPeriod switch
+            {
+                AllowedPeriod.Work => PeriodDefinitionOptions.FirstOrDefault(option =>
+                    string.Equals(option.Id, PeriodDefinitionCatalog.WorkId, StringComparison.OrdinalIgnoreCase)),
+                AllowedPeriod.OffWork => PeriodDefinitionOptions.FirstOrDefault(option =>
+                    string.Equals(option.Id, PeriodDefinitionCatalog.OffWorkId, StringComparison.OrdinalIgnoreCase)),
+                _ => PeriodDefinitionOptions.FirstOrDefault(option =>
+                    string.Equals(option.Id, PeriodDefinitionCatalog.AnyId, StringComparison.OrdinalIgnoreCase))
+            };
+        }
+
+        SelectedPeriodDefinition = selected ?? PeriodDefinitionOptions.FirstOrDefault();
+    }
+
+    private void ApplyPeriodDefinitionSelection(TaskItem task)
+    {
+        if (SelectedPeriodDefinition?.IsAdHoc == true)
+        {
+            task.PeriodDefinitionId = null;
+            task.AdHocStartTime = AdHocIsAllDay ? null : AdHocStartTime;
+            task.AdHocEndTime = AdHocIsAllDay ? null : AdHocEndTime;
+            task.AdHocWeekdays = SelectedAdHocWeekdays == AllWeekdays ? null : SelectedAdHocWeekdays;
+            task.AdHocIsAllDay = AdHocIsAllDay;
+            task.AdHocMode = SelectedAlignmentMode.Mode;
+            task.AllowedPeriod = AllowedPeriod.Custom;
+            return;
+        }
+
+        task.PeriodDefinitionId = SelectedPeriodDefinition?.Id;
+
+        if (SelectedPeriodDefinition?.Definition != null && !SelectedPeriodDefinition.IsCoreBuiltIn)
+        {
+            PeriodDefinition definition = SelectedPeriodDefinition.Definition;
+            task.AdHocStartTime = definition.StartTime;
+            task.AdHocEndTime = definition.EndTime;
+            task.AdHocWeekdays = definition.Weekdays;
+            task.AdHocIsAllDay = definition.IsAllDay;
+            task.AdHocMode = definition.Mode;
+        }
+        else
+        {
+            task.AdHocStartTime = null;
+            task.AdHocEndTime = null;
+            task.AdHocWeekdays = null;
+            task.AdHocIsAllDay = false;
+            task.AdHocMode = PeriodDefinitionMode.None;
+        }
+
+        task.AllowedPeriod = SelectedPeriodDefinition?.Id switch
+        {
+            PeriodDefinitionCatalog.WorkId => AllowedPeriod.Work,
+            PeriodDefinitionCatalog.OffWorkId => AllowedPeriod.OffWork,
+            PeriodDefinitionCatalog.AnyId => AllowedPeriod.Any,
+            _ => AllowedPeriod.Custom
+        };
+    }
+
+    private static bool HasAdHocDefinition(TaskItem task)
+    {
+        return task.AdHocStartTime.HasValue
+            || task.AdHocEndTime.HasValue
+            || task.AdHocWeekdays.HasValue
+            || task.AdHocIsAllDay
+            || task.AdHocMode != PeriodDefinitionMode.None
+            || task.AllowedPeriod == AllowedPeriod.Custom;
+    }
+
+    private static PeriodDefinitionOption CreateOption(PeriodDefinition definition, bool isCoreBuiltIn)
+    {
+        return new PeriodDefinitionOption(
+            definition.Id,
+            definition.Name,
+            PeriodDefinitionFormatter.DescribeDefinition(definition),
+            definition,
+            isAdHoc: false,
+            isCoreBuiltIn: isCoreBuiltIn);
+    }
+
+    private PeriodDefinition BuildAdHocDefinition()
+    {
+        return new PeriodDefinition
+        {
+            Id = string.Empty,
+            Name = "Ad-hoc custom",
+            StartTime = AdHocIsAllDay ? null : AdHocStartTime,
+            EndTime = AdHocIsAllDay ? null : AdHocEndTime,
+            Weekdays = SelectedAdHocWeekdays == Weekdays.None ? AllWeekdays : SelectedAdHocWeekdays,
+            IsAllDay = AdHocIsAllDay,
+            Mode = SelectedAlignmentMode.Mode
+        };
+    }
+
+    partial void OnSelectedPeriodDefinitionChanged(PeriodDefinitionOption? value)
+    {
+        OnPropertyChanged(nameof(IsAdHocSelection));
+        OnPropertyChanged(nameof(CanEditSelectedDefinition));
+        OnPropertyChanged(nameof(SelectedPeriodDefinitionDescription));
+    }
+
+    partial void OnAdHocStartTimeChanged(TimeSpan value)
+    {
+        OnPropertyChanged(nameof(SelectedPeriodDefinitionDescription));
+    }
+
+    partial void OnAdHocEndTimeChanged(TimeSpan value)
+    {
+        OnPropertyChanged(nameof(SelectedPeriodDefinitionDescription));
+    }
+
+    partial void OnAdHocIsAllDayChanged(bool value)
+    {
+        OnPropertyChanged(nameof(SelectedPeriodDefinitionDescription));
+    }
+
+    partial void OnSelectedAlignmentModeChanged(AlignmentModeOption value)
+    {
+        OnPropertyChanged(nameof(SelectedPeriodDefinitionDescription));
+    }
+
+    private DateTime GetTodayUtcDate()
+    {
+        DateTime utcNow = _clock.GetUtcNow().UtcDateTime;
+        return utcNow.Date;
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Local).ToUniversalTime()
+        };
+    }
+
+    partial void OnRepeatChanged(RepeatType value)
+    {
+        if (value != RepeatType.Weekly && SelectedWeekdays != Weekdays.None)
+        {
+            SelectedWeekdays = Weekdays.None;
+        }
+
+        if (value != RepeatType.Interval)
+        {
+            IntervalDays = 1;
+        }
+    }
+
+}

--- a/ShuffleTask.Presentation.Shared/ViewModels/PeriodDefinitionEditorViewModel.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/PeriodDefinitionEditorViewModel.cs
@@ -1,0 +1,174 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Utilities;
+
+namespace ShuffleTask.ViewModels;
+
+// Host-neutral period definition editor state and commands for MAUI presentation hosts.
+public sealed partial class PeriodDefinitionEditorViewModel : ViewModelWithWeekdaySelection
+{
+    private readonly IStorageService _storage;
+    private AppSettings _settings = new();
+    private string? _definitionId;
+    private bool _isNew = true;
+
+    public PeriodDefinitionEditorViewModel(IStorageService storage)
+    {
+        _storage = storage;
+        AlignmentModeOptions = AlignmentModeCatalog.Defaults;
+        SelectedAlignmentMode = AlignmentModeOptions[0];
+        SelectedWeekdays = PeriodDefinitionCatalog.AllWeekdays;
+    }
+
+    public IReadOnlyList<AlignmentModeOption> AlignmentModeOptions { get; }
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private bool isAllDay;
+
+    [ObservableProperty]
+    private TimeSpan startTime = new(9, 0, 0);
+
+    [ObservableProperty]
+    private TimeSpan endTime = new(17, 0, 0);
+
+    [ObservableProperty]
+    private AlignmentModeOption selectedAlignmentMode;
+
+    [ObservableProperty]
+    private bool isBusy;
+
+    public bool IsAlignmentFromSettings => IsSettingsAlignedMode(SelectedAlignmentMode?.Mode ?? PeriodDefinitionMode.None);
+
+    public string SettingsResolvedTimeRange => GetSettingsRangeText(SelectedAlignmentMode?.Mode ?? PeriodDefinitionMode.None);
+
+    public bool IsNew
+    {
+        get => _isNew;
+        private set => SetProperty(ref _isNew, value);
+    }
+
+    public event EventHandler<PeriodDefinitionSavedEventArgs>? Saved;
+
+    public async Task LoadAsync(PeriodDefinition? definition)
+    {
+        await _storage.InitializeAsync();
+        _settings = await _storage.GetSettingsAsync();
+        ApplyDefinition(definition);
+        OnPropertyChanged(nameof(SettingsResolvedTimeRange));
+    }
+
+    private void ApplyDefinition(PeriodDefinition? definition)
+    {
+        if (definition == null)
+        {
+            _definitionId = null;
+            IsNew = true;
+            Name = string.Empty;
+            SelectedWeekdays = PeriodDefinitionCatalog.AllWeekdays;
+            IsAllDay = false;
+            StartTime = new TimeSpan(9, 0, 0);
+            EndTime = new TimeSpan(17, 0, 0);
+            SelectedAlignmentMode = AlignmentModeOptions[0];
+            return;
+        }
+
+        _definitionId = definition.Id;
+        IsNew = string.IsNullOrWhiteSpace(definition.Id);
+        Name = definition.Name;
+        SelectedWeekdays = definition.Weekdays == Weekdays.None ? PeriodDefinitionCatalog.AllWeekdays : definition.Weekdays;
+        IsAllDay = definition.IsAllDay;
+        StartTime = definition.StartTime ?? new TimeSpan(9, 0, 0);
+        EndTime = definition.EndTime ?? new TimeSpan(17, 0, 0);
+        SelectedAlignmentMode = AlignmentModeOptions.FirstOrDefault(option => option.Mode == definition.Mode)
+            ?? AlignmentModeOptions[0];
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Name))
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await _storage.InitializeAsync();
+
+            var definition = new PeriodDefinition
+            {
+                Id = _definitionId ?? string.Empty,
+                Name = Name.Trim(),
+                Weekdays = SelectedWeekdays == Weekdays.None ? PeriodDefinitionCatalog.AllWeekdays : SelectedWeekdays,
+                IsAllDay = IsAllDay,
+                StartTime = IsAllDay ? null : StartTime,
+                EndTime = IsAllDay ? null : EndTime,
+                Mode = SelectedAlignmentMode.Mode
+            };
+
+            if (string.IsNullOrWhiteSpace(_definitionId))
+            {
+                await _storage.AddPeriodDefinitionAsync(definition);
+                _definitionId = definition.Id;
+                IsNew = false;
+            }
+            else
+            {
+                await _storage.UpdatePeriodDefinitionAsync(definition);
+            }
+
+            Saved?.Invoke(this, new PeriodDefinitionSavedEventArgs(definition));
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    partial void OnSelectedAlignmentModeChanged(AlignmentModeOption? value)
+    {
+        OnPropertyChanged(nameof(IsAlignmentFromSettings));
+        OnPropertyChanged(nameof(SettingsResolvedTimeRange));
+    }
+
+    private static bool IsSettingsAlignedMode(PeriodDefinitionMode mode)
+    {
+        return mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours)
+            || mode.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours)
+            || mode.HasFlag(PeriodDefinitionMode.Morning)
+            || mode.HasFlag(PeriodDefinitionMode.Lunch)
+            || mode.HasFlag(PeriodDefinitionMode.Evening);
+    }
+
+    private string GetSettingsRangeText(PeriodDefinitionMode mode)
+    {
+        (string label, TimeSpan start, TimeSpan end) = mode switch
+        {
+            var m when m.HasFlag(PeriodDefinitionMode.Morning) => ("Morning hours", _settings.MorningStart, _settings.MorningEnd),
+            var m when m.HasFlag(PeriodDefinitionMode.Lunch) => ("Lunch hours", _settings.LunchStart, _settings.LunchEnd),
+            var m when m.HasFlag(PeriodDefinitionMode.Evening) => ("Evening hours", _settings.EveningStart, _settings.EveningEnd),
+            var m when m.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours) => ("Work hours (off-work)", _settings.WorkStart, _settings.WorkEnd),
+            var m when m.HasFlag(PeriodDefinitionMode.AlignWithWorkHours) => ("Work hours", _settings.WorkStart, _settings.WorkEnd),
+            _ => (string.Empty, TimeSpan.Zero, TimeSpan.Zero)
+        };
+
+        if (string.IsNullOrWhiteSpace(label))
+        {
+            return string.Empty;
+        }
+
+        return $"Settings time range: {label} {start:hh\\:mm}–{end:hh\\:mm}";
+    }
+}

--- a/ShuffleTask.Presentation.Shared/ViewModels/PeriodDefinitionOption.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/PeriodDefinitionOption.cs
@@ -1,0 +1,31 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.ViewModels;
+
+// Shared display model for selectable period definitions.
+public sealed class PeriodDefinitionOption
+{
+    public PeriodDefinitionOption(string id, string name, string description, PeriodDefinition? definition, bool isAdHoc, bool isCoreBuiltIn)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+        Definition = definition;
+        IsAdHoc = isAdHoc;
+        IsCoreBuiltIn = isCoreBuiltIn;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public PeriodDefinition? Definition { get; }
+
+    public bool IsAdHoc { get; }
+
+    public bool IsCoreBuiltIn { get; }
+
+    public bool IsEditable => !IsAdHoc && !IsCoreBuiltIn;
+}

--- a/ShuffleTask.Presentation.Shared/ViewModels/PeriodDefinitionSavedEventArgs.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/PeriodDefinitionSavedEventArgs.cs
@@ -1,0 +1,14 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.ViewModels;
+
+// Shared event payload emitted by reusable period definition editor state.
+public sealed class PeriodDefinitionSavedEventArgs : EventArgs
+{
+    public PeriodDefinitionSavedEventArgs(PeriodDefinition definition)
+    {
+        Definition = definition;
+    }
+
+    public PeriodDefinition Definition { get; }
+}

--- a/ShuffleTask.Presentation.Shared/ViewModels/TasksViewModel.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/TasksViewModel.cs
@@ -1,0 +1,777 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Maui.ApplicationModel;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Application.Services;
+using ShuffleTask.Application.Utilities;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Utilities;
+
+namespace ShuffleTask.ViewModels;
+
+// Host-neutral task list state and commands for MAUI presentation hosts.
+public partial class TasksViewModel : ObservableObject
+{
+    private const string SortScore = "Score";
+    private const string SortImportance = "Importance";
+    private const string SortDeadline = "Deadline";
+    private const string RepeatFilterAll = "All";
+    private const string RepeatFilterRepeating = "Repeating";
+    private const string RepeatFilterNonRepeating = "One-off";
+
+    private readonly IStorageService _storage;
+    private readonly INetworkSyncService _networkSyncService;
+    private readonly TimeProvider _clock;
+    private readonly AppSettings _settings;
+    private bool _pendingSort;
+    private bool _pendingRefresh;
+    private bool _suppressRefresh;
+    private List<TaskListItem> _allTasks = [];
+
+    public TasksViewModel(IStorageService storage, TimeProvider clock, INetworkSyncService networkSyncService, AppSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(storage);
+        _storage = storage;
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _networkSyncService = networkSyncService;
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    public ObservableCollection<TaskListItem> Tasks { get; } = [];
+    public ObservableCollection<TaskListItem> ActiveTasks { get; } = [];
+    public ObservableCollection<TaskListItem> DoneTasks { get; } = [];
+    public ObservableCollection<TaskGroup> TaskGroups { get; private set; } = [];
+    public IReadOnlyList<string> SortOptions { get; } = new[] { SortScore, SortImportance, SortDeadline };
+    public IReadOnlyList<string> RepeatFilterOptions { get; } = new[] { RepeatFilterAll, RepeatFilterRepeating, RepeatFilterNonRepeating };
+
+    public bool HasActiveTasks => ActiveTasks.Count > 0;
+    public bool HasDoneTasks => DoneTasks.Count > 0;
+    public bool HasTasks => HasActiveTasks || HasDoneTasks;
+
+    [ObservableProperty]
+    private bool isBusy;
+
+    [ObservableProperty]
+    private string selectedSort = SortScore;
+
+    [ObservableProperty]
+    private bool filterAllowedNow;
+
+    [ObservableProperty]
+    private bool filterAllowedMorning;
+
+    [ObservableProperty]
+    private bool filterAllowedAfternoon;
+
+    [ObservableProperty]
+    private bool filterAllowedEvening;
+
+    [ObservableProperty]
+    private string selectedRepeatFilter = RepeatFilterAll;
+
+    public async Task LoadAsync(string? userId = null, string? deviceId = null)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await _storage.InitializeAsync();
+            List<TaskItem> items = await _storage.GetTasksAsync(
+                userId ?? _settings.Network?.UserId,
+                deviceId ?? _settings.Network?.DeviceId ?? string.Empty);
+            AppSettings settings = _settings;
+            DateTimeOffset now = _clock.GetUtcNow();
+
+            _allTasks = items
+                .Select(task => TaskListItem.From(task, settings, now))
+                .ToList();
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                ApplySortToCollections();
+                return Task.CompletedTask;
+            });
+        }
+        finally
+        {
+            IsBusy = false;
+            if (_pendingSort || _pendingRefresh)
+            {
+                _pendingSort = false;
+                _pendingRefresh = false;
+                ApplySortToCollections();
+            }
+        }
+    }
+
+    partial void OnSelectedSortChanged(string value)
+    {
+        RequestRefresh(true);
+    }
+
+    partial void OnFilterAllowedNowChanged(bool value)
+    {
+        RequestRefresh();
+    }
+
+    partial void OnFilterAllowedMorningChanged(bool value)
+    {
+        RequestRefresh();
+    }
+
+    partial void OnFilterAllowedAfternoonChanged(bool value)
+    {
+        RequestRefresh();
+    }
+
+    partial void OnFilterAllowedEveningChanged(bool value)
+    {
+        RequestRefresh();
+    }
+
+    partial void OnSelectedRepeatFilterChanged(string value)
+    {
+        RequestRefresh();
+    }
+
+    public void ResetFilters()
+    {
+        _suppressRefresh = true;
+        FilterAllowedNow = false;
+        FilterAllowedMorning = false;
+        FilterAllowedAfternoon = false;
+        FilterAllowedEvening = false;
+        SelectedRepeatFilter = RepeatFilterAll;
+        _suppressRefresh = false;
+        ApplySortToCollections();
+    }
+
+    private void RequestRefresh(bool isSortChange = false)
+    {
+        if (_suppressRefresh)
+        {
+            return;
+        }
+
+        if (IsBusy)
+        {
+            if (isSortChange)
+            {
+                _pendingSort = true;
+            }
+
+            _pendingRefresh = true;
+            return;
+        }
+
+        ApplySortToCollections();
+    }
+
+    private IEnumerable<TaskListItem> ApplySort(IEnumerable<TaskListItem> items)
+    {
+        return SelectedSort switch
+        {
+            SortImportance => items
+                .OrderByDescending(item => item.Task.Importance)
+                .ThenByDescending(item => item.PriorityScore)
+                .ThenBy(item => item.Task.Deadline ?? DateTime.MaxValue),
+            SortDeadline => items
+                .OrderBy(item => item.Task.Deadline ?? DateTime.MaxValue)
+                .ThenByDescending(item => item.Task.Importance)
+                .ThenByDescending(item => item.PriorityScore),
+            _ => items.OrderByDescending(item => item.PriorityScore)
+        };
+    }
+
+    private void ApplySortToCollections()
+    {
+#if !TEST
+        if (!MainThread.IsMainThread)
+        {
+            MainThread.BeginInvokeOnMainThread(ApplySortToCollections);
+            return;
+        }
+#endif
+
+        List<TaskListItem> items = _allTasks.ToList();
+        Tasks.Clear();
+        ActiveTasks.Clear();
+        DoneTasks.Clear();
+
+        IEnumerable<TaskListItem> filteredItems = ApplyFilters(items);
+        SeparateTasksToActiveAndDone(ApplySort(filteredItems));
+        AddAppropriateTaskGroups();
+        OnTaskBooleansChanged();
+    }
+
+    private IEnumerable<TaskListItem> ApplyFilters(IEnumerable<TaskListItem> items)
+    {
+        IEnumerable<TaskListItem> filteredItems = items;
+
+        if (FilterAllowedNow || FilterAllowedMorning || FilterAllowedAfternoon || FilterAllowedEvening)
+        {
+            DateTimeOffset now = _clock.GetUtcNow();
+            filteredItems = filteredItems.Where(item => MatchesAllowedTimeFilter(item.Task, now));
+        }
+
+        filteredItems = SelectedRepeatFilter switch
+        {
+            RepeatFilterRepeating => filteredItems.Where(item => item.Task.Repeat != RepeatType.None),
+            RepeatFilterNonRepeating => filteredItems.Where(item => item.Task.Repeat == RepeatType.None),
+            _ => filteredItems
+        };
+
+        return filteredItems;
+    }
+
+    private bool MatchesAllowedTimeFilter(TaskItem task, DateTimeOffset now)
+    {
+        if (FilterAllowedNow && TimeWindowService.AllowedNow(task, now, _settings))
+        {
+            return true;
+        }
+
+        DateTimeOffset localNow = TimeZoneInfo.ConvertTime(now, TimeZoneInfo.Local);
+
+        if (FilterAllowedMorning && IsAllowedDuringWindow(task, localNow, _settings.MorningStart, _settings.MorningEnd))
+        {
+            return true;
+        }
+
+        if (FilterAllowedAfternoon && IsAllowedDuringWindow(task, localNow, _settings.LunchEnd, _settings.EveningStart))
+        {
+            return true;
+        }
+
+        if (FilterAllowedEvening && IsAllowedDuringWindow(task, localNow, _settings.EveningStart, _settings.EveningEnd))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsAllowedDuringWindow(TaskItem task, DateTimeOffset localNow, TimeSpan start, TimeSpan end)
+    {
+        DateTimeOffset windowStartLocal = new(localNow.Date + start, localNow.Offset);
+        DateTimeOffset windowEndLocal = start == end
+            ? windowStartLocal.AddDays(1)
+            : (start < end
+                ? new DateTimeOffset(localNow.Date + end, localNow.Offset)
+                : new DateTimeOffset(localNow.Date + end, localNow.Offset).AddDays(1));
+
+        if (windowEndLocal <= windowStartLocal)
+        {
+            return false;
+        }
+
+        HashSet<DateTimeOffset> probes = BuildAllowedWindowProbes(task, windowStartLocal, windowEndLocal);
+        foreach (DateTimeOffset probe in probes.OrderBy(value => value))
+        {
+            if (TimeWindowService.AllowedNow(task, probe.ToOffset(TimeSpan.Zero), _settings))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private HashSet<DateTimeOffset> BuildAllowedWindowProbes(TaskItem task, DateTimeOffset windowStartLocal, DateTimeOffset windowEndLocal)
+    {
+        HashSet<DateTimeOffset> probes = [];
+
+        void AddProbe(DateTimeOffset localProbe)
+        {
+            if (localProbe >= windowStartLocal && localProbe < windowEndLocal)
+            {
+                probes.Add(localProbe);
+            }
+        }
+
+        AddProbe(windowStartLocal);
+        AddProbe(windowStartLocal.AddTicks(1));
+        AddProbe(windowEndLocal.AddTicks(-1));
+
+        foreach (TimeSpan boundary in GetTransitionBoundaries(task))
+        {
+            DateTime startDate = windowStartLocal.Date.AddDays(-1);
+            DateTime endDate = windowEndLocal.Date.AddDays(1);
+
+            for (DateTime day = startDate; day <= endDate; day = day.AddDays(1))
+            {
+                DateTimeOffset boundaryLocal = new(day + boundary, windowStartLocal.Offset);
+                AddProbe(boundaryLocal.AddTicks(-1));
+                AddProbe(boundaryLocal);
+                AddProbe(boundaryLocal.AddTicks(1));
+            }
+        }
+
+        for (DateTime day = windowStartLocal.Date.AddDays(-1); day <= windowEndLocal.Date.AddDays(1); day = day.AddDays(1))
+        {
+            DateTimeOffset midnight = new(day, windowStartLocal.Offset);
+            AddProbe(midnight.AddTicks(-1));
+            AddProbe(midnight);
+            AddProbe(midnight.AddTicks(1));
+        }
+
+        return probes;
+    }
+
+    private IReadOnlyCollection<TimeSpan> GetTransitionBoundaries(TaskItem task)
+    {
+        HashSet<TimeSpan> boundaries =
+        [
+            _settings.WorkStart,
+            _settings.WorkEnd,
+            _settings.MorningStart,
+            _settings.MorningEnd,
+            _settings.LunchStart,
+            _settings.LunchEnd,
+            _settings.EveningStart,
+            _settings.EveningEnd
+        ];
+
+        PeriodDefinition definition = ResolvePeriodDefinition(task);
+        (TimeSpan definitionStart, TimeSpan definitionEnd) = ResolveTimeWindow(definition);
+        boundaries.Add(definitionStart);
+        boundaries.Add(definitionEnd);
+
+        return boundaries;
+    }
+
+    private PeriodDefinition ResolvePeriodDefinition(TaskItem task)
+    {
+        if (PeriodDefinitionCatalog.TryGet(task.PeriodDefinitionId, out PeriodDefinition catalogDefinition))
+        {
+            return catalogDefinition;
+        }
+
+        if (TaskItemPeriodDefinitionHelper.TryBuildAdHocDefinition(task, out PeriodDefinition adHocDefinition))
+        {
+            return adHocDefinition;
+        }
+
+        return task.AllowedPeriod switch
+        {
+            AllowedPeriod.Work => PeriodDefinitionCatalog.Work,
+            AllowedPeriod.OffWork => PeriodDefinitionCatalog.OffWork,
+            AllowedPeriod.Custom => new PeriodDefinition
+            {
+                Id = string.Empty,
+                Name = "Legacy custom",
+                StartTime = task.CustomStartTime,
+                EndTime = task.CustomEndTime,
+                Weekdays = task.CustomWeekdays ?? PeriodDefinitionCatalog.AllWeekdays,
+                IsAllDay = !task.CustomStartTime.HasValue || !task.CustomEndTime.HasValue,
+                Mode = PeriodDefinitionMode.None
+            },
+            _ => PeriodDefinitionCatalog.Any
+        };
+    }
+
+    private (TimeSpan Start, TimeSpan End) ResolveTimeWindow(PeriodDefinition definition)
+    {
+        bool alignsWithWorkHours = definition.Mode.HasFlag(PeriodDefinitionMode.AlignWithWorkHours)
+            || definition.Mode.HasFlag(PeriodDefinitionMode.OffWorkRelativeToWorkHours);
+
+        if (alignsWithWorkHours)
+        {
+            return (_settings.WorkStart, _settings.WorkEnd);
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Morning))
+        {
+            return (_settings.MorningStart, _settings.MorningEnd);
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Lunch))
+        {
+            return (_settings.LunchStart, _settings.LunchEnd);
+        }
+
+        if (definition.Mode.HasFlag(PeriodDefinitionMode.Evening))
+        {
+            return (_settings.EveningStart, _settings.EveningEnd);
+        }
+
+        return (definition.StartTime ?? TimeSpan.Zero, definition.EndTime ?? TimeSpan.Zero);
+    }
+
+    private void SeparateTasksToActiveAndDone(IEnumerable<TaskListItem> sortedItems)
+    {
+        foreach (TaskListItem entry in sortedItems)
+        {
+            Tasks.Add(entry);
+            if (entry.Task.Status == TaskLifecycleStatus.Completed)
+            {
+                DoneTasks.Add(entry);
+            }
+            else
+            {
+                ActiveTasks.Add(entry);
+            }
+        }
+    }
+
+    private void AddAppropriateTaskGroups()
+    {
+        List<TaskListItem> activeItems = ActiveTasks.ToList();
+        List<TaskListItem> doneItems = DoneTasks.ToList();
+        List<TaskGroup> taskGroups = [];
+
+        if (activeItems.Count > 0)
+        {
+            taskGroups.Add(new TaskGroup("Active Tasks", false, activeItems));
+        }
+
+        if (doneItems.Count > 0)
+        {
+            taskGroups.Add(new TaskGroup("Done Tasks", activeItems.Count > 0, doneItems));
+        }
+
+        TaskGroups = new ObservableCollection<TaskGroup>(taskGroups);
+        OnPropertyChanged(nameof(TaskGroups));
+    }
+
+    private void OnTaskBooleansChanged()
+    {
+        OnPropertyChanged(nameof(HasActiveTasks));
+        OnPropertyChanged(nameof(HasDoneTasks));
+        OnPropertyChanged(nameof(HasTasks));
+    }
+
+    public async Task TogglePauseAsync(TaskItem task)
+    {
+        task.Paused = !task.Paused;
+        await _storage.UpdateTaskAsync(task);
+        await _networkSyncService.PublishTaskUpsertAsync(task);
+        await LoadAsync();
+    }
+
+    public async Task SetCutInLineModeAsync(TaskItem task, CutInLineMode mode)
+    {
+        if (task is null)
+        {
+            return;
+        }
+
+        if (task.CutInLineMode != mode)
+        {
+            task.CutInLineMode = mode;
+            await _storage.UpdateTaskAsync(task);
+            await _networkSyncService.PublishTaskUpsertAsync(task);
+        }
+
+        await LoadAsync();
+    }
+
+    public async Task ResumeAsync(TaskItem task)
+    {
+        if (task is null)
+        {
+            return;
+        }
+
+        TaskItem? updated = await _storage.ResumeTaskAsync(task.Id);
+
+        if (updated is not null)
+        {
+            await _networkSyncService.PublishTaskUpsertAsync(updated); 
+        }
+
+        await LoadAsync();
+    }
+
+    public async Task DeleteAsync(TaskItem task)
+    {
+        await _storage.DeleteTaskAsync(task.Id);
+        await _networkSyncService.PublishTaskDeletedAsync(task.Id);
+        await LoadAsync();
+    }
+
+    public async Task MarkDoneAsync(TaskItem task)
+    {
+        if (task is null)
+        {
+            return;
+        }
+
+        TaskItem? updated = await _storage.MarkTaskDoneAsync(task.Id);
+
+        if (updated is not null)
+        {
+            await _networkSyncService.PublishTaskUpsertAsync(updated); 
+        }
+
+        await LoadAsync();
+    }
+
+}
+
+public class TaskListItem
+{
+    public TaskItem Task { get; }
+
+    public ImportanceUrgencyScore Score { get; }
+
+    public double PriorityScore => Score.CombinedScore;
+
+    public string ScoreText => $"Score {PriorityScore:0.#}";
+
+    public string Title => string.IsNullOrWhiteSpace(Task.Title) ? "Untitled" : Task.Title;
+
+    public string Description => string.IsNullOrWhiteSpace(Task.Description) ? "No description" : Task.Description;
+
+    public string RepeatText { get; }
+
+    public string ScheduleText { get; }
+
+    public string ImportanceText { get; }
+
+    public string AllowedPeriodText { get; }
+
+    public string StatusText { get; }
+
+    public bool HasStatusBadge { get; }
+
+    public string StatusBackgroundColor { get; }
+
+    public string StatusTextColor { get; }
+
+    public bool CanResume { get; }
+
+    public bool HasCutInLineBadge => Task.CutInLineMode != CutInLineMode.None;
+
+    public string CutInLineBadgeText => Task.CutInLineMode switch
+    {
+        CutInLineMode.Once => "Cut-in-line: Once",
+        CutInLineMode.UntilCompletion => "Cut-in-line: Until complete",
+        _ => string.Empty
+    };
+
+    public string CutInLineBadgeBackgroundColor => Task.CutInLineMode switch
+    {
+        CutInLineMode.Once => "#DBEAFE",
+        CutInLineMode.UntilCompletion => "#FEEBC8",
+        _ => "Transparent"
+    };
+
+    public string CutInLineBadgeTextColor => Task.CutInLineMode switch
+    {
+        CutInLineMode.Once => "#1D4ED8",
+        CutInLineMode.UntilCompletion => "#92400E",
+        _ => "#1F2937"
+    };
+
+    private TaskListItem(
+        TaskItem task,
+        string repeatText,
+        string scheduleText,
+        string importanceText,
+        string allowedPeriodText,
+        TaskStatusPresentation status, ImportanceUrgencyScore score)
+    {
+        Task = task;
+        RepeatText = repeatText;
+        ScheduleText = scheduleText;
+        ImportanceText = importanceText;
+        AllowedPeriodText = allowedPeriodText;
+        StatusText = status.Text;
+        HasStatusBadge = status.HasBadge;
+        StatusBackgroundColor = status.BackgroundColor;
+        StatusTextColor = status.TextColor;
+        CanResume = status.CanResume;
+        Score = score;
+    }
+
+    public static TaskListItem From(TaskItem task, AppSettings settings, DateTimeOffset now)
+    {
+        string repeat = task.Repeat switch
+        {
+            RepeatType.None => "One-off",
+            RepeatType.Daily => "Daily",
+            RepeatType.Weekly => $"Weekly ({FormatWeekdays(task.Weekdays)})",
+            RepeatType.Interval => $"Every {Math.Max(1, task.IntervalDays)} day(s)",
+            _ => task.Repeat.ToString()
+        };
+
+        string schedule = task.Deadline.HasValue
+            ? $"Due {FormatAbsolute(task.Deadline)}"
+            : "No deadline";
+
+        int importance = Math.Clamp(task.Importance, 1, 5);
+        string importanceStars = new string('★', importance).PadRight(5, '☆');
+        string importanceText = $"Importance: {importanceStars} ({importance}/5)";
+
+        string allowedPeriodText = $"Auto shuffle: {PeriodDefinitionFormatter.FormatAllowedPeriodLabel(task)}";
+
+        TaskStatusPresentation status = BuildStatusPresentation(task, now);
+        ImportanceUrgencyScore score = ImportanceUrgencyCalculator.Calculate(task, now, settings);
+
+        return new TaskListItem(
+            task,
+            repeat,
+            schedule,
+            importanceText,
+            allowedPeriodText,
+            status, score);
+    }
+
+    private static TaskStatusPresentation BuildStatusPresentation(TaskItem task, DateTimeOffset reference)
+    {
+        if (task.Paused)
+        {
+            return new TaskStatusPresentation("Paused", true, "#FEE2E2", "#C53030", false);
+        }
+
+        return task.Status switch
+        {
+            TaskLifecycleStatus.Active => TaskStatusPresentation.Active,
+            TaskLifecycleStatus.Snoozed => BuildSnoozedPresentation(task, reference),
+            TaskLifecycleStatus.Completed => BuildCompletedPresentation(task, reference),
+            _ => TaskStatusPresentation.Active
+        };
+    }
+
+    private static TaskStatusPresentation BuildSnoozedPresentation(TaskItem task, DateTimeOffset reference)
+    {
+        string until = FormatRelative(task.SnoozedUntil ?? task.NextEligibleAt, reference);
+        string text = string.IsNullOrEmpty(until) ? "Snoozed" : $"Snoozed until {until}";
+        return new TaskStatusPresentation(text, true, "#FEF3C7", "#975A16", true);
+    }
+
+    private static TaskStatusPresentation BuildCompletedPresentation(TaskItem task, DateTimeOffset reference)
+    {
+        bool oneOff = task.Repeat == RepeatType.None;
+        string next = FormatRelative(task.NextEligibleAt, reference);
+        string text = "Completed";
+
+        if (!oneOff && !string.IsNullOrEmpty(next))
+        {
+            text = $"Completed • next at {next}";
+        }
+
+        return new TaskStatusPresentation(text, true, "#C6F6D5", "#276749", true);
+    }
+
+    private static string FormatRelative(DateTime? value, DateTimeOffset reference)
+    {
+        if (!value.HasValue)
+        {
+            return string.Empty;
+        }
+
+        DateTimeOffset? target = EnsureUtc(value);
+        if (target == null)
+        {
+            return string.Empty;
+        }
+
+        DateTimeOffset referenceLocal = TimeZoneInfo.ConvertTime(reference, TimeZoneInfo.Local);
+        DateTimeOffset targetLocal = TimeZoneInfo.ConvertTime(target.Value, TimeZoneInfo.Local);
+
+        DateTime referenceDate = referenceLocal.Date;
+        if (targetLocal.Date == referenceDate)
+        {
+            return targetLocal.ToString("h:mm tt", CultureInfo.CurrentCulture);
+        }
+
+        if (targetLocal.Date == referenceDate.AddDays(1))
+        {
+            return $"tomorrow {targetLocal.ToString("h:mm tt", CultureInfo.CurrentCulture)}";
+        }
+
+        return targetLocal.ToString("MMM d h:mm tt", CultureInfo.CurrentCulture);
+    }
+
+    private static string FormatAbsolute(DateTime? value)
+    {
+        if (!value.HasValue)
+        {
+            return "--";
+        }
+
+        DateTimeOffset? target = EnsureUtc(value);
+        if (target == null)
+        {
+            return "--";
+        }
+
+        DateTimeOffset local = TimeZoneInfo.ConvertTime(target.Value, TimeZoneInfo.Local);
+        return local.ToString("MMM d, yyyy HH:mm", CultureInfo.CurrentCulture);
+    }
+
+    private static DateTimeOffset? EnsureUtc(DateTime? value)
+    {
+        if (!value.HasValue)
+        {
+            return null;
+        }
+
+        DateTime dt = value.Value;
+        return dt.Kind switch
+        {
+            DateTimeKind.Utc => new DateTimeOffset(dt, TimeSpan.Zero),
+            DateTimeKind.Local => new DateTimeOffset(dt.ToUniversalTime(), TimeSpan.Zero),
+            _ => new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc), TimeSpan.Zero)
+        };
+    }
+
+    private static string FormatWeekdays(Weekdays weekdays)
+    {
+        if (weekdays == Weekdays.None)
+        {
+            return "--";
+        }
+
+        var names = new List<string>();
+        void Add(Weekdays day, string label)
+        {
+            if (weekdays.HasFlag(day))
+            {
+                names.Add(label);
+            }
+        }
+
+        Add(Weekdays.Mon, "Mon");
+        Add(Weekdays.Tue, "Tue");
+        Add(Weekdays.Wed, "Wed");
+        Add(Weekdays.Thu, "Thu");
+        Add(Weekdays.Fri, "Fri");
+        Add(Weekdays.Sat, "Sat");
+        Add(Weekdays.Sun, "Sun");
+
+        return string.Join(", ", names);
+    }
+
+    private sealed record TaskStatusPresentation(
+        string Text,
+        bool HasBadge,
+        string BackgroundColor,
+        string TextColor,
+        bool CanResume)
+    {
+        public static TaskStatusPresentation Active { get; } = new("Active", false, "#E2E8F0", "#2D3748", false);
+    }
+}
+
+public class TaskGroup : ObservableCollection<TaskListItem>
+{
+    public TaskGroup(string title, bool showDivider, IEnumerable<TaskListItem> items)
+        : base(items)
+    {
+        Title = title;
+        ShowDivider = showDivider;
+    }
+
+    public string Title { get; }
+
+    public bool ShowDivider { get; }
+}

--- a/ShuffleTask.Presentation.Tests/SharedPresentationRegistrationTests.cs
+++ b/ShuffleTask.Presentation.Tests/SharedPresentationRegistrationTests.cs
@@ -3,8 +3,8 @@ using NSubstitute;
 using NUnit.Framework;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
-using ShuffleTask.Presentation;
 using ShuffleTask.Presentation.Services;
+using ShuffleTask.Presentation.Shared;
 using ShuffleTask.ViewModels;
 
 namespace ShuffleTask.Presentation.Tests;

--- a/ShuffleTask.Presentation.Tests/SharedPresentationRegistrationTests.cs
+++ b/ShuffleTask.Presentation.Tests/SharedPresentationRegistrationTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NUnit.Framework;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Application.Models;
+using ShuffleTask.Presentation;
+using ShuffleTask.Presentation.Services;
+using ShuffleTask.ViewModels;
+
+namespace ShuffleTask.Presentation.Tests;
+
+public class SharedPresentationRegistrationTests
+{
+    [Test]
+    public void AddShuffleTaskSharedPresentation_RegistersReusablePresentationServicesOnly()
+    {
+        var services = new ServiceCollection();
+
+        services.AddShuffleTaskSharedPresentation();
+
+        Assert.That(services.Any(ServiceType<TimeProvider>), Is.True);
+        Assert.That(services.Any(ServiceType<ISchedulerService>), Is.True);
+        Assert.That(services.Any(ServiceType<ShuffleCoordinatorService>), Is.True);
+        Assert.That(services.Any(ServiceType<DashboardViewModel>), Is.True);
+        Assert.That(services.Any(ServiceType<TasksViewModel>), Is.True);
+        Assert.That(services.Any(ServiceType<EditTaskViewModel>), Is.True);
+        Assert.That(services.Any(ServiceType<PeriodDefinitionEditorViewModel>), Is.True);
+        Assert.That(services.Any(d => d.ServiceType.Name == "SettingsViewModel"), Is.False);
+        Assert.That(services.Any(d => d.ServiceType.Namespace == "ShuffleTask.Views"), Is.False);
+    }
+
+    [Test]
+    public void AddShuffleTaskSharedPresentation_InvokesDashboardHostHookWhenDashboardIsResolved()
+    {
+        var services = new ServiceCollection();
+        var hookWasCalled = false;
+
+        services.AddSingleton(Substitute.For<IStorageService>());
+        services.AddSingleton(Substitute.For<INotificationService>());
+        services.AddSingleton(Substitute.For<IPersistentBackgroundService>());
+        services.AddSingleton(Substitute.For<INetworkSyncService>());
+        services.AddSingleton(new AppSettings());
+        services.AddShuffleTaskSharedPresentation((provider, dashboard) =>
+        {
+            Assert.That(provider, Is.Not.Null);
+            Assert.That(dashboard, Is.Not.Null);
+            hookWasCalled = true;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        _ = provider.GetRequiredService<DashboardViewModel>();
+
+        Assert.That(hookWasCalled, Is.True);
+    }
+
+    private static Func<ServiceDescriptor, bool> ServiceType<T>() => descriptor => descriptor.ServiceType == typeof(T);
+}

--- a/ShuffleTask.Presentation.Tests/ShuffleTask.Presentation.Tests.csproj
+++ b/ShuffleTask.Presentation.Tests/ShuffleTask.Presentation.Tests.csproj
@@ -10,16 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="../ShuffleTask.Presentation/ViewModels/TasksViewModel.cs" Link="ViewModels/TasksViewModel.cs" />
-    <Compile Include="../ShuffleTask.Presentation/Services/ShuffleCoordinatorService.cs" Link="Services/ShuffleCoordinatorService.cs" />
-    <Compile Include="../ShuffleTask.Presentation/Services/IPersistentBackgroundService.cs" Link="Services/IPersistentBackgroundService.cs" />
-    <Compile Include="../ShuffleTask.Presentation/Utilities/PersistedTimerState.cs" Link="Utilities/PersistedTimerState.cs" />
-    <Compile Include="../ShuffleTask.Presentation/Utilities/PersistedSchedulerState.cs" Link="Utilities/PersistedSchedulerState.cs" />
-    <Compile Include="../ShuffleTask.Presentation/Utilities/TaskTimerSettings.cs" Link="Utilities/TaskTimerSettings.cs" />
-    <Compile Include="../ShuffleTask.Presentation/PreferenceKeys.cs" Link="PreferenceKeys.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="4.5.1" />
@@ -29,9 +19,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ShuffleTask.Presentation.Shared\ShuffleTask.Presentation.Shared.csproj" />
     <ProjectReference Include="..\ShuffleTask.Application\ShuffleTask.Application.csproj" />
     <ProjectReference Include="..\ShuffleTask.Domain\ShuffleTask.Domain.csproj" />
     <ProjectReference Include="..\ShuffleTask.Tests\ShuffleTask.Tests.csproj" />

--- a/ShuffleTask.Presentation/MauiProgram.cs
+++ b/ShuffleTask.Presentation/MauiProgram.cs
@@ -6,6 +6,7 @@ using ShuffleTask.Application.Utilities;
 using ShuffleTask.Persistence;
 using ShuffleTask.Presentation.EventsHandlers;
 using ShuffleTask.Presentation.Services;
+using ShuffleTask.Presentation.Shared;
 using ShuffleTask.ViewModels;
 using ShuffleTask.Views;
 using Yaref92.Events;

--- a/ShuffleTask.Presentation/MauiProgram.cs
+++ b/ShuffleTask.Presentation/MauiProgram.cs
@@ -56,7 +56,6 @@ public static partial class MauiProgram
         });
 
         // DI registrations
-        builder.Services.AddSingleton<TimeProvider>(_ => TimeProvider.System);
         builder.Services.AddSingleton<IShuffleLogger>(sp => new DefaultShuffleLogger(sp.GetRequiredService<TimeProvider>()));
         builder.Services.AddSingleton(provider =>
         {
@@ -69,27 +68,13 @@ public static partial class MauiProgram
         builder.Services.AddSingleton<INotificationService, NotificationService>();
         builder.Services.AddSingleton<IPersistentBackgroundService, PersistentBackgroundService>();
         SetupEventAggregation(builder);
-        builder.Services.AddSingleton<ISchedulerService>(sp => new SchedulerService(deterministic: false));
-        builder.Services.AddSingleton<ShuffleCoordinatorService>();
-
-        // ViewModels
-        builder.Services.AddSingleton<DashboardViewModel>(sp =>
+        builder.Services.AddShuffleTaskSharedPresentation((sp, dashboardViewModel) =>
         {
-            var storage = sp.GetRequiredService<IStorageService>();
-            var scheduler = sp.GetRequiredService<ISchedulerService>();
-            var notifications = sp.GetRequiredService<INotificationService>();
-            var shuffleCoordinator = sp.GetRequiredService<ShuffleCoordinatorService>();
-            var timeProvider = sp.GetRequiredService<TimeProvider>();
-            var networkSync = sp.GetRequiredService<INetworkSyncService>();
-            var appSettings = sp.GetRequiredService<AppSettings>();
-            var dashboardViewModel = new DashboardViewModel(storage, scheduler, notifications, shuffleCoordinator, timeProvider, networkSync, appSettings);
             var taskStartedHandler = sp.GetRequiredService<TaskStartedAsyncHandler>();
             taskStartedHandler.RegisterDashboard(dashboardViewModel);
-            return dashboardViewModel;
         });
-        builder.Services.AddSingleton<TasksViewModel>();
-        builder.Services.AddSingleton<EditTaskViewModel>();
-        builder.Services.AddSingleton<PeriodDefinitionEditorViewModel>();
+
+        // Host-specific ViewModels
         builder.Services.AddSingleton<SettingsViewModel>();
 
         // Views

--- a/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
+++ b/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <!-- Build Windows by default to unblock, other targets can be re-enabled later -->
-        <TargetFrameworks>net10.0-android</TargetFrameworks>
-      <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TargetFramework)' == ''">net10.0-android</TargetFrameworks>
+      <TargetFrameworks Condition="'$(TargetFramework)' == '' and $([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
         <!--<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('android'))">$(TargetFrameworks);net10.0-android</TargetFrameworks>-->
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('ios'))">$(TargetFrameworks);net10.0-ios</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('maccatalyst'))">$(TargetFrameworks);net10.0-maccatalyst</TargetFrameworks>
@@ -45,6 +45,8 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- Reusable presentation ViewModels and coordinator services for standalone and SecondBrain hosts. -->
+        <ProjectReference Include="..\ShuffleTask.Presentation.Shared\ShuffleTask.Presentation.Shared.csproj" />
         <ProjectReference Include="..\ShuffleTask.Application\ShuffleTask.Application.csproj" />
         <ProjectReference Include="..\ShuffleTask.Domain\ShuffleTask.Domain.csproj" />
         <ProjectReference Include="..\ShuffleTask.Persistence\ShuffleTask.Persistence.csproj" />


### PR DESCRIPTION
Implements:

# GitHub Issue #302: Split reusable MAUI layer from standalone app presentation host

URL: https://github.com/com-mit-group/ShuffleTask/issues/302

## Context
The current MAUI layer should be separated so the reusable presentation layer can be consumed by both SecondBrain and standalone apps. The standalone app should have its own presentation host/project.

The ViewModels may be reusable across hosts, but Views may need to diverge between SecondBrain and the standalone app experience.

## Scope
- Inventory the current MAUI Views, ViewModels, navigation, resources, platform services, and app startup wiring.
- Extract shared presentation/ViewModel code into a reusable project that SecondBrain and standalone app hosts can reference.
- Keep app-specific Views, Shell/navigation, resources, platform integrations, and host startup in the standalone presentation project.
- Decide explicitly which Views can be shared and which should remain host-specific.
- Add or update tests around shared ViewModels and host composition where practical.
- Document the resulting project boundaries and references.

## Acceptance criteria
- Shared MAUI/ViewModel code is isolated in a reusable project.
- A standalone app presentation project remains as the runnable host.
- SecondBrain integration requirements are captured without forcing identical Views where they do not fit.

Codex plan:

1) Where to look

- Read AGENTS.md, ARCHITECTURE.md, and the MAUI solution/project files to confirm project boundaries and build expectations.
- Inspect ShuffleTask.Maui, ShuffleTask.Presentation.Shared, and related test projects for current Views, ViewModels, navigation, resources, platform services, and startup wiring.
- Check existing documentation for presentation-layer boundaries and SecondBrain integration notes.

2) Files / areas likely to touch

- ShuffleTask.Presentation.Shared project files and contents for reusable ViewModel/presentation services.
- Standalone MAUI host project files for app-specific Shell/navigation/resources/platform startup wiring.
- MAUI or shared presentation test project files if tests exist or can be added with minimal dependency impact.
- ARCHITECTURE.md or nearby presentation documentation for the resulting boundary and SecondBrain requirements.

3) Assumptions

- Existing application, domain, persistence, backend, web, and Python behavior should remain unchanged.
- Views and host Shell/navigation can stay in the standalone app unless an existing view is already clearly reusable without host assumptions.
- The reusable layer should be buildable as a referenced project by multiple hosts, including future SecondBrain integration.

4) Plan

- Inventory the current MAUI host and shared presentation project to identify what is already reusable and what remains host-specific.
- Move or expose only reusable ViewModel/presentation-service code through the shared project while keeping Views, Shell/navigation, resources, platform integrations, and MauiProgram host wiring in the standalone MAUI project.
- Add or update focused tests around shared ViewModel/service composition where practical without expanding into application/domain changes.
- Document the project boundary, shared versus host-specific View decisions, and SecondBrain integration expectations.

5) Risks / gotchas

- MAUI build targets can be sensitive to platform-specific package references and generated XAML artifacts.
- Moving XAML Views into a shared library could accidentally force identical UX across hosts, so default to host-specific Views unless clearly reusable.
- Startup registration changes must preserve standalone app runtime behavior and dependency injection composition.

6) Recommended implementation approach

Treat this as a boundary-hardening pass around the existing presentation split. Prefer small project-reference, namespace, and documentation changes over broad file movement. Keep reusable code in ShuffleTask.Presentation.Shared and keep runnable host composition in the standalone MAUI project, with tests validating only the shared surface or host composition points that can run under the repository's MAUI verification profile.

Local verification:
```text
bash "/home/codex-auto/automation/scripts/codex-verify.sh" --profiles "maui"
```
