### PR TITLE
#306: Replace implicit reseeding with intentional onboarding

### DIFF
--- a/ShuffleTask.Application/Abstractions/IOnboardingService.cs
+++ b/ShuffleTask.Application/Abstractions/IOnboardingService.cs
@@ -1,0 +1,10 @@
+using ShuffleTask.Domain.Entities;
+
+namespace ShuffleTask.Application.Abstractions;
+
+public interface IOnboardingService
+{
+    Task<int> GetCompletedVersionAsync();
+    Task CompleteAsync(int version);
+    Task CompleteWithSamplesAsync(IReadOnlyCollection<TaskItem> samples, int version);
+}

--- a/ShuffleTask.Persistence/StorageService.Database.cs
+++ b/ShuffleTask.Persistence/StorageService.Database.cs
@@ -33,6 +33,7 @@ public partial class StorageService
         await _db.CreateTableAsync<PeriodDefinitionRecord>().ConfigureAwait(false);
 
         await RunSchemaMigrationsAsync().ConfigureAwait(false);
+        await EnsureOnboardingStateAsync().ConfigureAwait(false);
         await RecoverSettingsAtStartupAsync().ConfigureAwait(false);
         await EnsurePresetPeriodDefinitionsAsync().ConfigureAwait(false);
     }

--- a/ShuffleTask.Persistence/StorageService.Onboarding.cs
+++ b/ShuffleTask.Persistence/StorageService.Onboarding.cs
@@ -1,0 +1,144 @@
+using System.Globalization;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Persistence.Models;
+
+namespace ShuffleTask.Persistence;
+
+public partial class StorageService
+{
+    private async Task EnsureOnboardingStateAsync()
+    {
+        KeyValueEntity? existing = await Db.FindAsync<KeyValueEntity>(OnboardingVersionKey).ConfigureAwait(false);
+        if (existing != null)
+        {
+            return;
+        }
+
+        bool hasPriorUse = false;
+        if (_databaseExistedBeforeOpen)
+        {
+            int taskCount = await Db.Table<TaskItemRecord>().CountAsync().ConfigureAwait(false);
+            KeyValueEntity? settings = await Db.FindAsync<KeyValueEntity>(SettingsKey).ConfigureAwait(false);
+            hasPriorUse = taskCount > 0 || settings != null;
+        }
+
+        await Db.RunInTransactionAsync(conn =>
+        {
+            if (conn.Find<KeyValueEntity>(OnboardingVersionKey) == null)
+            {
+                conn.Insert(new KeyValueEntity
+                {
+                    Key = OnboardingVersionKey,
+                    Value = hasPriorUse ? "1" : "0"
+                });
+            }
+        }).ConfigureAwait(false);
+    }
+
+    public async Task<int> GetCompletedVersionAsync()
+    {
+        KeyValueEntity? entry = await Db.FindAsync<KeyValueEntity>(OnboardingVersionKey).ConfigureAwait(false);
+        return entry != null
+            && int.TryParse(entry.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int version)
+            ? Math.Max(0, version)
+            : 0;
+    }
+
+    public async Task CompleteAsync(int version)
+    {
+        if (version <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version));
+        }
+
+        await _onboardingLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await Db.RunInTransactionAsync(conn =>
+            {
+                SetCompletedVersion(conn, version);
+                _faultInjector?.BeforeCommit("onboarding.complete");
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            _onboardingLock.Release();
+        }
+    }
+
+    public async Task CompleteWithSamplesAsync(IReadOnlyCollection<TaskItem> samples, int version)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (version <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version));
+        }
+
+        await _onboardingLock.WaitAsync().ConfigureAwait(false);
+        await _taskLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_taskSchemaIsFuture)
+            {
+                throw new InvalidOperationException("Sample tasks cannot be added because the stored task schema is newer than this app.");
+            }
+
+            if (await GetCompletedVersionAsync().ConfigureAwait(false) >= version)
+            {
+                return;
+            }
+
+            var records = new List<TaskItemRecord>(samples.Count);
+            foreach (TaskItem sample in samples)
+            {
+                if (string.IsNullOrWhiteSpace(sample.Id))
+                {
+                    throw new InvalidOperationException("Onboarding sample tasks require stable identifiers.");
+                }
+
+                EnsureMetadata(sample, null, bumpVersion: true);
+                records.Add(BuildTaskRecord(sample));
+            }
+
+            await Db.RunInTransactionAsync(conn =>
+            {
+                foreach (TaskItemRecord record in records)
+                {
+                    if (conn.Find<TaskItemRecord>(record.Id) == null)
+                    {
+                        conn.Insert(record);
+                    }
+                }
+
+                SetCompletedVersion(conn, version);
+                _faultInjector?.BeforeCommit("onboarding.samples");
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            _taskLock.Release();
+            _onboardingLock.Release();
+        }
+    }
+
+    private static void SetCompletedVersion(SQLite.SQLiteConnection connection, int version)
+    {
+        KeyValueEntity? entry = connection.Find<KeyValueEntity>(OnboardingVersionKey);
+        if (entry == null)
+        {
+            connection.Insert(new KeyValueEntity
+            {
+                Key = OnboardingVersionKey,
+                Value = version.ToString(CultureInfo.InvariantCulture)
+            });
+            return;
+        }
+
+        if (!int.TryParse(entry.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int existingVersion)
+            || existingVersion < version)
+        {
+            entry.Value = version.ToString(CultureInfo.InvariantCulture);
+            connection.Update(entry);
+        }
+    }
+}

--- a/ShuffleTask.Persistence/StorageService.cs
+++ b/ShuffleTask.Persistence/StorageService.cs
@@ -6,9 +6,10 @@ using ShuffleTask.Domain.Entities;
 
 namespace ShuffleTask.Persistence;
 
