### PR TITLE
#301: Enable Ubuntu run path for the MAUI layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,37 @@ A task prioritization and scheduling system that helps you focus by intelligentl
 ### Architecture & Design
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - Clean layered architecture with structured logging and state management
 
+### Ubuntu MAUI Android smoke test
+
+The runnable MAUI host is `ShuffleTask.Presentation`. On Ubuntu, use the Android target:
+
+- Host project: `ShuffleTask.Presentation/ShuffleTask.Presentation.csproj`
+- Ubuntu target framework: `net10.0-android`
+- Shared presentation target frameworks: `net10.0` and `net10.0-android`
+
+Install the .NET SDK used by the repo, the .NET MAUI workload, and the Android SDK:
+
+```bash
+dotnet workload install maui
+export ANDROID_HOME="$HOME/Android/Sdk"
+```
+
+Then build the Android target from Ubuntu:
+
+```bash
+scripts/maui-android-ubuntu.sh build
+```
+
+To run on a booted emulator or attached Android device:
+
+```bash
+scripts/maui-android-ubuntu.sh run
+```
+
+Use `scripts/maui-android-ubuntu.sh run --device SERIAL` when more than one device is attached. The helper fails early with actionable messages when the MAUI workload, Android SDK, platform packages, platform-tools, or a runnable device/emulator are missing.
+
+Windows, iOS, and MacCatalyst targets remain native-host paths. Build Windows on Windows, iOS on macOS with the Apple toolchain, and MacCatalyst on macOS.
+
 ### Core Flows
 
 **Task Selection Flow:**

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ export ANDROID_HOME="$HOME/Android/Sdk"
 Then build the Android target from Ubuntu:
 
 ```bash
-scripts/maui-android-ubuntu.sh build
+bash scripts/maui-android-ubuntu.sh build
 ```
 
 To run on a booted emulator or attached Android device:
 
 ```bash
-scripts/maui-android-ubuntu.sh run
+bash scripts/maui-android-ubuntu.sh run
 ```
 
-Use `scripts/maui-android-ubuntu.sh run --device SERIAL` when more than one device is attached. The helper fails early with actionable messages when the MAUI workload, Android SDK, platform packages, platform-tools, or a runnable device/emulator are missing.
+Use `bash scripts/maui-android-ubuntu.sh run --device SERIAL` when more than one device is attached. The helper fails early with actionable messages when the MAUI workload, Android SDK, platform packages, platform-tools, or a runnable device/emulator are missing.
 
 Windows, iOS, and MacCatalyst targets remain native-host paths. Build Windows on Windows, iOS on macOS with the Apple toolchain, and MacCatalyst on macOS.
 