-public partial class StorageService : IStorageService
+public partial class StorageService : IStorageService, IOnboardingService
 {
     private const string SettingsKey = "app_settings";
+    private const string OnboardingVersionKey = "onboarding_completed_version";
     private const string TaskSchemaVersionKey = "schema_tasks";
     private const string PeriodSchemaVersionKey = "schema_periods";
     private const int CurrentSettingsSchemaVersion = 2;
@@ -34,6 +35,7 @@ public partial class StorageService : IStorageService
     private SQLiteAsyncConnection? _db;
     private readonly SemaphoreSlim _settingsLock = new(1, 1);
     private readonly SemaphoreSlim _taskLock = new(1, 1);
+    private readonly SemaphoreSlim _onboardingLock = new(1, 1);
     private bool _taskSchemaIsFuture;
     private bool _periodSchemaIsFuture;
     private bool _databaseExistedBeforeOpen;

--- a/ShuffleTask.Presentation.Shared/ViewModels/OnboardingViewModel.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/OnboardingViewModel.cs
@@ -1,0 +1,229 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Models;
+
+namespace ShuffleTask.ViewModels;
+
+public enum OnboardingOutcome
+{
+    CreatedTask,
+    AddedSamples,
+    ContinuedEmpty
+}
+
+public sealed class OnboardingCompletedEventArgs(OnboardingOutcome outcome) : EventArgs
+{
+    public OnboardingOutcome Outcome { get; } = outcome;
+}
+
+public partial class OnboardingViewModel : ObservableObject
+{
+    public const int CurrentVersion = 1;
+
+    private readonly IOnboardingService _onboarding;
+    private readonly TimeProvider _clock;
+    private int _operationRunning;
+
+    public OnboardingViewModel(IOnboardingService onboarding, TimeProvider clock)
+    {
+        _onboarding = onboarding ?? throw new ArgumentNullException(nameof(onboarding));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public event EventHandler? CreateTaskRequested;
+    public event EventHandler<OnboardingCompletedEventArgs>? Completed;
+
+    public OperationState OperationState { get; } = new();
+
+    [ObservableProperty]
+    private bool isVisible = true;
+
+    public bool CanChoose => IsVisible
+        && Volatile.Read(ref _operationRunning) == 0
+        && !OperationState.IsLoading;
+
+    public void SetStartupLoading()
+    {
+        IsVisible = true;
+        OperationState.SetLoading("Preparing your workspace…");
+        RefreshCommands();
+    }
+
+    public async Task<bool> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        OperationState.SetLoading("Checking first-run setup…");
+        RefreshCommands();
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int completedVersion = await _onboarding.GetCompletedVersionAsync();
+            if (completedVersion >= CurrentVersion)
+            {
+                IsVisible = false;
+                OperationState.SetIdle();
+                return false;
+            }
+
+            IsVisible = true;
+            OperationState.SetSuccess("Choose how you want to start ShuffleTask.");
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            IsVisible = true;
+            OperationState.SetTransientFailure(
+                "Setup was canceled. Retry to continue.",
+                false,
+                LoadAsync,
+                isBlocking: true);
+            return true;
+        }
+        catch
+        {
+            IsVisible = true;
+            OperationState.SetTransientFailure(
+                "ShuffleTask could not read first-run setup. Your existing data is unchanged.",
+                false,
+                LoadAsync,
+                isBlocking: true);
+            return true;
+        }
+        finally
+        {
+            RefreshCommands();
+        }
+    }
+
+    public void SetStartupFailure(Func<CancellationToken, Task> retry)
+    {
+        ArgumentNullException.ThrowIfNull(retry);
+        IsVisible = true;
+        OperationState.SetTransientFailure(
+            "ShuffleTask could not initialize local storage safely. Check storage access and retry.",
+            false,
+            retry,
+            isBlocking: true);
+        RefreshCommands();
+    }
+
+    public void ReturnToChoices()
+    {
+        IsVisible = true;
+        OperationState.SetSuccess("No task was created. Choose how you want to continue.");
+        RefreshCommands();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanChoose))]
+    private void CreateTask()
+    {
+        if (!CanChoose)
+        {
+            return;
+        }
+
+        OperationState.SetLoading("Opening the new task editor…");
+        RefreshCommands();
+        CreateTaskRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    public Task CompleteCreatedTaskAsync(CancellationToken cancellationToken = default)
+        => RunCompletionAsync(
+            OnboardingOutcome.CreatedTask,
+            "Saving first-run choice…",
+            "Your first task is ready.",
+            () => _onboarding.CompleteAsync(CurrentVersion),
+            cancellationToken);
+
+    [RelayCommand(CanExecute = nameof(CanChoose))]
+    private Task AddSampleTasksAsync(CancellationToken cancellationToken)
+        => RunCompletionAsync(
+            OnboardingOutcome.AddedSamples,
+            "Adding sample tasks…",
+            "Sample tasks added. You can edit or delete them at any time.",
+            () => _onboarding.CompleteWithSamplesAsync(CreateSamples(), CurrentVersion),
+            cancellationToken);
+
+    [RelayCommand(CanExecute = nameof(CanChoose))]
+    private Task ContinueWithoutSamplesAsync(CancellationToken cancellationToken)
+        => RunCompletionAsync(
+            OnboardingOutcome.ContinuedEmpty,
+            "Saving your choice…",
+            "Starting with an empty task list.",
+            () => _onboarding.CompleteAsync(CurrentVersion),
+            cancellationToken);
+
+    private async Task RunCompletionAsync(
+        OnboardingOutcome outcome,
+        string loadingMessage,
+        string successMessage,
+        Func<Task> persist,
+        CancellationToken cancellationToken)
+    {
+        if (Interlocked.CompareExchange(ref _operationRunning, 1, 0) != 0)
+        {
+            return;
+        }
+
+        OperationState.SetLoading(loadingMessage);
+        RefreshCommands();
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await persist();
+            IsVisible = false;
+            OperationState.SetSuccess(successMessage, localDataSaved: true);
+            Completed?.Invoke(this, new OnboardingCompletedEventArgs(outcome));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            IsVisible = true;
+            OperationState.SetTransientFailure(
+                "Setup was canceled before your choice was saved. Retry to continue.",
+                false,
+                token => RunCompletionAsync(outcome, loadingMessage, successMessage, persist, token),
+                isBlocking: true);
+        }
+        catch
+        {
+            IsVisible = true;
+            OperationState.SetTransientFailure(
+                "Your choice could not be saved. No sample tasks or setup marker were committed. Retry to continue.",
+                false,
+                token => RunCompletionAsync(outcome, loadingMessage, successMessage, persist, token),
+                isBlocking: true);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _operationRunning, 0);
+            RefreshCommands();
+        }
+    }
+
+    private IReadOnlyCollection<TaskItem> CreateSamples()
+    {
+        DateTime nowUtc = _clock.GetUtcNow().UtcDateTime;
+        return new[]
+        {
+            new TaskItem { Id = "onboarding-v1-dishes", Title = "Dishes", Importance = 3, Repeat = RepeatType.Daily, AllowedPeriod = AllowedPeriod.OffWork },
+            new TaskItem { Id = "onboarding-v1-inbox-zero", Title = "Inbox Zero", Importance = 4, Repeat = RepeatType.Interval, IntervalDays = 2, AllowedPeriod = AllowedPeriod.Work },
+            new TaskItem { Id = "onboarding-v1-laundry", Title = "Laundry", Importance = 2, Repeat = RepeatType.Weekly, Weekdays = Weekdays.Sat, AllowedPeriod = AllowedPeriod.OffWork },
+            new TaskItem { Id = "onboarding-v1-tax-paperwork", Title = "Tax paperwork", Importance = 5, Repeat = RepeatType.None, Deadline = nowUtc.AddDays(3), AllowedPeriod = AllowedPeriod.Any }
+        };
+    }
+
+    partial void OnIsVisibleChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanChoose));
+        RefreshCommands();
+    }
+
+    private void RefreshCommands()
+    {
+        OnPropertyChanged(nameof(CanChoose));
+        CreateTaskCommand.NotifyCanExecuteChanged();
+        AddSampleTasksCommand.NotifyCanExecuteChanged();
+        ContinueWithoutSamplesCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/ShuffleTask.Presentation.Shared/ViewModels/OnboardingViewModel.cs
+++ b/ShuffleTask.Presentation.Shared/ViewModels/OnboardingViewModel.cs
@@ -25,6 +25,7 @@ public partial class OnboardingViewModel : ObservableObject
     private readonly IOnboardingService _onboarding;
     private readonly TimeProvider _clock;
     private int _operationRunning;
+    private bool _choicesReady;
 
     public OnboardingViewModel(IOnboardingService onboarding, TimeProvider clock)
     {
@@ -40,12 +41,14 @@ public partial class OnboardingViewModel : ObservableObject
     [ObservableProperty]
     private bool isVisible = true;
 
-    public bool CanChoose => IsVisible
+    public bool CanChoose => _choicesReady
+        && IsVisible
         && Volatile.Read(ref _operationRunning) == 0
         && !OperationState.IsLoading;
 
     public void SetStartupLoading()
     {
+        _choicesReady = false;
         IsVisible = true;
         OperationState.SetLoading("Preparing your workspace…");
         RefreshCommands();
@@ -61,17 +64,20 @@ public partial class OnboardingViewModel : ObservableObject
             int completedVersion = await _onboarding.GetCompletedVersionAsync();
             if (completedVersion >= CurrentVersion)
             {
+                _choicesReady = false;
                 IsVisible = false;
                 OperationState.SetIdle();
                 return false;
             }
 
+            _choicesReady = true;
             IsVisible = true;
             OperationState.SetSuccess("Choose how you want to start ShuffleTask.");
             return true;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            _choicesReady = false;
             IsVisible = true;
             OperationState.SetTransientFailure(
                 "Setup was canceled. Retry to continue.",
@@ -82,6 +88,7 @@ public partial class OnboardingViewModel : ObservableObject
         }
         catch
         {
+            _choicesReady = false;
             IsVisible = true;
             OperationState.SetTransientFailure(
                 "ShuffleTask could not read first-run setup. Your existing data is unchanged.",
@@ -99,6 +106,7 @@ public partial class OnboardingViewModel : ObservableObject
     public void SetStartupFailure(Func<CancellationToken, Task> retry)
     {
         ArgumentNullException.ThrowIfNull(retry);
+        _choicesReady = false;
         IsVisible = true;
         OperationState.SetTransientFailure(
             "ShuffleTask could not initialize local storage safely. Check storage access and retry.",
@@ -110,6 +118,7 @@ public partial class OnboardingViewModel : ObservableObject
 
     public void ReturnToChoices()
     {
+        _choicesReady = true;
         IsVisible = true;
         OperationState.SetSuccess("No task was created. Choose how you want to continue.");
         RefreshCommands();
@@ -123,6 +132,7 @@ public partial class OnboardingViewModel : ObservableObject
             return;
         }
 
+        _choicesReady = false;
         OperationState.SetLoading("Opening the new task editor…");
         RefreshCommands();
         CreateTaskRequested?.Invoke(this, EventArgs.Empty);
@@ -166,6 +176,7 @@ public partial class OnboardingViewModel : ObservableObject
             return;
         }
 
+        _choicesReady = false;
         OperationState.SetLoading(loadingMessage);
         RefreshCommands();
         try

--- a/ShuffleTask.Presentation.Tests/OnboardingViewModelTests.cs
+++ b/ShuffleTask.Presentation.Tests/OnboardingViewModelTests.cs
@@ -91,6 +91,7 @@ public class OnboardingViewModelTests
             Assert.That(viewModel.OperationState.Kind, Is.EqualTo(OperationStateKind.TransientFailure));
             Assert.That(viewModel.OperationState.CanRetry, Is.True);
             Assert.That(viewModel.IsVisible, Is.True);
+            Assert.That(viewModel.CanChoose, Is.False);
             Assert.That(completionCount, Is.Zero);
         });
 
@@ -127,6 +128,22 @@ public class OnboardingViewModelTests
         await viewModel.CompleteCreatedTaskAsync();
 
         await onboarding.Received(1).CompleteAsync(OnboardingViewModel.CurrentVersion);
+    }
+
+    [Test]
+    public void StartupFailure_DisablesChoicesAndLeavesSingleRetry()
+    {
+        var onboarding = Substitute.For<IOnboardingService>();
+        var viewModel = new OnboardingViewModel(onboarding, TimeProvider.System);
+
+        viewModel.SetStartupFailure(_ => Task.CompletedTask);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.CanChoose, Is.False);
+            Assert.That(viewModel.OperationState.CanRetry, Is.True);
+            Assert.That(viewModel.OperationState.Kind, Is.EqualTo(OperationStateKind.TransientFailure));
+        });
     }
 
     private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider

--- a/ShuffleTask.Presentation.Tests/OnboardingViewModelTests.cs
+++ b/ShuffleTask.Presentation.Tests/OnboardingViewModelTests.cs
@@ -114,11 +114,13 @@ public class OnboardingViewModelTests
     public async Task CreateTask_CompletesOnlyAfterSavedTaskCallback()
     {
         var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.GetCompletedVersionAsync().Returns(0);
         onboarding.CompleteAsync(Arg.Any<int>()).Returns(Task.CompletedTask);
         var viewModel = new OnboardingViewModel(onboarding, TimeProvider.System);
         int requests = 0;
         viewModel.CreateTaskRequested += (_, _) => requests++;
 
+        await viewModel.LoadAsync();
         viewModel.CreateTaskCommand.Execute(null);
 
         Assert.That(requests, Is.EqualTo(1));

--- a/ShuffleTask.Presentation.Tests/OnboardingViewModelTests.cs
+++ b/ShuffleTask.Presentation.Tests/OnboardingViewModelTests.cs
@@ -1,0 +1,136 @@
+using NSubstitute;
+using NUnit.Framework;
+using ShuffleTask.Application.Abstractions;
+using ShuffleTask.Domain.Entities;
+using ShuffleTask.Presentation.Models;
+using ShuffleTask.ViewModels;
+
+namespace ShuffleTask.Presentation.Tests;
+
+[TestFixture]
+public class OnboardingViewModelTests
+{
+    [Test]
+    public async Task LoadAsync_IncompleteSetup_ShowsChoices()
+    {
+        var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.GetCompletedVersionAsync().Returns(0);
+        var viewModel = new OnboardingViewModel(onboarding, TimeProvider.System);
+
+        bool visible = await viewModel.LoadAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(visible, Is.True);
+            Assert.That(viewModel.IsVisible, Is.True);
+            Assert.That(viewModel.CanChoose, Is.True);
+            Assert.That(viewModel.OperationState.Kind, Is.EqualTo(OperationStateKind.Success));
+        });
+    }
+
+    [Test]
+    public async Task LoadAsync_CompletedSetup_DoesNotShowOnboarding()
+    {
+        var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.GetCompletedVersionAsync().Returns(OnboardingViewModel.CurrentVersion);
+        var viewModel = new OnboardingViewModel(onboarding, TimeProvider.System);
+
+        bool visible = await viewModel.LoadAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(visible, Is.False);
+            Assert.That(viewModel.IsVisible, Is.False);
+            Assert.That(viewModel.OperationState.Kind, Is.EqualTo(OperationStateKind.Idle));
+        });
+    }
+
+    [Test]
+    public async Task ContinueWithoutSamples_PersistsBeforeCompletion()
+    {
+        var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.CompleteAsync(Arg.Any<int>()).Returns(Task.CompletedTask);
+        var viewModel = new OnboardingViewModel(onboarding, TimeProvider.System);
+        OnboardingOutcome? outcome = null;
+        viewModel.Completed += (_, args) => outcome = args.Outcome;
+
+        await viewModel.ContinueWithoutSamplesCommand.ExecuteAsync(null);
+
+        await onboarding.Received(1).CompleteAsync(OnboardingViewModel.CurrentVersion);
+        Assert.Multiple(() =>
+        {
+            Assert.That(outcome, Is.EqualTo(OnboardingOutcome.ContinuedEmpty));
+            Assert.That(viewModel.IsVisible, Is.False);
+            Assert.That(viewModel.OperationState.LocalDataSaved, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task AddSamples_FailureRetainsIntentAndRetryCompletesOnce()
+    {
+        var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.CompleteWithSamplesAsync(Arg.Any<IReadOnlyCollection<TaskItem>>(), Arg.Any<int>())
+            .Returns(
+                Task.FromException(new IOException("Injected failure.")),
+                Task.CompletedTask);
+        var clock = new FixedTimeProvider(new DateTimeOffset(2026, 8, 4, 8, 0, 0, TimeSpan.Zero));
+        var viewModel = new OnboardingViewModel(onboarding, clock);
+        int completionCount = 0;
+        viewModel.Completed += (_, args) =>
+        {
+            if (args.Outcome == OnboardingOutcome.AddedSamples)
+            {
+                completionCount++;
+            }
+        };
+
+        await viewModel.AddSampleTasksCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.OperationState.Kind, Is.EqualTo(OperationStateKind.TransientFailure));
+            Assert.That(viewModel.OperationState.CanRetry, Is.True);
+            Assert.That(viewModel.IsVisible, Is.True);
+            Assert.That(completionCount, Is.Zero);
+        });
+
+        await viewModel.OperationState.RetryCommand.ExecuteAsync(null);
+
+        await onboarding.Received(2).CompleteWithSamplesAsync(
+            Arg.Is<IReadOnlyCollection<TaskItem>>(samples =>
+                samples.Count == 4
+                && samples.Select(sample => sample.Id).Distinct(StringComparer.Ordinal).Count() == 4),
+            OnboardingViewModel.CurrentVersion);
+        Assert.Multiple(() =>
+        {
+            Assert.That(completionCount, Is.EqualTo(1));
+            Assert.That(viewModel.IsVisible, Is.False);
+            Assert.That(viewModel.OperationState.Kind, Is.EqualTo(OperationStateKind.Success));
+        });
+    }
+
+    [Test]
+    public async Task CreateTask_CompletesOnlyAfterSavedTaskCallback()
+    {
+        var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.CompleteAsync(Arg.Any<int>()).Returns(Task.CompletedTask);
+        var viewModel = new OnboardingViewModel(onboarding, TimeProvider.System);
+        int requests = 0;
+        viewModel.CreateTaskRequested += (_, _) => requests++;
+
+        viewModel.CreateTaskCommand.Execute(null);
+
+        Assert.That(requests, Is.EqualTo(1));
+        await onboarding.DidNotReceive().CompleteAsync(Arg.Any<int>());
+
+        viewModel.ReturnToChoices();
+        await viewModel.CompleteCreatedTaskAsync();
+
+        await onboarding.Received(1).CompleteAsync(OnboardingViewModel.CurrentVersion);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/ShuffleTask.Presentation/App.xaml.cs
+++ b/ShuffleTask.Presentation/App.xaml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
-using ShuffleTask.Domain.Entities;
 using ShuffleTask.Presentation;
 using ShuffleTask.Presentation.Models;
 using ShuffleTask.Presentation.Services;
@@ -18,6 +17,7 @@ public partial class App : Microsoft.Maui.Controls.Application
     private readonly TimeProvider _clock;
     private readonly AppSettings _settings;
     private readonly IShuffleLogger? _logger;
+    private readonly MainPage _mainPage;
     private bool _startupRunning;
     private bool _resumeRunning;
 
@@ -32,6 +32,7 @@ public partial class App : Microsoft.Maui.Controls.Application
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         _logger = logger;
+        _mainPage = mainPage;
         StartupOperationState.PropertyChanged += OnStartupOperationStateChanged;
         RequestedThemeChanged += (_, __) => { };
     }
@@ -64,8 +65,9 @@ public partial class App : Microsoft.Maui.Controls.Application
         StartupOperationState.SetLoading("Starting ShuffleTask…");
         try
         {
+            await _mainPage.ShowOnboardingLoadingAsync();
             cancellationToken.ThrowIfCancellationRequested();
-            await EnsureSeedDataAsync();
+            await _storage.InitializeAsync();
             await PersistedTimerState.RecoverAgainstStorageAsync(_storage, _logger);
             if (_settings.BackgroundActivityEnabled)
             {
@@ -73,6 +75,7 @@ public partial class App : Microsoft.Maui.Controls.Application
             }
 
             StartupOperationState.SetSuccess("ShuffleTask is ready.");
+            await _mainPage.ResolveOnboardingAsync(cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -81,6 +84,7 @@ public partial class App : Microsoft.Maui.Controls.Application
                 null,
                 StartAsync,
                 isBlocking: true);
+            await _mainPage.ShowOnboardingFailureAsync(StartAsync);
         }
         catch (Exception ex)
         {
@@ -89,6 +93,7 @@ public partial class App : Microsoft.Maui.Controls.Application
                 "ShuffleTask could not start safely. Check local storage access and retry.",
                 null,
                 StartAsync);
+            await _mainPage.ShowOnboardingFailureAsync(StartAsync);
         }
         finally
         {
@@ -145,48 +150,4 @@ public partial class App : Microsoft.Maui.Controls.Application
         _coordinator.SuspendInProcessTimer();
     }
 