--- a/scripts/maui-android-ubuntu.sh
+++ b/scripts/maui-android-ubuntu.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT="ShuffleTask.Presentation/ShuffleTask.Presentation.csproj"
+FRAMEWORK="net10.0-android"
+CONFIGURATION="Debug"
+MODE="build"
+DEVICE_SERIAL=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/maui-android-ubuntu.sh [build|run] [--configuration Debug|Release] [--device SERIAL]
+
+Build or run the MAUI host from Ubuntu through the Android target.
+
+Examples:
+  scripts/maui-android-ubuntu.sh build
+  scripts/maui-android-ubuntu.sh run
+  scripts/maui-android-ubuntu.sh run --device emulator-5554
+USAGE
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    fail "$2"
+  fi
+}
+
+resolve_android_sdk() {
+  if [[ -n "${ANDROID_HOME:-}" ]]; then
+    printf '%s\n' "$ANDROID_HOME"
+    return 0
+  fi
+
+  if [[ -n "${ANDROID_SDK_ROOT:-}" ]]; then
+    printf '%s\n' "$ANDROID_SDK_ROOT"
+    return 0
+  fi
+
+  if [[ -d "$HOME/Android/Sdk" ]]; then
+    printf '%s\n' "$HOME/Android/Sdk"
+    return 0
+  fi
+
+  return 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    build|run)
+      MODE="$1"
+      shift
+      ;;
+    --configuration)
+      [[ $# -ge 2 ]] || fail "--configuration requires Debug or Release."
+      CONFIGURATION="$2"
+      shift 2
+      ;;
+    --device)
+      [[ $# -ge 2 ]] || fail "--device requires an Android device serial."
+      DEVICE_SERIAL="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$CONFIGURATION" in
+  Debug|Release) ;;
+  *) fail "--configuration must be Debug or Release." ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+[[ -f "$PROJECT" ]] || fail "Cannot find $PROJECT. Run this script from the ShuffleTask repository."
+
+require_command dotnet "Install the .NET SDK that matches the repo target, then rerun this command."
+
+if ! dotnet workload list 2>/dev/null | grep -Eq '(^|[[:space:]])maui($|[[:space:]]|-)|(^|[[:space:]])maui-android($|[[:space:]])'; then
+  fail "Install the .NET MAUI workload with: dotnet workload install maui"
+fi
+
+ANDROID_SDK="$(resolve_android_sdk)" || fail "Install the Android SDK and set ANDROID_HOME or ANDROID_SDK_ROOT, or use the default $HOME/Android/Sdk path."
+[[ -d "$ANDROID_SDK" ]] || fail "Android SDK path does not exist: $ANDROID_SDK"
+[[ -d "$ANDROID_SDK/platforms" ]] || fail "Android SDK platforms are missing. Install an Android platform with sdkmanager, for example: sdkmanager \"platforms;android-35\""
+[[ -d "$ANDROID_SDK/platform-tools" ]] || fail "Android SDK platform-tools are missing. Install them with: sdkmanager \"platform-tools\""
+
+BUILD_ARGS=(
+  "$PROJECT"
+  -f "$FRAMEWORK"
+  -c "$CONFIGURATION"
+)
+
+if [[ "$MODE" == "run" ]]; then
+  ADB="$ANDROID_SDK/platform-tools/adb"
+  [[ -x "$ADB" ]] || ADB="$(command -v adb || true)"
+  [[ -n "$ADB" ]] || fail "Cannot find adb. Install Android platform-tools or add adb to PATH."
+
+  if [[ -z "$DEVICE_SERIAL" ]]; then
+    mapfile -t DEVICES < <("$ADB" devices | awk 'NR > 1 && $2 == "device" { print $1 }')
+    [[ "${#DEVICES[@]}" -gt 0 ]] || fail "No attached Android device or running emulator found. Start an emulator or connect a device, then rerun."
+  else
+    if ! "$ADB" devices | awk 'NR > 1 && $1 == serial && $2 == "device" { found = 1 } END { exit found ? 0 : 1 }' serial="$DEVICE_SERIAL"; then
+      fail "Android device '$DEVICE_SERIAL' is not connected and ready according to adb devices."
+    fi
+    BUILD_ARGS+=("-p:AndroidDevice=$DEVICE_SERIAL")
+  fi
+
+  BUILD_ARGS+=("-t:Run")
+fi
+
+printf 'Running: dotnet build %s\n' "${BUILD_ARGS[*]}"
+dotnet build "${BUILD_ARGS[@]}"

--- a/scripts/maui-android-ubuntu.sh
+++ b/scripts/maui-android-ubuntu.sh
@@ -9,14 +9,14 @@ DEVICE_SERIAL=""
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/maui-android-ubuntu.sh [build|run] [--configuration Debug|Release] [--device SERIAL]
+Usage: bash scripts/maui-android-ubuntu.sh [build|run] [--configuration Debug|Release] [--device SERIAL]
 
 Build or run the MAUI host from Ubuntu through the Android target.
 
 Examples:
-  scripts/maui-android-ubuntu.sh build
-  scripts/maui-android-ubuntu.sh run
-  scripts/maui-android-ubuntu.sh run --device emulator-5554
+  bash scripts/maui-android-ubuntu.sh build
+  bash scripts/maui-android-ubuntu.sh run
+  bash scripts/maui-android-ubuntu.sh run --device emulator-5554
 USAGE
 }
 