-    private async Task EnsureSeedDataAsync()
-    {
-        await _storage.InitializeAsync();
-        var existing = await _storage.GetTasksAsync();
-        if (existing.Count > 0)
-        {
-            return;
-        }
-
-        DateTime nowUtc = _clock.GetUtcNow().UtcDateTime;
-
-        var samples = new List<TaskItem>
-        {
-            new TaskItem { Title = "Dishes", Importance = 3, Repeat = RepeatType.Daily, AllowedPeriod = AllowedPeriod.OffWork },
-            new TaskItem { Title = "Inbox Zero", Importance = 4, Repeat = RepeatType.Interval, IntervalDays = 2, AllowedPeriod = AllowedPeriod.Work },
-            new TaskItem { Title = "Laundry", Importance = 2, Repeat = RepeatType.Weekly, Weekdays = Weekdays.Sat, AllowedPeriod = AllowedPeriod.OffWork },
-            new TaskItem { Title = "Tax paperwork", Importance = 5, Repeat = RepeatType.None, Deadline = nowUtc.AddDays(3), AllowedPeriod = AllowedPeriod.Any }
-        };
-
-        foreach (var task in samples)
-        {
-            await _storage.AddTaskAsync(task);
-        }
-
-        _settings.WorkStart = new TimeSpan(9, 0, 0);
-        _settings.WorkEnd = new TimeSpan(17, 0, 0);
-        _settings.EnableNotifications = true;
-        _settings.SoundOn = true;
-        _settings.Active = true;
-        _settings.BackgroundActivityEnabled = true;
-        _settings.AutoShuffleEnabled = true;
-        _settings.ReminderMinutes = 60;
-        _settings.MaxDailyShuffles = 6;
-        _settings.QuietHoursStart = new TimeSpan(22, 0, 0);
-        _settings.QuietHoursEnd = new TimeSpan(7, 0, 0);
-        _settings.StreakBias = 0.3;
-        _settings.StableRandomnessPerDay = true;
-        _settings.Touch(_clock);
-        await _storage.SetSettingsAsync(_settings);
-
-        PersistedTimerState.Clear(_logger);
-        PersistedSchedulerState.ClearPendingShuffle(_logger);
-        PersistedSchedulerState.SaveDailyCount(new DateTimeOffset(nowUtc.Date, TimeSpan.Zero), 0, _logger);
-    }
 }

--- a/ShuffleTask.Presentation/App.xaml.cs
+++ b/ShuffleTask.Presentation/App.xaml.cs
@@ -20,6 +20,7 @@ public partial class App : Microsoft.Maui.Controls.Application
     private readonly MainPage _mainPage;
     private bool _startupRunning;
     private bool _resumeRunning;
+    private bool _backgroundStartupAllowed;
 
     public OperationState StartupOperationState { get; } = new();
 
@@ -62,6 +63,7 @@ public partial class App : Microsoft.Maui.Controls.Application
         }
 
         _startupRunning = true;
+        _backgroundStartupAllowed = false;
         StartupOperationState.SetLoading("Starting ShuffleTask…");
         try
         {
@@ -69,13 +71,14 @@ public partial class App : Microsoft.Maui.Controls.Application
             cancellationToken.ThrowIfCancellationRequested();
             await _storage.InitializeAsync();
             await PersistedTimerState.RecoverAgainstStorageAsync(_storage, _logger);
-            if (_settings.BackgroundActivityEnabled)
+            bool onboardingRequired = await _mainPage.ResolveOnboardingAsync(cancellationToken);
+            _backgroundStartupAllowed = !onboardingRequired;
+            if (_backgroundStartupAllowed && _settings.BackgroundActivityEnabled)
             {
                 await _coordinator.StartAsync();
             }
 
             StartupOperationState.SetSuccess("ShuffleTask is ready.");
-            await _mainPage.ResolveOnboardingAsync(cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -109,7 +112,7 @@ public partial class App : Microsoft.Maui.Controls.Application
 
     internal async Task ResumeAsync(CancellationToken cancellationToken = default)
     {
-        if (_resumeRunning || !_settings.BackgroundActivityEnabled)
+        if (_resumeRunning || !_backgroundStartupAllowed || !_settings.BackgroundActivityEnabled)
         {
             return;
         }

--- a/ShuffleTask.Presentation/MauiProgram.cs
+++ b/ShuffleTask.Presentation/MauiProgram.cs
@@ -66,6 +66,7 @@ public static partial class MauiProgram
             return new StorageService(clock, dbPath, shuffleLogger);
         });
         builder.Services.AddSingleton<IStorageService>(sp => sp.GetRequiredService<StorageService>());
+        builder.Services.AddSingleton<IOnboardingService>(sp => sp.GetRequiredService<StorageService>());
         builder.Services.AddSingleton<INotificationService, NotificationService>();
         builder.Services.AddSingleton<IPersistentBackgroundService, PersistentBackgroundService>();
         SetupEventAggregation(builder);
@@ -102,6 +103,7 @@ public static partial class MauiProgram
         builder.Services.AddSingleton<EditTaskViewModel>();
         builder.Services.AddSingleton<PeriodDefinitionEditorViewModel>();
         builder.Services.AddSingleton<SettingsViewModel>();
+        builder.Services.AddSingleton<OnboardingViewModel>();
 
         // Views
         builder.Services.AddSingleton<DashboardPage>();
@@ -111,6 +113,7 @@ public static partial class MauiProgram
         builder.Services.AddSingleton<TasksPage>();
         builder.Services.AddSingleton<EditTaskPage>();
         builder.Services.AddSingleton<PeriodDefinitionEditorPage>();
+        builder.Services.AddSingleton<OnboardingPage>();
 
 #if DEBUG
         var loggingBuilder = builder.Logging;

--- a/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
+++ b/ShuffleTask.Presentation/ShuffleTask.Presentation.csproj
@@ -74,6 +74,9 @@
       <MauiXaml Update="Views\DashboardPage.xaml">
         <Generator>MSBuild:Compile</Generator>
       </MauiXaml>
+      <MauiXaml Update="Views\OnboardingPage.xaml">
+        <Generator>MSBuild:Compile</Generator>
+      </MauiXaml>
       <MauiXaml Update="Controls\NumericStepper.xaml">
         <Generator>MSBuild:Compile</Generator>
       </MauiXaml>

--- a/ShuffleTask.Presentation/Views/EditTaskPage.xaml
+++ b/ShuffleTask.Presentation/Views/EditTaskPage.xaml
@@ -30,9 +30,11 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Entry Grid.Row="0"
+            <Entry x:Name="TitleEntry"
+                   Grid.Row="0"
                    Text="{Binding Title}"
-                   Placeholder="Title" />
+                   Placeholder="Title"
+                   SemanticProperties.Description="Task title" />
 
             <Editor Grid.Row="1"
                     HeightRequest="120"

--- a/ShuffleTask.Presentation/Views/EditTaskPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/EditTaskPage.xaml.cs
@@ -30,6 +30,10 @@ public partial class EditTaskPage : ContentPage
         }
 
         UpdateTitle();
+        if (_viewModel?.IsNew == true)
+        {
+            Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(250), () => TitleEntry.Focus());
+        }
     }
 
     protected override void OnBindingContextChanged()

--- a/ShuffleTask.Presentation/Views/EditTaskPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/EditTaskPage.xaml.cs
@@ -13,6 +13,8 @@ public partial class EditTaskPage : ContentPage
     private EditTaskViewModel? _viewModel;
     private bool _eventsSubscribed;
 
+    internal bool WasSavedBeforeClosing { get; private set; }
+
     public EditTaskPage(EditTaskViewModel vm)
     {
         InitializeComponent();
@@ -22,6 +24,7 @@ public partial class EditTaskPage : ContentPage
     protected override void OnAppearing()
     {
         base.OnAppearing();
+        WasSavedBeforeClosing = false;
 
         if (BindingContext is EditTaskViewModel vm)
         {
@@ -47,12 +50,14 @@ public partial class EditTaskPage : ContentPage
 
     private async void OnSaved(object? sender, EventArgs e)
     {
+        WasSavedBeforeClosing = true;
         UnsubscribeFromViewModel();
         await Navigation.PopAsync();
     }
 
     private async void OnCancelClicked(object sender, EventArgs e)
     {
+        WasSavedBeforeClosing = false;
         UnsubscribeFromViewModel();
         await Navigation.PopAsync();
     }

--- a/ShuffleTask.Presentation/Views/MainPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using ShuffleTask.Application.Abstractions;
 using ShuffleTask.Application.Models;
 using ShuffleTask.Presentation;
 using ShuffleTask.Presentation.Services;
+using ShuffleTask.ViewModels;
 using MauiApplication = Microsoft.Maui.Controls.Application;
 
 namespace ShuffleTask.Views;
@@ -10,6 +11,14 @@ namespace ShuffleTask.Views;
 public partial class MainPage : TabbedPage
 {
     private bool _tabsInitialized;
+    private DashboardViewModel? _dashboardViewModel;
+    private TasksViewModel? _tasksViewModel;
+    private TasksPage? _tasksPage;
+    private OnboardingPage? _onboardingPage;
+    private OnboardingViewModel? _onboardingViewModel;
+    private NavigationPage? _dashboardTab;
+    private NavigationPage? _tasksTab;
+    private NavigationPage? _onboardingModal;
 
     public MainPage()
     {
@@ -17,10 +26,26 @@ public partial class MainPage : TabbedPage
         TryInitializeFromServices();
     }
 
-    public MainPage(DashboardPage dashboardPage, TasksPage tasksPage, PeersPage peersPage, SettingsPage settingsPage)
+    public MainPage(
+        DashboardPage dashboardPage,
+        TasksPage tasksPage,
+        PeersPage peersPage,
+        SettingsPage settingsPage,
+        OnboardingPage onboardingPage,
+        DashboardViewModel dashboardViewModel,
+        TasksViewModel tasksViewModel,
+        OnboardingViewModel onboardingViewModel)
     {
         InitializeComponent();
-        ConfigureTabs(dashboardPage, tasksPage, peersPage, settingsPage);
+        ConfigureTabs(
+            dashboardPage,
+            tasksPage,
+            peersPage,
+            settingsPage,
+            onboardingPage,
+            dashboardViewModel,
+            tasksViewModel,
+            onboardingViewModel);
     }
 
     private void TryInitializeFromServices()
@@ -40,13 +65,32 @@ public partial class MainPage : TabbedPage
         var tasksPage = services.GetService<TasksPage>();
         var peersPage = services.GetService<PeersPage>();
         var settingsPage = services.GetService<SettingsPage>();
+        var onboardingPage = services.GetService<OnboardingPage>();
+        var dashboardViewModel = services.GetService<DashboardViewModel>();
+        var tasksViewModel = services.GetService<TasksViewModel>();
+        var onboardingViewModel = services.GetService<OnboardingViewModel>();
 
-        if (dashboardPage == null || tasksPage == null || peersPage == null || settingsPage == null)
+        if (dashboardPage == null
+            || tasksPage == null
+            || peersPage == null
+            || settingsPage == null
+            || onboardingPage == null
+            || dashboardViewModel == null
+            || tasksViewModel == null
+            || onboardingViewModel == null)
         {
             return;
         }
 
-        ConfigureTabs(dashboardPage, tasksPage, peersPage, settingsPage);
+        ConfigureTabs(
+            dashboardPage,
+            tasksPage,
+            peersPage,
+            settingsPage,
+            onboardingPage,
+            dashboardViewModel,
+            tasksViewModel,
+            onboardingViewModel);
     }
 
     protected override void OnHandlerChanged()
@@ -71,7 +115,15 @@ public partial class MainPage : TabbedPage
         return MauiProgram.TryGetServiceProvider();
     }
 
-    private void ConfigureTabs(DashboardPage dashboardPage, TasksPage tasksPage, PeersPage peersPage, SettingsPage settingsPage)
+    private void ConfigureTabs(
+        DashboardPage dashboardPage,
+        TasksPage tasksPage,
+        PeersPage peersPage,
+        SettingsPage settingsPage,
+        OnboardingPage onboardingPage,
+        DashboardViewModel dashboardViewModel,
+        TasksViewModel tasksViewModel,
+        OnboardingViewModel onboardingViewModel)
     {
         if (_tabsInitialized)
         {
@@ -84,19 +136,150 @@ public partial class MainPage : TabbedPage
 
         Children.Clear();
 
-        var dashboardTab = CreateTab(dashboardPage);
-        var tasksTab = CreateTab(tasksPage);
+        _dashboardTab = CreateTab(dashboardPage);
+        _tasksTab = CreateTab(tasksPage);
         var peersTab = CreateTab(peersPage);
         var settingsTab = CreateTab(settingsPage);
 
-        Children.Add(dashboardTab);
-        Children.Add(tasksTab);
+        Children.Add(_dashboardTab);
+        Children.Add(_tasksTab);
         Children.Add(peersTab);
         Children.Add(settingsTab);
 
-        CurrentPage = dashboardTab;
+        _dashboardViewModel = dashboardViewModel;
+        _tasksViewModel = tasksViewModel;
+        _tasksPage = tasksPage;
+        _onboardingPage = onboardingPage;
+        _onboardingViewModel = onboardingViewModel;
+        _onboardingModal = new NavigationPage(onboardingPage);
+        _onboardingViewModel.CreateTaskRequested += OnCreateTaskRequested;
+        _onboardingViewModel.Completed += OnOnboardingCompleted;
+        _tasksPage.OnboardingTaskEditorClosed += OnOnboardingTaskEditorClosed;
+
+        CurrentPage = _dashboardTab;
         Title = "ShuffleTask";
         _tabsInitialized = true;
+    }
+
+    public async Task ShowOnboardingLoadingAsync()
+    {
+        TryInitializeFromServices();
+        if (_onboardingViewModel == null)
+        {
+            return;
+        }
+
+        _onboardingViewModel.SetStartupLoading();
+        await ShowOnboardingModalAsync();
+    }
+
+    public async Task ResolveOnboardingAsync(CancellationToken cancellationToken = default)
+    {
+        if (_onboardingViewModel == null)
+        {
+            return;
+        }
+
+        bool shouldShow = await _onboardingViewModel.LoadAsync(cancellationToken);
+        if (shouldShow)
+        {
+            CurrentPage = _dashboardTab;
+            await ShowOnboardingModalAsync();
+        }
+        else
+        {
+            await HideOnboardingModalAsync();
+        }
+    }
+
+    public async Task ShowOnboardingFailureAsync(Func<CancellationToken, Task> retry)
+    {
+        if (_onboardingViewModel == null)
+        {
+            return;
+        }
+
+        _onboardingViewModel.SetStartupFailure(retry);
+        await ShowOnboardingModalAsync();
+    }
+
+    private async Task ShowOnboardingModalAsync()
+    {
+        if (_onboardingModal == null || Navigation.ModalStack.Contains(_onboardingModal))
+        {
+            return;
+        }
+
+        await Navigation.PushModalAsync(_onboardingModal, animated: false);
+    }
+
+    private async Task HideOnboardingModalAsync()
+    {
+        if (_onboardingModal != null && Navigation.ModalStack.LastOrDefault() == _onboardingModal)
+        {
+            await Navigation.PopModalAsync(animated: false);
+        }
+    }
+
+    private async void OnCreateTaskRequested(object? sender, EventArgs e)
+    {
+        if (_tasksPage == null || _tasksTab == null)
+        {
+            return;
+        }
+
+        await HideOnboardingModalAsync();
+        CurrentPage = _tasksTab;
+        await _tasksPage.OpenNewTaskForOnboardingAsync();
+    }
+
+    private async void OnOnboardingTaskEditorClosed(object? sender, OnboardingTaskEditorClosedEventArgs e)
+    {
+        if (_onboardingViewModel == null)
+        {
+            return;
+        }
+
+        if (e.Saved)
+        {
+            await _onboardingViewModel.CompleteCreatedTaskAsync();
+            if (_onboardingViewModel.IsVisible)
+            {
+                await ShowOnboardingModalAsync();
+            }
+            return;
+        }
+
+        _onboardingViewModel.ReturnToChoices();
+        CurrentPage = _dashboardTab;
+        await ShowOnboardingModalAsync();
+    }
+
+    private async void OnOnboardingCompleted(object? sender, OnboardingCompletedEventArgs e)
+    {
+        await HideOnboardingModalAsync();
+
+        if (e.Outcome == OnboardingOutcome.CreatedTask)
+        {
+            CurrentPage = _tasksTab;
+        }
+        else
+        {
+            CurrentPage = _dashboardTab;
+        }
+
+        if (_tasksViewModel != null)
+        {
+            await _tasksViewModel.LoadAsync();
+        }
+
+        _dashboardViewModel?.OperationState.SetSuccess(
+            e.Outcome == OnboardingOutcome.AddedSamples
+                ? "Sample tasks added. Dashboard ready."
+                : e.Outcome == OnboardingOutcome.ContinuedEmpty
+                    ? "Dashboard ready with an empty task list."
+                    : "Your first task is ready.",
+            localDataSaved: true);
     }
 
     private static NavigationPage CreateTab(ContentPage page)

--- a/ShuffleTask.Presentation/Views/MainPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/MainPage.xaml.cs
@@ -173,11 +173,11 @@ public partial class MainPage : TabbedPage
         await ShowOnboardingModalAsync();
     }
 
-    public async Task ResolveOnboardingAsync(CancellationToken cancellationToken = default)
+    public async Task<bool> ResolveOnboardingAsync(CancellationToken cancellationToken = default)
     {
         if (_onboardingViewModel == null)
         {
-            return;
+            return false;
         }
 
         bool shouldShow = await _onboardingViewModel.LoadAsync(cancellationToken);
@@ -190,6 +190,8 @@ public partial class MainPage : TabbedPage
         {
             await HideOnboardingModalAsync();
         }
+
+        return shouldShow;
     }
 
     public async Task ShowOnboardingFailureAsync(Func<CancellationToken, Task> retry)

--- a/ShuffleTask.Presentation/Views/OnboardingPage.xaml
+++ b/ShuffleTask.Presentation/Views/OnboardingPage.xaml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xaml-comp compile="true"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:ShuffleTask.ViewModels;assembly=ShuffleTask.Presentation.Shared"
+             x:Class="ShuffleTask.Views.OnboardingPage"
+             x:DataType="vm:OnboardingViewModel"
+             Title="Welcome to ShuffleTask"
+             BackgroundColor="{AppThemeBinding Light=#f4f5f7, Dark=#121212}">
+    <ScrollView>
+        <Grid Padding="24"
+              MinimumHeightRequest="420">
+            <Border MaximumWidthRequest="560"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"
+                    Padding="28"
+                    StrokeShape="RoundRectangle 18"
+                    BackgroundColor="{AppThemeBinding Light=White, Dark=#242424}"
+                    Stroke="{AppThemeBinding Light=#d8dce2, Dark=#4a4a4a}">
+                <VerticalStackLayout Spacing="18">
+                    <Label x:Name="OnboardingHeading"
+                           Text="Start with data you trust"
+                           FontSize="28"
+                           FontAttributes="Bold"
+                           LineBreakMode="WordWrap"
+                           SemanticProperties.HeadingLevel="Level1"
+                           SemanticProperties.Description="Welcome to ShuffleTask. Start with data you trust." />
+
+                    <Label Text="Choose once how to begin. ShuffleTask will preserve this choice and will never recreate deleted sample tasks."
+                           FontSize="16"
+                           LineBreakMode="WordWrap" />
+
+                    <Button x:Name="CreateTaskButton"
+                            Text="Create a task"
+                            Command="{Binding CreateTaskCommand}"
+                            IsEnabled="{Binding CanChoose}"
+                            MinimumHeightRequest="44"
+                            FontAttributes="Bold"
+                            SemanticProperties.Description="Create your first task in the full task editor" />
+
+                    <Button Text="Add sample tasks"
+                            Command="{Binding AddSampleTasksCommand}"
+                            IsEnabled="{Binding CanChoose}"
+                            MinimumHeightRequest="44"
+                            SemanticProperties.Description="Add four editable sample tasks" />
+
+                    <Button Text="Continue without samples"
+                            Command="{Binding ContinueWithoutSamplesCommand}"
+                            IsEnabled="{Binding CanChoose}"
+                            MinimumHeightRequest="44"
+                            BackgroundColor="Transparent"
+                            TextColor="{AppThemeBinding Light=#334155, Dark=#e2e8f0}"
+                            SemanticProperties.Description="Continue with an empty task list" />
+
+                    <Border Padding="12"
+                            StrokeShape="RoundRectangle 8"
+                            IsVisible="{Binding OperationState.HasMessage}"
+                            SemanticProperties.Description="{Binding OperationState.Announcement}">
+                        <Grid ColumnDefinitions="*,Auto"
+                              ColumnSpacing="8">
+                            <Label x:Name="OperationStateMessage"
+                                   Text="{Binding OperationState.Message}"
+                                   LineBreakMode="WordWrap"
+                                   VerticalTextAlignment="Center" />
+                            <Button Grid.Column="1"
+                                    Text="Retry"
+                                    Command="{Binding OperationState.RetryCommand}"
+                                    IsVisible="{Binding OperationState.CanRetry}"
+                                    MinimumHeightRequest="44"
+                                    MinimumWidthRequest="72" />
+                        </Grid>
+                    </Border>
+
+                    <ActivityIndicator IsVisible="{Binding OperationState.IsLoading}"
+                                       IsRunning="{Binding OperationState.IsLoading}"
+                                       SemanticProperties.Description="First-run setup is loading" />
+                </VerticalStackLayout>
+            </Border>
+        </Grid>
+    </ScrollView>
+</ContentPage>

--- a/ShuffleTask.Presentation/Views/OnboardingPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/OnboardingPage.xaml.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using ShuffleTask.Presentation.Models;
+using ShuffleTask.Presentation.Utilities;
+using ShuffleTask.ViewModels;
+
+namespace ShuffleTask.Views;
+
+public partial class OnboardingPage : ContentPage
+{
+    private readonly OnboardingViewModel _viewModel;
+
+    public OnboardingPage(OnboardingViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel;
+        BindingContext = viewModel;
+        _viewModel.OperationState.PropertyChanged += OnOperationStateChanged;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(250), () =>
+        {
+            if (_viewModel.CanChoose)
+            {
+                CreateTaskButton.Focus();
+            }
+        });
+    }
+
+    protected override bool OnBackButtonPressed() => _viewModel.IsVisible || base.OnBackButtonPressed();
+
+    private void OnOperationStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(OperationState.Announcement)
+            && !string.IsNullOrWhiteSpace(_viewModel.OperationState.Announcement))
+        {
+            OperationStateAccessibility.Announce(Dispatcher, OperationStateMessage, _viewModel.OperationState);
+        }
+
+        if (e.PropertyName == nameof(OperationState.IsLoading) && _viewModel.CanChoose)
+        {
+            Dispatcher.Dispatch(() => CreateTaskButton.Focus());
+        }
+    }
+}

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml.cs
@@ -10,6 +10,10 @@ public partial class TasksPage : ContentPage
 {
     private readonly TasksViewModel _vm;
     private readonly IServiceProvider _services;
+    private bool _onboardingEditorOpen;
+    private bool _onboardingEditorSaved;
+
+    public event EventHandler<OnboardingTaskEditorClosedEventArgs>? OnboardingTaskEditorClosed;
 
     public TasksPage(TasksViewModel vm, IServiceProvider services)
     {
@@ -40,6 +44,18 @@ public partial class TasksPage : ContentPage
 
     private async void OnAddClicked(object? sender, EventArgs e)
     {
+        await OpenEditorAsync(null);
+    }
+
+    public async Task OpenNewTaskForOnboardingAsync()
+    {
+        if (_onboardingEditorOpen)
+        {
+            return;
+        }
+
+        _onboardingEditorOpen = true;
+        _onboardingEditorSaved = false;
         await OpenEditorAsync(null);
     }
 
@@ -147,6 +163,13 @@ public partial class TasksPage : ContentPage
         {
             editorVm.Saved -= OnEditorSaved;
             page.Disappearing -= OnEditorPageDisappearing;
+            if (_onboardingEditorOpen)
+            {
+                bool saved = _onboardingEditorSaved;
+                _onboardingEditorOpen = false;
+                _onboardingEditorSaved = false;
+                OnboardingTaskEditorClosed?.Invoke(this, new OnboardingTaskEditorClosedEventArgs(saved));
+            }
         }
 
         page.Disappearing -= OnEditorPageDisappearing;
@@ -164,6 +187,16 @@ public partial class TasksPage : ContentPage
             vm.Saved -= OnEditorSaved;
         }
 
+        if (_onboardingEditorOpen)
+        {
+            _onboardingEditorSaved = true;
+        }
+
         await _vm.LoadAsync();
     }