### PR DESCRIPTION
Implements:

# GitHub Issue #301: Enable Ubuntu run path for the MAUI layer

URL: https://github.com/com-mit-group/ShuffleTask/issues/301

## Context
We need to be able to run or at least smoke-test the MAUI layer from the Ubuntu development environment.

On Ubuntu the practical MAUI path is Android, not native Linux desktop: verify the .NET MAUI workload, Android SDK/emulator or attached device, and a repo-specific run command. Windows, iOS, and MacCatalyst targets remain host-specific.

## Scope
- Inventory the current MAUI target frameworks and workload requirements.
- Add or update docs/scripts for Ubuntu setup and Android run/build commands.
- Ensure the repo has a clear fallback when MAUI workloads or Android SDK pieces are missing.
- Verify an Android build/run path from Ubuntu when an emulator or device is available.
- Capture blockers explicitly if a full run is not feasible in this environment.

## Acceptance criteria
- A documented Ubuntu command exists for building/running the MAUI layer through the Android target.
- Missing workload/SDK failures are actionable.
- Non-Android platform targets are documented as requiring their native host.

Codex plan:

1) Where to look
- `ShuffleTask.Presentation/ShuffleTask.Presentation.csproj` for host target frameworks, MAUI package versions, and platform-specific target conditions.
- `ShuffleTask.Presentation.Shared/ShuffleTask.Presentation.Shared.csproj` for shared presentation target frameworks used by the MAUI host.
- Existing top-level docs such as `README.md` and any existing scripts/docs directories for developer setup conventions.
- Local verification profile: `bash "/home/codex-auto/automation/scripts/codex-verify.sh" --profiles "maui"`.

2) Files / areas likely to touch
- Add a small repo script under an existing or appropriate scripts location for Ubuntu MAUI Android build/run checks.
- Update `README.md` or a focused docs file with Ubuntu MAUI Android setup and commands.
- Avoid Backend, persistence, domain, Web, Python, and unrelated presentation code.

3) Assumptions
- Ubuntu support means Android target build/run only; Windows, iOS, and MacCatalyst remain native-host paths.
- A local emulator or attached Android device is optional for build validation but required for `dotnet build -t:Run`.
- The script should fail early with actionable messages when .NET, MAUI workload, Android SDK, or device/emulator requirements are missing.

4) Plan
- Inventory the MAUI host and shared presentation target frameworks and document the practical Ubuntu target as `net10.0-android`.
- Add a focused Ubuntu MAUI helper command that checks required local tooling and builds or runs the Android target.
- Document setup, build, run, and missing-tool fallback guidance in the repo developer docs.
- Verify with the configured MAUI local check and, where possible, run the helper in a non-device build/smoke mode.

5) Risks / gotchas
- `dotnet workload list` output varies by SDK version, so workload detection should be simple and resilient.
- Android SDK environment variables differ by machine; support both `ANDROID_HOME` and `ANDROID_SDK_ROOT`.
- `dotnet build -t:Run` will not work without a booted emulator or attached device, so docs must distinguish build smoke test from device run.
- The repo targets .NET 10 MAUI package versions, so commands should use the project’s existing target framework rather than inventing older target names.

6) Recommended implementation approach
- Prefer a small Bash helper script with `build` and `run` modes, clear stderr guidance, and no dependency on CI-only tooling.
- Keep docs concise: list prerequisites, exact repo commands, and host-specific target limitations.
- Do not change project target frameworks unless the current MAUI project blocks the Ubuntu Android path.

Local verification:
```text
bash "/home/codex-auto/automation/scripts/codex-verify.sh" --profiles "maui"
```