+}
+
+public sealed class OnboardingTaskEditorClosedEventArgs(bool saved) : EventArgs
+{
+    public bool Saved { get; } = saved;
 }

--- a/ShuffleTask.Presentation/Views/TasksPage.xaml.cs
+++ b/ShuffleTask.Presentation/Views/TasksPage.xaml.cs
@@ -11,7 +11,6 @@ public partial class TasksPage : ContentPage
     private readonly TasksViewModel _vm;
     private readonly IServiceProvider _services;
     private bool _onboardingEditorOpen;
-    private bool _onboardingEditorSaved;
 
     public event EventHandler<OnboardingTaskEditorClosedEventArgs>? OnboardingTaskEditorClosed;
 
@@ -55,7 +54,6 @@ public partial class TasksPage : ContentPage
         }
 
         _onboardingEditorOpen = true;
-        _onboardingEditorSaved = false;
         await OpenEditorAsync(null);
     }
 
@@ -159,25 +157,51 @@ public partial class TasksPage : ContentPage
         editorVm.Saved -= OnEditorSaved;
         editorVm.Saved += OnEditorSaved;
 
-        void OnEditorPageDisappearing(object? s, EventArgs e)
+        if (Parent is not NavigationPage navigationPage)
         {
-            editorVm.Saved -= OnEditorSaved;
-            page.Disappearing -= OnEditorPageDisappearing;
-            if (_onboardingEditorOpen)
-            {
-                bool saved = _onboardingEditorSaved;
-                _onboardingEditorOpen = false;
-                _onboardingEditorSaved = false;
-                OnboardingTaskEditorClosed?.Invoke(this, new OnboardingTaskEditorClosedEventArgs(saved));
-            }
+            throw new InvalidOperationException("The Tasks page requires a navigation host to open the task editor.");
         }
 
-        page.Disappearing -= OnEditorPageDisappearing;
-        page.Disappearing += OnEditorPageDisappearing;
+        void OnEditorPopped(object? sender, NavigationEventArgs e)
+        {
+            if (e.Page != page)
+            {
+                return;
+            }
+
+            editorVm.Saved -= OnEditorSaved;
+            navigationPage.Popped -= OnEditorPopped;
+            if (!_onboardingEditorOpen)
+            {
+                return;
+            }
+
+            _onboardingEditorOpen = false;
+            OnboardingTaskEditorClosed?.Invoke(
+                this,
+                new OnboardingTaskEditorClosedEventArgs(page.WasSavedBeforeClosing));
+        }
+
+        navigationPage.Popped += OnEditorPopped;
 
         page.BindingContext = editorVm;
         page.Title = editorVm.IsNew ? "New Task" : "Edit Task";
-        await Navigation.PushAsync(page);
+        try
+        {
+            await navigationPage.PushAsync(page);
+        }
+        catch
+        {
+            editorVm.Saved -= OnEditorSaved;
+            navigationPage.Popped -= OnEditorPopped;
+            if (_onboardingEditorOpen)
+            {
+                _onboardingEditorOpen = false;
+                OnboardingTaskEditorClosed?.Invoke(this, new OnboardingTaskEditorClosedEventArgs(false));
+            }
+
+            throw;
+        }
     }
 
     private async void OnEditorSaved(object? sender, EventArgs e)
@@ -185,11 +209,6 @@ public partial class TasksPage : ContentPage
         if (sender is EditTaskViewModel vm)
         {
             vm.Saved -= OnEditorSaved;
-        }
-
-        if (_onboardingEditorOpen)
-        {
-            _onboardingEditorSaved = true;
         }
 
         await _vm.LoadAsync();

--- a/ShuffleTask.Tests/StorageServicePersistenceTests.cs
+++ b/ShuffleTask.Tests/StorageServicePersistenceTests.cs
@@ -645,6 +645,115 @@ public class StorageServicePersistenceTests
         });
     }
 
+    [Test]
+    public async Task Onboarding_FreshDatabaseStartsIncomplete_AndExplicitEmptyPersistsAcrossRestart()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+
+        Assert.That(await storage.GetCompletedVersionAsync(), Is.Zero);
+
+        await storage.CompleteAsync(1);
+        var reloaded = new StorageService(TimeProvider.System, dbPath);
+        await reloaded.InitializeAsync();
+        int completedVersion = await reloaded.GetCompletedVersionAsync();
+        var tasks = await reloaded.GetTasksAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(completedVersion, Is.EqualTo(1));
+            Assert.That(tasks, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Onboarding_PreMarkerSettingsEvidenceMigratesAsCompleted()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+        await storage.SetSettingsAsync(new AppSettings { FocusMinutes = 37 });
+
+        dynamic db = GetDb(storage);
+        await db.ExecuteAsync("DELETE FROM KeyValueEntity WHERE Key = 'onboarding_completed_version'");
+
+        var migrated = new StorageService(TimeProvider.System, dbPath);
+        await migrated.InitializeAsync();
+
+        Assert.That(await migrated.GetCompletedVersionAsync(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Onboarding_SamplesAreAtomicIdempotentAndDoNotChangeSettings()
+    {
+        var dbPath = CreateDbPath();
+        var storage = new StorageService(TimeProvider.System, dbPath);
+        await storage.InitializeAsync();
+        await storage.SetSettingsAsync(new AppSettings
+        {
+            FocusMinutes = 37,
+            BackgroundActivityEnabled = false,
+            EnableNotifications = false
+        });
+        var samples = CreateOnboardingSamples();
+
+        await storage.CompleteWithSamplesAsync(samples, 1);
+        await storage.CompleteWithSamplesAsync(samples, 1);
+
+        var settings = await storage.GetSettingsAsync();
+        var tasks = await storage.GetTasksAsync();
+        int completedVersion = await storage.GetCompletedVersionAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(completedVersion, Is.EqualTo(1));
+            Assert.That(tasks.Select(task => task.Id), Is.EquivalentTo(samples.Select(task => task.Id)));
+            Assert.That(settings.FocusMinutes, Is.EqualTo(37));
+            Assert.That(settings.BackgroundActivityEnabled, Is.False);
+            Assert.That(settings.EnableNotifications, Is.False);
+        });
+
+        foreach (TaskItem task in tasks)
+        {
+            await storage.DeleteTaskAsync(task.Id);
+        }
+
+        var reloaded = new StorageService(TimeProvider.System, dbPath);
+        await reloaded.InitializeAsync();
+        var remainingTasks = await reloaded.GetTasksAsync();
+        int reloadedVersion = await reloaded.GetCompletedVersionAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(remainingTasks, Is.Empty);
+            Assert.That(reloadedVersion, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task Onboarding_SampleFailureRollsBackTasksAndMarker()
+    {
+        var fault = new ThrowingFaultInjector { FailOperation = "onboarding.samples" };
+        var storage = new StorageService(TimeProvider.System, CreateDbPath(), faultInjector: fault);
+        await storage.InitializeAsync();
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => storage.CompleteWithSamplesAsync(CreateOnboardingSamples(), 1));
+        var tasks = await storage.GetTasksAsync();
+        int completedVersion = await storage.GetCompletedVersionAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tasks, Is.Empty);
+            Assert.That(completedVersion, Is.Zero);
+        });
+    }
+
+    private static IReadOnlyCollection<TaskItem> CreateOnboardingSamples()
+        => new[]
+        {
+            new TaskItem { Id = "sample-one", Title = "One" },
+            new TaskItem { Id = "sample-two", Title = "Two" }
+        };
+
     private static async Task WriteRawSettingsValueAsync(StorageService storage, string json)
     {
         dynamic db = GetDb(storage);


### PR DESCRIPTION
Implements:

# GitHub Issue #306: Replace implicit reseeding with intentional onboarding

URL: https://github.com/com-mit-group/ShuffleTask/issues/306

## Roadmap metadata

- Roadmap ID: M1.01
- Type: UX / Feature
- Priority: High
- User value: High
- Depends on: None
- Blocks: None

## Repository evidence

- `App.StartAsync` initializes storage and `EnsureSeedDataAsync` inserts four samples whenever storage is empty, then overwrites several settings.
- `MainPage` always selects Dashboard first; the Tasks page already has a returning-empty message that reseeding can hide.
- Durable/versioned persistence (#280), backup/import (#281), the shared/host split (#302), and operation state (#307) are already delivered and must be reused rather than rebuilt.

## Problem and desired outcome

A clean install and a returning empty collection are currently indistinguishable. Samples appear without consent, deleting every task is undone on restart, and settings change silently. First launch must be honest: initialize safely, ask once, and preserve the user's choice.

## Scope

- Add one versioned onboarding-completion setting independent of task count.
- After storage initializes, show a blocking onboarding surface over the Dashboard-first host before normal Dashboard interaction.
- Primary action: **Create a task**. Secondary action: **Add sample tasks**. Tertiary action: **Continue without samples**.
- Keep sample insertion transactional and idempotent; do not overwrite user settings.
- Migrate existing installations without showing onboarding when existing task/settings evidence proves prior use.
- Reuse #307 operation state for loading, retry, validation, and success.

## Out of scope

Tutorial carousels, accounts, analytics, new persistence foundations, or automatic reseeding.

## User journey

- **User intent:** start with truthful data and capture real work.
- **Starting state:** fresh install has initialized storage, zero tasks, and no onboarding marker; a returning empty user has the completed marker.
- **Discoverable entry point:** the one-time onboarding surface appears over the initial Dashboard. Returning empty users instead see normal Dashboard/Tasks empty-state actions.
- **Actions:** choose Create a task, Add sample tasks, or Continue without samples.
- **Visible successful outcome:** Create switches to Tasks and opens the full new-task editor; samples close onboarding and refresh Dashboard/Tasks with realistic samples; continue closes onboarding and shows the honest empty Dashboard.
- **Exit/continue:** save or cancel the editor, shuffle samples, or use the empty-state Tasks action.
- **Return later:** restart never repeats onboarding after a completed choice and never recreates deleted tasks.

## Product states

- **Fresh install:** blocking loading state, then the three explicit choices.
- **Returning user:** no onboarding when the completion marker or migrated prior-use evidence exists.
- **Empty:** returning empty collection stays empty and offers Create task / Tasks navigation.
- **Loading:** choices are disabled while storage initialization or sample insertion runs.
- **Validation:** Not applicable — onboarding has no free-form input.
- **Disabled:** background scheduling/notifications remain off or unchanged until the user changes settings; onboarding never silently enables them.
- **Cancel/back:** back cannot bypass an unrecorded first-run decision; canceling Create returns to onboarding until Continue empty or samples is chosen.
- **Retry:** initialization or sample-creation failure shows a single Retry and keeps the chosen intent.
- **Failure:** no marker, samples, timers, or settings are partially committed; existing data is untouched.
- **Stale/overlapping operations:** double activation is ignored and sample insertion is idempotent.
- **Success feedback:** announce the chosen outcome once and move focus to the destination heading or title field.

## Data and refresh

- Persist the versioned onboarding marker only with/after the successful choice; sample tasks commit transactionally.
- Local persistence is authoritative before success is announced.
- Downstream network/notification work is not started by onboarding; if later refresh work fails, report that separately without reversing committed local data.
- Refresh Dashboard and Tasks immediately after sample insertion or first-task save.
- The marker, explicit empty choice, samples, and created task survive navigation and restart.
- Never lose existing tasks/settings or duplicate samples.

## Navigation

- Entry is the initial Dashboard overlay.
- Create selects the Tasks tab and pushes Edit Task with focus in Title.
- Add samples returns to Dashboard; Continue empty stays on Dashboard with an action to open Tasks.
- Back/cancel from Edit returns to onboarding until the first-run choice is completed.
- Restore focus to the onboarding action or destination heading as appropriate.
- Notification/deep-link entry during incomplete onboarding waits until initialization succeeds, then resumes without bypassing onboarding.

## Accessibility and supported layouts

- Touch, Windows mouse, Enter/Space activation, and logical Tab/Shift+Tab order are required.
- Heading, choice names, progress, errors, and success are exposed and announced once to TalkBack/Narrator.
- Focus starts at the heading then the primary action; retry and navigation restore focus predictably.
- Support 200% text, narrow Android, resized Windows, light/dark themes, and 44×44 targets.
- No action is gesture-only.

## Realistic required demo: “Clean install to trusted first task”

On Android and Windows, clear app data, launch through the real app icon, observe Dashboard-blocking initialization, choose Create a task, enter “Submit August expense report,” save, navigate Dashboard → Tasks, restart, and confirm the same task remains. Repeat from clean state with samples, then delete all samples and restart to prove they do not return. Inject initialization failure and verify Retry; cancel first-task creation and verify onboarding remains actionable.

## Product-completeness gate

- [ ] The workflow has a discoverable entry point.
- [ ] Fresh-install and empty-state behavior are defined.
- [ ] The user receives visible completion or success feedback.
- [ ] Persistence completes safely before the UI claims success where required.
- [ ] The current screen refreshes immediately.
- [ ] Other affected screens show the updated state without requiring an app restart.
- [ ] Navigation into, out of, and back into the workflow is verified.
- [ ] Empty, validation, cancel, retry, stale, disabled, and failure states are handled or explicitly justified as not applicable.
- [ ] Accessibility and responsive-layout requirements pass.
- [ ] The realistic user demo passes.
- [ ] No user data is silently lost, duplicated, or misreported.
- [ ] The issue delivers usable product behavior rather than only an internal service or model.

## Acceptance criteria

- [ ] First-run completion is persisted separately from task count and migrated safely for existing installations.
- [ ] Samples require explicit consent, commit atomically, and are created at most once.
- [ ] Returning empty collections remain empty after restart.
- [ ] Onboarding never changes unrelated settings or starts background/network/notification work.
- [ ] The three navigation outcomes and initialization failure recovery match this issue.
- [ ] Android/Windows accessibility and layout checks pass.

## Verification

- `dotnet test ShuffleTask.Tests/ShuffleTask.Tests.csproj`
- `dotnet test ShuffleTask.Presentation.Tests/ShuffleTask.Presentation.Tests.csproj`
- Run the named demo on Android and Windows with clean, migrated, failure, decline, delete-all, navigation, and restart states.

AutoDev plan:

1) Where to look
   - `EnsureSeedDataAsync`, `StartAsync`, and `StartupOperationState` in `ShuffleTask.Presentation/App.xaml.cs`
   - `IStorageService`, `StorageService.InitializeAsync`, `KeyValueEntity`, and `RunInTransactionAsync`
   - `MainPage`, `DashboardPage`, `TasksPage.OpenEditorAsync`, and `EditTaskViewModel.Saved`
   - Existing `OperationState` loading/retry/success patterns in presentation view models and pages
   - Persistence transaction/fault-injection tests in `ShuffleTask.Tests/StorageServicePersistenceTests.cs`
   - Tasks/navigation tests in `ShuffleTask.Presentation.Tests`

2) Files / areas likely to touch
   - Persistence contract and implementation for a versioned onboarding marker plus atomic/idempotent sample insertion
   - `App.xaml.cs` startup flow to initialize and expose onboarding without reseeding or changing settings/background state
   - Dashboard-first onboarding UI/navigation and focused tests for fresh, migrated, decline, sample, retry, cancel, and restart behavior

3) Assumptions
   - A blocking modal presented over the already-selected Dashboard satisfies the requested Dashboard overlay while preserving the existing `TabbedPage` host.
   - Existing pre-marker task or persisted-settings evidence is sufficient to mark an installation migrated; a newly created database is recorded as incomplete before default settings are materialized.
   - Completing “Create a task” occurs only after the editor successfully saves; cancel leaves onboarding incomplete and visible.
   - Sample identities can be stable internal IDs so repeated/stale activation is idempotent without changing task-domain behavior.
   - Manual Android/Windows demo and accessibility checks may remain a documented verification item when device runners are unavailable locally.

4) Plan
   - Replace startup reseeding with persistent onboarding initialization: store a versioned completion marker independent of task count, migrate installations with prior-use evidence, and add one atomic/idempotent transaction that inserts the four samples and completes onboarding without writing settings.
   - Add focused persistence tests covering fresh versus migrated state, explicit empty completion, atomic/idempotent samples, rollback on injected failure, and delete-all/restart behavior.
   - Present a blocking, responsive, accessible onboarding surface after successful storage initialization using `OperationState`; wire Create to the existing Tasks/new-task editor and complete only on save, Samples to the atomic persistence operation plus Dashboard/Tasks refresh, Continue to marker persistence, and Retry to the retained failed intent.
   - Add presentation tests for the three outcomes, duplicate activation, cancel/back, failure/retry, success announcements, and startup/background isolation; verify with `dotnet test ShuffleTask.Tests/ShuffleTask.Tests.csproj`, `dotnet test ShuffleTask.Presentation.Tests/ShuffleTask.Presentation.Tests.csproj`, and the configured local verification script.

5) Risks / gotchas
   - `AppSettings` is eagerly loaded during DI, so migration evidence must be captured during database initialization before a fresh default settings row can be mistaken for prior use.
   - Completing the marker separately from sample inserts would permit partial state; both must use one SQLite transaction and the existing fault injector.
   - Modal back gestures/system back must not dismiss an unresolved onboarding decision, while editor cancel must return to the choices.
   - Sample insertion must not start the coordinator, notifications, network sync, or mutate existing settings.
   - Dashboard and Tasks are singleton pages/view models, so refresh and event subscriptions must avoid stale handlers or duplicate announcements.

6) Recommended implementation approach
   - Option A: Add a small onboarding persistence API backed by the existing key-value/task transaction machinery and a dedicated modal onboarding page/view model that delegates task editing to the existing Tasks flow. This is the fastest low-risk way to block the Dashboard-first host and keep state testable.
   - Option B: If modal lifecycle prevents reliable back/focus handling, place the same onboarding view model in a Dashboard overlay; keep the persistence API and tests unchanged and limit host changes to coordinating tab/editor navigation.


Local verification:

~~~
pwsh -File "C:\Users\yaref92\codex-tools\codex-verify.ps1" -Profiles "auto"
~~~

Closes #306
